### PR TITLE
Support for input remapping (mouse-buttons/modifiers-keys).

### DIFF
--- a/implot.h
+++ b/implot.h
@@ -174,28 +174,19 @@ struct ImPlotStyle {
 
 // Input mapping structure, default values listed in the comments.
 struct ImPlotInputMap {
-
+    ImGuiMouseButton PanButton;             // LMB      enables panning when held
+    ImGuiKeyModFlags PanMod;                // none     optional modifier that must be held for panning
+    ImGuiMouseButton FitButton;             // LMB      fits visible data when double clicked
+    ImGuiMouseButton ContextMenuButton;     // RMB      opens plot context menu (if enabled) when double clicked
+    ImGuiMouseButton BoxSelectButton;       // RMB      begins box selection when pressed and confirms selection when released
+    ImGuiKeyModFlags BoxSelectMod;          // none     optional modifier that must be held for box selection
+    ImGuiMouseButton BoxSelectCancelButton; // LMB      cancels active box selection when pressed
+    ImGuiMouseButton QueryButton;           // MMB      begins query selection when pressed and end query selection when released
+    ImGuiKeyModFlags QueryMod;              // none     optional modifier that must be held for query selection
+    ImGuiKeyModFlags QueryToggleMod;        // Ctrl     when held, active box selections turn into queries
+    ImGuiKeyModFlags HorizontalMod;         // Alt      expands active box selection/query horizontally to plot edge when held
+    ImGuiKeyModFlags VerticalMod;           // Shift    expands active box selection/query vertically to plot edge when held
     ImPlotInputMap();
-
-    ImGuiMouseButton PanButton;             // left mouse
-    ImGuiKeyModFlags PanMod;                // none
-    
-    ImGuiMouseButton BoxSelectButton;       // right mouse
-    ImGuiKeyModFlags BoxSelectMod;          // none
-    
-    ImGuiMouseButton BoxCancelButton;       // left mouse
-    
-    ImGuiMouseButton QueryClickButton;      // left mouse
-    ImGuiKeyModFlags QueryClickMod;         // ctrl
-    
-    ImGuiMouseButton QueryDragButton;       // middle mouse
-    ImGuiKeyModFlags QueryDragMod;          // none
-    
-    ImGuiMouseButton QueryDragButton2;      // right mouse, alternative way to query drag, useful when middle mouse is not available
-    ImGuiKeyModFlags QueryDragMod2;         // ctrl
-    
-    ImGuiKeyModFlags HorizontalSizeMod;     // alt
-    ImGuiKeyModFlags VerticalSizeMod;       // shift    
 };
 
 //-----------------------------------------------------------------------------

--- a/implot.h
+++ b/implot.h
@@ -47,7 +47,7 @@ enum ImPlotFlags_ {
     ImPlotFlags_Crosshairs  = 1 << 6,  // the default mouse cursor will be replaced with a crosshair when hovered
     ImPlotFlags_AntiAliased = 1 << 7,  // lines and fills will be anti-aliased (not recommended)
     ImPlotFlags_NoChild     = 1 << 8,  // a child window region will not be used to capture mouse scroll (can boost performance for single ImGui window applications)
-    ImPlotFlags_YAxis2      = 1 << 9, // enable a 2nd y-axis
+    ImPlotFlags_YAxis2      = 1 << 9,  // enable a 2nd y-axis
     ImPlotFlags_YAxis3      = 1 << 10, // enable a 3rd y-axis
     ImPlotFlags_Default     = ImPlotFlags_MousePos | ImPlotFlags_Legend | ImPlotFlags_Highlight | ImPlotFlags_BoxSelect | ImPlotFlags_ContextMenu
 };


### PR DESCRIPTION
Hello,

**First of**; great library. Thank you so much for writing it, and sharing it with the community. It's already incredibly useful for us.

**Second;** I don't expect this pull-request to be accepted in its current form. While my changes currently serve our needs, consider it a rough sketch at best. I hope it can start a discussion on whether ImPlot even needs support for input remapping, and if so, how to best do that.

**Some background**: we integrated ImPlot in an already complex application that has existing input-bindings for things like select, zoom, and pan. We use the same input patterns across a variety of different 2D and 3D panels, and our users have certain expectations as to what Left/Right/Middle mouse buttons do, as well as Ctrl/Alt/Shift modifier keys.

To be more specific, we use middle-click for panning in 2D panels, and left-click for boxes select and zoom. This happens to be different from the existing ImPlot defaults.

Rather than changing the (currently) hardcoded key-bindings, I figure it'd add a little configurable struct that specifies the bindings, in the hope the official version of ImPlot can add such a feature at some point. I imagine there might be other ImPlot users who'd like to configure the input mechanism.

The diff should be pretty self explanatory, but it essentially boils down to this one struct:

![image](https://user-images.githubusercontent.com/44677/84321667-6fbe3780-ab28-11ea-8d9f-5cc2f913e3e9.png)

Like I said, I'm not attached to my solution. Change the names of structs and functions, or come up with a different system all together. I'm open to suggestions, and more than happy to do the work and submit a new pull request.

For now, a couple of thoughts/questions to start the conversation...

Currently, ImPlot has no global state that applies across different `BeginPlot`/`EndPlot` pairs. That's great, as each plot is independent. However, because (imho) input-mapping is preferably consistent across an entire application, it seemed most useful to me to have a single global `ImPlot::SetInputMap` that you simply call once (probably right after initializing ImGui), and never touch again.

The alternative would be to have make it an extra argument to `BeginPlot`, or have a `SetNextPlotInputMap` function. The current input mapping would then become a part of the `gp` state variable, instead of being saved in a global `gi` as I currently do. If we did this though, you'd have to pass the same input map in every location where you do plotting in a program. 

To support the odd scenario where one wants to change the input map just locally in a specific location, I made it so `SetInputMap` returns the previous input mapping, so you can save it and then restore it when you're done.

Unrelated, I should point out that we haven't yet had a need for the query-drag system in our software. We only use box-select and panning. While I tried to get it right in adding support for input remapping, I did only a bare minimum of testing to make sure query-drags still work, and still interact properly with switching between select/query, and cancelling of queries. I suspect I may have gotten a few corner cases wrong, input-code is always tricky like that.

Once again, thank you for this great library. And to be clear, I'm open to the argument that a custom input feature is not worth the added complexity. In which case, just let me know and close this pull request. Thank you!