### PR TITLE
Make EndItem not inline

### DIFF
--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -162,7 +162,7 @@ inline bool BeginItem(const char* label_id, ImPlotCol recolor_from) {
 }
 
 // Ends an item (call only if BeginItem returns true)
-inline void EndItem() {
+void EndItem() {
     ImPlotContext& gp = *GImPlot;
     // pop rendering clip rect
     PopPlotClipRect();


### PR DESCRIPTION
On some compilers (e.g. clang on Mac), this results in a linker error as
it's inlined and can't be found from other source files (e.g. implot_demo).