### PR TITLE
Fix implicit double to float conversions.

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -244,9 +244,9 @@ struct ImTick {
     double PlotPos;
     float  PixelPos;
     ImVec2 Size;
-    int    TextOffset;    
+    int    TextOffset;
     bool   Major;
-    bool   RenderLabel;    
+    bool   RenderLabel;
 };
 
 struct ImPlotItem {
@@ -369,7 +369,7 @@ struct ImPlotContext {
     bool FitY[MAX_Y_AXES] = {};
     // Hover states
     bool Hov_Frame;
-    bool Hov_Grid;    
+    bool Hov_Grid;
     // Render flags
     bool RenderX, RenderY[MAX_Y_AXES];
     // Mouse pos
@@ -2107,16 +2107,16 @@ inline void RenderLineStrip(Transformer transformer, ImDrawList& DrawList, Gette
    if (i_start >= count ) i_start -= count;
    int i_end = offset + count;
    if (i_end >= count) i_end -= count;
-   
+
    const int    segments  = count - 1;
-   ImVec2 p1 = transformer(getter(offset));    
+   ImVec2 p1 = transformer(getter(offset));
    if (HasFlag(gp.CurrentPlot->Flags, ImPlotFlags_AntiAliased)) {
       for (int i1 = i_start; i1 != i_end; i1 = i1 + 1 < count ? i1 + 1 : i1 + 1 - count) {
          ImVec2 p2 = transformer(getter(i1));
 
          if (!cull || gp.BB_Grid.Overlaps(ImRect(ImMin(p1,p2), ImMax(p1,p2))))
                RenderLineAA(DrawList, p1, p2, line_weight, col_line);
-         p1 = p2;            
+         p1 = p2;
       }
    }
    else {
@@ -2124,7 +2124,7 @@ inline void RenderLineStrip(Transformer transformer, ImDrawList& DrawList, Gette
       DrawList.PrimReserve(segments * 6, segments * 4);
       int segments_culled = 0;
       for (int i1 = i_start; i1 != i_end; i1 = i1 + 1 < count ? i1 + 1 : i1 + 1 - count) {
-         ImVec2 p2 = transformer(getter(i1));           
+         ImVec2 p2 = transformer(getter(i1));
 
          if (!cull || gp.BB_Grid.Overlaps(ImRect(ImMin(p1, p2), ImMax(p1, p2))))
             RenderLine(DrawList, p1, p2, line_weight, col_line, uv);
@@ -2632,7 +2632,7 @@ inline void PlotDigitalEx(const char* label_id, Getter getter, int count, int of
 
     if (gp.Style.Colors[ImPlotCol_Line].w != -1)
         item->Color = gp.Style.Colors[ImPlotCol_Line];
-    
+
   // find data extents
     if (gp.FitThisFrame) {
         for (int i = 0; i < count; ++i) {

--- a/implot.cpp
+++ b/implot.cpp
@@ -427,9 +427,9 @@ inline void UpdateTransformCache() {
 
         gp.My[i] = (gp.PixelRange[i].Max.y - gp.PixelRange[i].Min.y) / gp.CurrentPlot->YAxis[i].Range.Size();
     }
-    gp.LogDenX = log10(gp.CurrentPlot->XAxis.Range.Max / gp.CurrentPlot->XAxis.Range.Min);
+    gp.LogDenX = log10f(gp.CurrentPlot->XAxis.Range.Max / gp.CurrentPlot->XAxis.Range.Min);
     for (int i = 0; i < MAX_Y_AXES; i++) {
-        gp.LogDenY[i] = log10(gp.CurrentPlot->YAxis[i].Range.Max / gp.CurrentPlot->YAxis[i].Range.Min);
+        gp.LogDenY[i] = log10f(gp.CurrentPlot->YAxis[i].Range.Max / gp.CurrentPlot->YAxis[i].Range.Min);
     }
     gp.Mx = (gp.PixelRange[0].Max.x - gp.PixelRange[0].Min.x) / gp.CurrentPlot->XAxis.Range.Size();
 }
@@ -442,11 +442,11 @@ inline ImVec2 PixelsToPlot(float x, float y, int y_axis_in = -1) {
     plt.y = (y - gp.PixelRange[y_axis].Min.y) / gp.My[y_axis] + gp.CurrentPlot->YAxis[y_axis].Range.Min;
     if (HasFlag(gp.CurrentPlot->XAxis.Flags, ImPlotAxisFlags_LogScale)) {
         float t = (plt.x - gp.CurrentPlot->XAxis.Range.Min) / gp.CurrentPlot->XAxis.Range.Size();
-        plt.x = pow(10.0f, t * gp.LogDenX) * gp.CurrentPlot->XAxis.Range.Min;
+        plt.x = powf(10.0f, t * gp.LogDenX) * gp.CurrentPlot->XAxis.Range.Min;
     }
     if (HasFlag(gp.CurrentPlot->YAxis[y_axis].Flags, ImPlotAxisFlags_LogScale)) {
         float t = (plt.y - gp.CurrentPlot->YAxis[y_axis].Range.Min) / gp.CurrentPlot->YAxis[y_axis].Range.Size();
-        plt.y = pow(10.0f, t * gp.LogDenY[y_axis]) * gp.CurrentPlot->YAxis[y_axis].Range.Min;
+        plt.y = powf(10.0f, t * gp.LogDenY[y_axis]) * gp.CurrentPlot->YAxis[y_axis].Range.Min;
     }
     return plt;
 }
@@ -461,11 +461,11 @@ inline ImVec2 PlotToPixels(float x, float y, int y_axis_in = -1) {
     const int y_axis = y_axis_in >= 0 ? y_axis_in : gp.CurrentPlot->CurrentYAxis;
     ImVec2 pix;
     if (HasFlag(gp.CurrentPlot->XAxis.Flags, ImPlotAxisFlags_LogScale)) {
-        float t = log10(x / gp.CurrentPlot->XAxis.Range.Min) / gp.LogDenX;
+        float t = log10f(x / gp.CurrentPlot->XAxis.Range.Min) / gp.LogDenX;
         x       = ImLerp(gp.CurrentPlot->XAxis.Range.Min, gp.CurrentPlot->XAxis.Range.Max, t);
     }
     if (HasFlag(gp.CurrentPlot->YAxis[y_axis].Flags, ImPlotAxisFlags_LogScale)) {
-        float t = log10(y / gp.CurrentPlot->YAxis[y_axis].Range.Min) / gp.LogDenY[y_axis];
+        float t = log10f(y / gp.CurrentPlot->YAxis[y_axis].Range.Min) / gp.LogDenY[y_axis];
         y       = ImLerp(gp.CurrentPlot->YAxis[y_axis].Range.Min, gp.CurrentPlot->YAxis[y_axis].Range.Max, t);
     }
     pix.x = gp.PixelRange[y_axis].Min.x + gp.Mx * (x - gp.CurrentPlot->XAxis.Range.Min);
@@ -497,7 +497,7 @@ struct Plt2PixLogLin {
 
     ImVec2 operator()(const ImVec2& plt) { return (*this)(plt.x, plt.y); }
     ImVec2 operator()(float x, float y) {
-        float t = log10(x / gp.CurrentPlot->XAxis.Range.Min) / gp.LogDenX;
+        float t = log10f(x / gp.CurrentPlot->XAxis.Range.Min) / gp.LogDenX;
         x       = ImLerp(gp.CurrentPlot->XAxis.Range.Min, gp.CurrentPlot->XAxis.Range.Max, t);
         return ImVec2( gp.PixelRange[y_axis].Min.x + gp.Mx * (x - gp.CurrentPlot->XAxis.Range.Min),
                  gp.PixelRange[y_axis].Min.y + gp.My[y_axis] * (y - gp.CurrentPlot->YAxis[y_axis].Range.Min) );
@@ -511,7 +511,7 @@ struct Plt2PixLinLog {
 
     ImVec2 operator()(const ImVec2& plt) { return (*this)(plt.x, plt.y); }
     ImVec2 operator()(float x, float y) {
-        float t = log10(y / gp.CurrentPlot->YAxis[y_axis].Range.Min) / gp.LogDenY[y_axis];
+        float t = log10f(y / gp.CurrentPlot->YAxis[y_axis].Range.Min) / gp.LogDenY[y_axis];
         y       = ImLerp(gp.CurrentPlot->YAxis[y_axis].Range.Min, gp.CurrentPlot->YAxis[y_axis].Range.Max, t);
         return ImVec2( gp.PixelRange[y_axis].Min.x + gp.Mx * (x - gp.CurrentPlot->XAxis.Range.Min),
                  gp.PixelRange[y_axis].Min.y + gp.My[y_axis] * (y - gp.CurrentPlot->YAxis[y_axis].Range.Min) );
@@ -525,9 +525,9 @@ struct Plt2PixLogLog {
 
     ImVec2 operator()(const ImVec2& plt) { return (*this)(plt.x, plt.y); }
     ImVec2 operator()(float x, float y) {
-        float t = log10(x / gp.CurrentPlot->XAxis.Range.Min) / gp.LogDenX;
+        float t = log10f(x / gp.CurrentPlot->XAxis.Range.Min) / gp.LogDenX;
         x       = ImLerp(gp.CurrentPlot->XAxis.Range.Min, gp.CurrentPlot->XAxis.Range.Max, t);
-        t       = log10(y / gp.CurrentPlot->YAxis[y_axis].Range.Min) / gp.LogDenY[y_axis];
+        t       = log10f(y / gp.CurrentPlot->YAxis[y_axis].Range.Min) / gp.LogDenY[y_axis];
         y       = ImLerp(gp.CurrentPlot->YAxis[y_axis].Range.Min, gp.CurrentPlot->YAxis[y_axis].Range.Max, t);
         return ImVec2( gp.PixelRange[y_axis].Min.x + gp.Mx * (x - gp.CurrentPlot->XAxis.Range.Min),
                  gp.PixelRange[y_axis].Min.y + gp.My[y_axis] * (y - gp.CurrentPlot->YAxis[y_axis].Range.Min) );
@@ -576,8 +576,8 @@ inline void GetTicks(const ImPlotRange& scale, int nMajor, int nMinor, bool logs
     if (logscale) {
         if (scale.Min <= 0 || scale.Max <= 0)
             return;
-        int exp_min = (int)(ImFloor(log10(scale.Min)));
-        int exp_max = (int)(ImCeil(log10(scale.Max)));
+        int exp_min = (int)(ImFloor(log10f(scale.Min)));
+        int exp_max = (int)(ImCeil(log10f(scale.Max)));
         for (int e = exp_min - 1; e < exp_max + 1; ++e) {
             double major1 = ImPow(10, (double)(e));
             double major2 = ImPow(10, (double)(e + 1));
@@ -2558,7 +2558,7 @@ inline void DrawPieSlice(ImDrawList& DrawList, const ImVec2& center, float radiu
     float da = (a1 - a0) / (n - 1);
     for (int i = 0; i < n; ++i) {
         float a = a0 + i * da;
-        buffer[i + 1] = PlotToPixels(center.x + radius * cos(a), center.y + radius * sin(a));
+        buffer[i + 1] = PlotToPixels(center.x + radius * cosf(a), center.y + radius * sinf(a));
     }
     DrawList.AddConvexPolyFilled(buffer, n + 1, col);
 }
@@ -2595,7 +2595,7 @@ void PlotPieChart(const char** label_ids, float* values, int count, const ImVec2
                 sprintf(buffer, "%.0f%%", percent * 100);
                 ImVec2 size = ImGui::CalcTextSize(buffer);
                 float angle = a0 + (a1 - a0) * 0.5f;
-                ImVec2 pos = PlotToPixels(center.x + 0.5f * radius * cos(angle), center.y + 0.5f * radius * sin(angle));
+                ImVec2 pos = PlotToPixels(center.x + 0.5f * radius * cosf(angle), center.y + 0.5f * radius * sinf(angle));
                 DrawList.AddText(pos - size * 0.5f + ImVec2(1,1), IM_COL32(0,0,0,255), buffer);
                 DrawList.AddText(pos - size * 0.5f, IM_COL32(255,255,255,255), buffer);
             }

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -718,8 +718,8 @@ void ShowDemoWindow(bool* p_open) {
     if (ImGui::CollapsingHeader("Offset Data")) {
         float xs[50], ys[50];
         for (int i = 0; i < 50; ++i) {
-            xs[i] = 0.5 + 0.4 * cos(i/50.f * 6.28);
-            ys[i] = 0.5 + 0.4 * sin(i/50.f * 6.28);
+            xs[i] = 0.5f + 0.4f * cos(i/50.f * 6.28f);
+            ys[i] = 0.5f + 0.4f * sin(i/50.f * 6.28f);
         }
         static int offset = 0;
         ImGui::SliderInt("Offset", &offset, -100, 100);

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -44,7 +44,7 @@ struct ScrollingData {
     int MaxSize;
     int Offset;
     ImVector<ImVec2> Data;
-    ScrollingData() { 
+    ScrollingData() {
         MaxSize = 1000;
         Offset  = 0;
         Data.reserve(MaxSize);
@@ -68,7 +68,7 @@ struct ScrollingData {
 struct RollingData {
     float Span;
     ImVector<ImVec2> Data;
-    RollingData() { 
+    RollingData() {
         Span = 10.0f;
         Data.reserve(1000);
     }
@@ -178,8 +178,8 @@ void ShowDemoWindow(bool* p_open) {
 
             ImPlot::PushStyleVar(ImPlotStyleVar_MarkerSize, 6);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Square);
-            ImPlot::PushStyleColor(ImPlotCol_MarkerFill, ImVec4(1,0,0,0.25f));      
-            ImPlot::PushStyleColor(ImPlotCol_MarkerOutline, ImVec4(0,0,0,0));      
+            ImPlot::PushStyleColor(ImPlotCol_MarkerFill, ImVec4(1,0,0,0.25f));
+            ImPlot::PushStyleColor(ImPlotCol_MarkerOutline, ImVec4(0,0,0,0));
             ImPlot::PlotScatter("Data 2", xs2, ys2, 50);
             ImPlot::PopStyleColor(2);
             ImPlot::PopStyleVar(2);
@@ -305,50 +305,50 @@ void ShowDemoWindow(bool* p_open) {
             float ys[2] = {10,11};
             // filled
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Circle);
-            ImPlot::PlotLine("Circle##Fill", xs, ys, 2);   
+            ImPlot::PlotLine("Circle##Fill", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Square);   ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Square##Fill", xs, ys, 2);   
+            ImPlot::PlotLine("Square##Fill", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Diamond);  ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Diamond##Fill", xs, ys, 2);   
+            ImPlot::PlotLine("Diamond##Fill", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Up);       ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Up##Fill", xs, ys, 2);   
+            ImPlot::PlotLine("Up##Fill", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Down);     ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Down##Fill", xs, ys, 2);   
+            ImPlot::PlotLine("Down##Fill", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Left);     ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Left##Fill", xs, ys, 2);   
+            ImPlot::PlotLine("Left##Fill", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Right);    ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Right##Fill", xs, ys, 2);   
+            ImPlot::PlotLine("Right##Fill", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Cross);    ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Cross##Fill", xs, ys, 2);   
+            ImPlot::PlotLine("Cross##Fill", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Plus);     ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Plus##Fill", xs, ys, 2);   
+            ImPlot::PlotLine("Plus##Fill", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Asterisk); ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Asterisk##Fill", xs, ys, 2);   
+            ImPlot::PlotLine("Asterisk##Fill", xs, ys, 2);
             ImPlot::PopStyleVar(10);
 
             xs[0] = 6; xs[1] = 9;
             ys[0] = 10; ys[1] = 11;
             ImPlot::PushStyleColor(ImPlotCol_MarkerFill, ImVec4(0,0,0,0));
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Circle);
-            ImPlot::PlotLine("Circle", xs, ys, 2);   
+            ImPlot::PlotLine("Circle", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Square);   ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Square", xs, ys, 2);   
+            ImPlot::PlotLine("Square", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Diamond);  ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Diamond", xs, ys, 2);   
+            ImPlot::PlotLine("Diamond", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Up);       ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Up", xs, ys, 2);   
+            ImPlot::PlotLine("Up", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Down);     ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Down", xs, ys, 2);   
+            ImPlot::PlotLine("Down", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Left);     ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Left", xs, ys, 2);   
+            ImPlot::PlotLine("Left", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Right);    ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Right", xs, ys, 2);   
+            ImPlot::PlotLine("Right", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Cross);    ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Cross", xs, ys, 2);   
+            ImPlot::PlotLine("Cross", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Plus);     ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Plus", xs, ys, 2);   
+            ImPlot::PlotLine("Plus", xs, ys, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Asterisk); ys[0]--; ys[1]--;
-            ImPlot::PlotLine("Asterisk", xs, ys, 2);   
+            ImPlot::PlotLine("Asterisk", xs, ys, 2);
             ImPlot::PopStyleColor();
             ImPlot::PopStyleVar(10);
 
@@ -358,7 +358,7 @@ void ShowDemoWindow(bool* p_open) {
             ImPlot::PushStyleVar(ImPlotStyleVar_LineWeight, 2);
             ImPlot::PushStyleVar(ImPlotStyleVar_MarkerSize, 8);
             ImPlot::PushStyleVar(ImPlotStyleVar_MarkerWeight, 2);
-            ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Circle | ImPlotMarker_Cross); 
+            ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Circle | ImPlotMarker_Cross);
             ImPlot::PushStyleColor(ImPlotCol_MarkerOutline, ImVec4(0,0,0,1));
             ImPlot::PushStyleColor(ImPlotCol_MarkerFill, ImVec4(1,1,1,1));
             ImPlot::PushStyleColor(ImPlotCol_Line, ImVec4(0,0,0,1));
@@ -459,7 +459,7 @@ void ShowDemoWindow(bool* p_open) {
         static ImVector<ImVec2> data;
         ImPlotLimits range, query;
         if (ImPlot::BeginPlot("##Drawing", NULL, NULL, ImVec2(-1,0), ImPlotFlags_Default | ImPlotFlags_Query, ImPlotAxisFlags_GridLines, ImPlotAxisFlags_GridLines)) {
-            if (ImPlot::IsPlotHovered() && ImGui::IsMouseClicked(0) && ImGui::GetIO().KeyCtrl) 
+            if (ImPlot::IsPlotHovered() && ImGui::IsMouseClicked(0) && ImGui::GetIO().KeyCtrl)
                 data.push_back(ImPlot::GetPlotMousePos());
             ImPlot::PushStyleVar(ImPlotStyleVar_Marker, ImPlotMarker_Diamond);
             if (data.size() > 0)


### PR DESCRIPTION
You do not include <cmath> in implot.cpp and instead rely on the include of math.h through the imgui_internal.h header - this C version of the header not have the float overloads leading to double to float conversion warnings.