### PR TITLE
Exposed RegisterItem and ImPlotList struct

### DIFF
--- a/implot.h
+++ b/implot.h
@@ -195,6 +195,18 @@ struct ImPlotInputMap {
     ImPlotInputMap();
 };
 
+// State information for Plot items
+struct ImPlotItem {
+    ImPlotItem();
+    ~ImPlotItem();
+    bool Show;
+    bool SeenThisFrame;
+    bool Highlight;
+    ImVec4 Color;
+    int NameOffset;
+    ImGuiID ID;
+};
+
 //-----------------------------------------------------------------------------
 // ImPlot End-User API
 //-----------------------------------------------------------------------------
@@ -414,6 +426,9 @@ void ShowColormapScale(double scale_min, double scale_max, float height);
 void PushPlotClipRect();
 // Pop plot clip rect.
 void PopPlotClipRect();
+
+// Register item. Useful for showing custom rendering in the legend. Check 'Show' to decide if the draw custom items
+ImPlotItem* RegisterItem(const char* label_id);
 
 //-----------------------------------------------------------------------------
 // Demo

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -240,26 +240,17 @@ struct ImPlotAxisColor
 };
 
 // State information for Plot items
-struct ImPlotItem
-{
-    ImGuiID ID;
-    ImVec4  Color;
-    bool    Show;
-    bool    Highlight;
-    bool    SeenThisFrame;
-    int     NameOffset;
+ImPlotItem::ImPlotItem() {
+    ID            = 0;
+    Color         = ImPlot::NextColormapColor();
+    Show          = true;
+    SeenThisFrame = false;
+    Highlight     = false;
+    NameOffset    = -1;
+}
 
-    ImPlotItem() {
-        ID            = 0;
-        Color         = ImPlot::NextColormapColor();
-        Show          = true;
-        SeenThisFrame = false;
-        Highlight     = false;
-        NameOffset    = -1;
-    }
+ImPlotItem::~ImPlotItem() { ID = 0; }
 
-    ~ImPlotItem() { ID = 0; }
-};
 
 // Holds Plot state information that must persist after EndPlot
 struct ImPlotState


### PR DESCRIPTION
The purpose of this pull request is to expose **RegisterItem** and the **ImplotList** struct to allow users to added custom render items to the legend. For example, I implemented a general polygon fill custom rendering and wanted it to appear in the legend and be able to hide and show it. Here you can see it working:

* _Sin_ is the custom render item.

![Capture](https://user-images.githubusercontent.com/39973752/90666412-f40cf500-e212-11ea-9d82-1a3d2c8cac4d.PNG)

Here is the code in use:
```cpp
ImPlot::PushPlotClipRect();
auto item = ImPlot::RegisterItem("Sin");
if(item->Show)
    DrawPolygon(ImGui::GetWindowDrawList(), m_xs, m_ys);
ImPlot::PopPlotClipRect();
```
