### PR TITLE
Only display non-empty legends

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -628,9 +628,11 @@ ImPlotItem* RegisterItem(const char* label_id) {
     item->SeenThisFrame = true;
     int idx = gp.CurrentPlot->Items.GetIndex(item);
     item->ID = id;
-    gp.LegendIndices.push_back(idx);
-    item->NameOffset = gp.LegendLabels.size();
-    gp.LegendLabels.append(label_id, label_id + strlen(label_id) + 1);
+    if (ImGui::FindRenderedTextEnd(label_id, NULL) != label_id) {
+        gp.LegendIndices.push_back(idx);
+        item->NameOffset = gp.LegendLabels.size();
+        gp.LegendLabels.append(label_id, label_id + strlen(label_id) + 1);
+    }
     if (item->Show)
         gp.VisibleItemCount++;
     return item;


### PR DESCRIPTION
Does this seem reasonable?  I wanted some plot items to have no legend, and just prefixing them with `##` otherwise leaves a blank colored line in the legend bar.