### PR TITLE
Fix compiler warning in implot_demo.cpp

### DIFF
--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1009,7 +1009,7 @@ void ShowDemoWindow(bool* p_open) {
         static BenchmarkItem items[n_items];
         ImGui::BulletText("Make sure VSync is disabled.");
         ImGui::BulletText("%d lines with %d points each @ %.3f FPS.",n_items,1000,ImGui::GetIO().Framerate);
-        ImGui::BulletText("ImDrawIdx: %d-bit", sizeof(ImDrawIdx) * 8);
+        ImGui::BulletText("ImDrawIdx: %d-bit", (int)(sizeof(ImDrawIdx) * 8));
         ImGui::BulletText("ImGuiBackendFlags_RendererHasVtxOffset: %s", (ImGui::GetIO().BackendFlags & ImGuiBackendFlags_RendererHasVtxOffset) ? "True" : "False");
         ImGui::BulletText("If you see visual artifacts, do one of the following:");
         ImGui::Indent();


### PR DESCRIPTION
implot_demo.cpp:1012:69: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘long unsigned int’ [-Wformat=]