### PR TITLE
Handle possibly overlapping widgets added via ImGui::SetItemAllowOverlap()

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -1262,11 +1262,13 @@ bool BeginPlot(const char* title, const char* x_label, const char* y_label, cons
         frame_size.y = gp.Style.PlotMinSize.y;
     gp.BB_Frame = ImRect(Window->DC.CursorPos, Window->DC.CursorPos + frame_size);
     ImGui::ItemSize(gp.BB_Frame);
-    if (!ImGui::ItemAdd(gp.BB_Frame, 0, &gp.BB_Frame)) {
+    if (!ImGui::ItemAdd(gp.BB_Frame, ID, &gp.BB_Frame)) {
         Reset(GImPlot);
         return false;
     }
     gp.Hov_Frame = ImGui::ItemHoverable(gp.BB_Frame, ID);
+    if (G.HoveredIdPreviousFrame != 0 && G.HoveredIdPreviousFrame != ID)
+        gp.Hov_Frame = false;
     ImGui::RenderFrame(gp.BB_Frame.Min, gp.BB_Frame.Max, GetStyleColorU32(ImPlotCol_FrameBg), true, Style.FrameRounding);
 
     // canvas bb
@@ -1325,7 +1327,7 @@ bool BeginPlot(const char* title, const char* x_label, const char* y_label, cons
 
     // (5) calc plot bb
     gp.BB_Plot  = ImRect(gp.BB_Canvas.Min + ImVec2(pad_left, pad_top), gp.BB_Canvas.Max - ImVec2(pad_right, pad_bot));
-    gp.Hov_Plot = gp.BB_Plot.Contains(IO.MousePos);
+    gp.Hov_Plot = gp.BB_Plot.Contains(IO.MousePos) && gp.Hov_Frame;
 
     // x axis region bb and hover
     const ImRect xAxisRegion_bb(gp.BB_Plot.GetBL(), ImVec2(gp.BB_Plot.Max.x, gp.BB_Frame.Max.y));

--- a/implot.cpp
+++ b/implot.cpp
@@ -2503,6 +2503,11 @@ bool HorizontalGuide(const char* id, double* value, const ImVec4& col, float thi
     DrawList.AddLine(ImVec2(xl,y), ImVec2(xr,y),     col32, thickness);
     DrawList.AddLine(ImVec2(xl,y), ImVec2(xl+len,y), col32, 3*thickness);
     DrawList.AddLine(ImVec2(xr,y), ImVec2(xr-len,y), col32, 3*thickness);
+    PopPlotClipRect();
+
+    if (gp.CurrentPlot->Selecting || gp.CurrentPlot->Querying)
+        return false;
+
     ImVec2 old_cursor_pos = ImGui::GetCursorScreenPos();
     ImVec2 new_cursor_pos = ImVec2(xl, y - grab_size / 2.0f);
     ImGui::SetItemAllowOverlap();
@@ -2517,6 +2522,7 @@ bool HorizontalGuide(const char* id, double* value, const ImVec4& col, float thi
         snprintf(buf, 32, "%s = %.*f", id, Precision(range_y), *value);
         ImVec2 size = ImGui::CalcTextSize(buf);
         const int pad = 2;
+        PushPlotClipRect();
         if (yax == 0) {
             DrawList.AddRectFilled(ImVec2(xl,y-pad-size.y/2), ImVec2(xl + size.x + 2 * pad, y+pad+size.y/2), col32);
             DrawList.AddText(ImVec2(xl+pad,y-size.y/2),CalcTextColor(color),buf);
@@ -2525,8 +2531,8 @@ bool HorizontalGuide(const char* id, double* value, const ImVec4& col, float thi
             DrawList.AddRectFilled(ImVec2(xr-size.x-2*pad,y-pad-size.y/2), ImVec2(xr, y+pad+size.y/2), col32);
             DrawList.AddText(ImVec2(xr-size.x-pad,y-size.y/2),CalcTextColor(color),buf);
         }
+        PopPlotClipRect();
     }
-    PopPlotClipRect();
 
     bool dragging = false;
     if (ImGui::IsItemActive() && ImGui::IsMouseDragging(0)) {
@@ -2557,6 +2563,11 @@ bool VerticalGuide(const char* id, double* value, const ImVec4& col, float thick
     DrawList.AddLine(ImVec2(x,yt), ImVec2(x,yb),     col32, thickness);
     DrawList.AddLine(ImVec2(x,yt), ImVec2(x,yt+len), col32, 3*thickness);
     DrawList.AddLine(ImVec2(x,yb), ImVec2(x,yb-len), col32, 3*thickness);
+    PopPlotClipRect();
+
+    if (gp.CurrentPlot->Selecting || gp.CurrentPlot->Querying)
+        return false;
+
     ImVec2 old_cursor_pos = ImGui::GetCursorScreenPos();
     ImVec2 new_cursor_pos = ImVec2(x - grab_size / 2.0f, yt);
     ImGui::SetItemAllowOverlap();
@@ -2570,10 +2581,11 @@ bool VerticalGuide(const char* id, double* value, const ImVec4& col, float thick
         snprintf(buf, 32, "%s = %.*f", id, Precision(range_x), *value);
         ImVec2 size = ImGui::CalcTextSize(buf);
         const int pad = 2;
+        PushPlotClipRect();
         DrawList.AddRectFilled(ImVec2(x - size.x/2 - pad, yb - size.y - 2*pad), ImVec2(x + pad + size.x/2, yb), col32);
         DrawList.AddText(ImVec2(x - size.x/2, yb - size.y - pad), CalcTextColor(color), buf);
+        PopPlotClipRect();
     }
-    PopPlotClipRect();
 
     bool dragging = false;
     if (ImGui::IsItemActive() && ImGui::IsMouseDragging(0)) {

--- a/implot.cpp
+++ b/implot.cpp
@@ -2509,9 +2509,9 @@ bool HorizontalGuide(const char* id, double* value, const ImVec4& col, float thi
     ImGui::SetCursorScreenPos(new_cursor_pos);
     ImGui::InvisibleButton(id, ImVec2(xr - xl, grab_size));
     ImGui::SetCursorScreenPos(old_cursor_pos);
+    int yax = GetCurrentYAxis();
     if (ImGui::IsItemHovered() || ImGui::IsItemActive()) {
         ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
-        int yax = GetCurrentYAxis();
         double range_y = gp.YTicks[yax].Size > 1 ? (gp.YTicks[yax].Ticks[1].PlotPos - gp.YTicks[yax].Ticks[0].PlotPos) : gp.CurrentPlot->YAxis[yax].Range.Size();
         char buf[32];
         snprintf(buf, 32, "%s = %.*f", id, Precision(range_y), *value);
@@ -2531,6 +2531,7 @@ bool HorizontalGuide(const char* id, double* value, const ImVec4& col, float thi
     bool dragging = false;
     if (ImGui::IsItemActive() && ImGui::IsMouseDragging(0)) {
         *value = ImPlot::GetPlotMousePos().y;
+        *value = ImClamp(*value, gp.Y[yax].Axis->Range.Min, gp.Y[yax].Axis->Range.Max);
         dragging = true;
     }
     return dragging;
@@ -2577,6 +2578,7 @@ bool VerticalGuide(const char* id, double* value, const ImVec4& col, float thick
     bool dragging = false;
     if (ImGui::IsItemActive() && ImGui::IsMouseDragging(0)) {
         *value = ImPlot::GetPlotMousePos().x;
+        *value = ImClamp(*value, gp.X.Axis->Range.Min, gp.X.Axis->Range.Max);
         dragging = true;
     }
     return dragging;

--- a/implot.h
+++ b/implot.h
@@ -463,10 +463,10 @@ IMPLOT_API bool IsPlotQueried();
 // Returns the current plot query bounds.
 IMPLOT_API ImPlotLimits GetPlotQuery(int y_axis = IMPLOT_AUTO);
 
-// Shows a draggable horizontal guide line.
-IMPLOT_API bool HorizontalGuide(const char* id, double* value, const ImVec4& col = IMPLOT_AUTO_COL, float thickness = 2);
-// Shows a draggable vertical guide line.
-IMPLOT_API bool VerticalGuide(const char* id, double* value, const ImVec4& col = IMPLOT_AUTO_COL, float thickness = 2);
+// Shows a draggable horizontal guide line. #col defaults to ImGuiCol_Text.
+IMPLOT_API bool HorizontalGuide(const char* id, double* y_value, const ImVec4& col = IMPLOT_AUTO_COL, float thickness = 1);
+// Shows a draggable vertical guide line. #col defaults to ImGuiCol_Text.
+IMPLOT_API bool VerticalGuide(const char* id, double* x_value, const ImVec4& col = IMPLOT_AUTO_COL, float thickness = 1);
 
 //-----------------------------------------------------------------------------
 // Plot and Item Styling

--- a/implot.h
+++ b/implot.h
@@ -458,11 +458,11 @@ IMPLOT_API ImPlotLimits GetPlotLimits(int y_axis = IMPLOT_AUTO);
 //-----------------------------------------------------------------------------
 
 // Shows a draggable horizontal guide line. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool HorizontalGuide(const char* id, double* y_value, const ImVec4& col = IMPLOT_AUTO_COL, float thickness = 1);
+IMPLOT_API bool GrabLineH(const char* id, double* y_value, const ImVec4& col = IMPLOT_AUTO_COL, float thickness = 1);
 // Shows a draggable vertical guide line. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool VerticalGuide(const char* id, double* x_value, const ImVec4& col = IMPLOT_AUTO_COL, float thickness = 1);
+IMPLOT_API bool GrabLineV(const char* id, double* x_value, const ImVec4& col = IMPLOT_AUTO_COL, float thickness = 1);
 // Shows a draggable anchor point. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool AnchorPoint(const char* id, double* x, double* y, const ImVec4& col = IMPLOT_AUTO_COL, float radius = 5);
+IMPLOT_API bool GrabPoint(const char* id, double* x, double* y, const ImVec4& col = IMPLOT_AUTO_COL, float radius = 5);
 
 // Returns true if the current plot is being queried. Query must be enabled with ImPlotFlags_Query.
 IMPLOT_API bool IsPlotQueried();

--- a/implot.h
+++ b/implot.h
@@ -404,6 +404,8 @@ IMPLOT_API void PlotText(const char* text, double x, double y, bool vertical=fal
 // Plot Utils
 //-----------------------------------------------------------------------------
 
+// The following functions MUST be called before BeginPlot!
+
 // Set the axes range limits of the next plot. Call right before BeginPlot(). If ImGuiCond_Always is used, the axes limits will be locked.
 IMPLOT_API void SetNextPlotLimits(double xmin, double xmax, double ymin, double ymax, ImGuiCond cond = ImGuiCond_Once);
 // Set the X axis range limits of the next plot. Call right before BeginPlot(). If ImGuiCond_Always is used, the X axis limits will be locked.
@@ -423,27 +425,19 @@ IMPLOT_API void SetNextPlotTicksX(double x_min, double x_max, int n_ticks, const
 IMPLOT_API void SetNextPlotTicksY(const double* values, int n_ticks, const char* const labels[] = NULL, bool show_default = false, int y_axis = 0);
 IMPLOT_API void SetNextPlotTicksY(double y_min, double y_max, int n_ticks, const char* const labels[] = NULL, bool show_default = false, int y_axis = 0);
 
+// The following functions MUST be called between Begin/EndPlot!
+
 // Select which Y axis will be used for subsequent plot elements. The default is '0', or the first (left) Y axis. Enable 2nd and 3rd axes with ImPlotFlags_YAxisX.
 IMPLOT_API void SetPlotYAxis(int y_axis);
+// Hides or shows the next plot item (i.e. as if it were toggled from the legend). Use ImGuiCond_Always if you need to change this every frame.
+IMPLOT_API void HideNextItem(bool hidden = true, ImGuiCond cond = ImGuiCond_Once);
 
 // Convert pixels to a position in the current plot's coordinate system. A negative y_axis uses the current value of SetPlotYAxis (0 initially).
 IMPLOT_API ImPlotPoint PixelsToPlot(const ImVec2& pix, int y_axis = IMPLOT_AUTO);
 IMPLOT_API ImPlotPoint PixelsToPlot(float x, float y, int y_axis = IMPLOT_AUTO);
-
 // Convert a position in the current plot's coordinate system to pixels. A negative y_axis uses the current value of SetPlotYAxis (0 initially).
 IMPLOT_API ImVec2 PlotToPixels(const ImPlotPoint& plt, int y_axis = IMPLOT_AUTO);
 IMPLOT_API ImVec2 PlotToPixels(double x, double y, int y_axis = IMPLOT_AUTO);
-
-// Hides or shows the next plot item (i.e. as if it were toggled from the legend). Use ImGuiCond_Always if you need to change this every frame.
-IMPLOT_API void HideNextItem(bool hidden = true, ImGuiCond cond = ImGuiCond_Once);
-
-//-----------------------------------------------------------------------------
-// Plot Queries
-//-----------------------------------------------------------------------------
-
-// Use these functions to retrieve information about the current plot. They
-// MUST be called between BeginPlot and EndPlot!
-
 // Get the current Plot position (top-left) in pixels.
 IMPLOT_API ImVec2 GetPlotPos();
 // Get the curent Plot size in pixels.
@@ -458,15 +452,35 @@ IMPLOT_API bool IsPlotYAxisHovered(int y_axis = 0);
 IMPLOT_API ImPlotPoint GetPlotMousePos(int y_axis = IMPLOT_AUTO);
 // Returns the current plot axis range. A negative y_axis uses the current value of SetPlotYAxis (0 initially).
 IMPLOT_API ImPlotLimits GetPlotLimits(int y_axis = IMPLOT_AUTO);
+
 // Returns true if the current plot is being queried.
 IMPLOT_API bool IsPlotQueried();
 // Returns the current plot query bounds.
 IMPLOT_API ImPlotLimits GetPlotQuery(int y_axis = IMPLOT_AUTO);
 
+//-----------------------------------------------------------------------------
+// Plot Tools
+//-----------------------------------------------------------------------------
+
 // Shows a draggable horizontal guide line. #col defaults to ImGuiCol_Text.
 IMPLOT_API bool HorizontalGuide(const char* id, double* y_value, const ImVec4& col = IMPLOT_AUTO_COL, float thickness = 1);
 // Shows a draggable vertical guide line. #col defaults to ImGuiCol_Text.
 IMPLOT_API bool VerticalGuide(const char* id, double* x_value, const ImVec4& col = IMPLOT_AUTO_COL, float thickness = 1);
+
+//-----------------------------------------------------------------------------
+// Legend Utils and Tools
+//-----------------------------------------------------------------------------
+
+// Returns true if a plot item legend entry is hovered.
+IMPLOT_API bool IsLegendEntryHovered(const char* label_id);
+// Begin a drag and drop source from a legend entry. The only supported flag is SourceNoPreviewTooltip
+IMPLOT_API bool BeginLegendDragDropSource(const char* label_id, ImGuiDragDropFlags flags = 0);
+// End legend drag and drop source.
+IMPLOT_API void EndLegendDragDropSource();
+// Begin a popup for a legend entry.
+IMPLOT_API bool BeginLegendPopup(const char* label_id, ImGuiMouseButton mouse_button = 1);
+// End a popup for a legend entry.
+IMPLOT_API void EndLegendPopup();
 
 //-----------------------------------------------------------------------------
 // Plot and Item Styling
@@ -561,21 +575,6 @@ IMPLOT_API void ShowColormapScale(double scale_min, double scale_max, float heig
 
 // Returns a null terminated string name for a built-in colormap.
 IMPLOT_API const char* GetColormapName(ImPlotColormap colormap);
-
-//-----------------------------------------------------------------------------
-// Legend Utils
-//-----------------------------------------------------------------------------
-
-// Returns true if a plot item legend entry is hovered.
-IMPLOT_API bool IsLegendEntryHovered(const char* label_id);
-// Begin a drag and drop source from a legend entry. The only supported flag is SourceNoPreviewTooltip
-IMPLOT_API bool BeginLegendDragDropSource(const char* label_id, ImGuiDragDropFlags flags = 0);
-// End legend drag and drop source.
-IMPLOT_API void EndLegendDragDropSource();
-// Begin a popup for a legend entry.
-IMPLOT_API bool BeginLegendPopup(const char* label_id, ImGuiMouseButton mouse_button = 1);
-// End a popup for a legend entry.
-IMPLOT_API void EndLegendPopup();
 
 //-----------------------------------------------------------------------------
 // Miscellaneous

--- a/implot.h
+++ b/implot.h
@@ -453,11 +453,6 @@ IMPLOT_API ImPlotPoint GetPlotMousePos(int y_axis = IMPLOT_AUTO);
 // Returns the current plot axis range. A negative y_axis uses the current value of SetPlotYAxis (0 initially).
 IMPLOT_API ImPlotLimits GetPlotLimits(int y_axis = IMPLOT_AUTO);
 
-// Returns true if the current plot is being queried.
-IMPLOT_API bool IsPlotQueried();
-// Returns the current plot query bounds.
-IMPLOT_API ImPlotLimits GetPlotQuery(int y_axis = IMPLOT_AUTO);
-
 //-----------------------------------------------------------------------------
 // Plot Tools
 //-----------------------------------------------------------------------------
@@ -466,6 +461,13 @@ IMPLOT_API ImPlotLimits GetPlotQuery(int y_axis = IMPLOT_AUTO);
 IMPLOT_API bool HorizontalGuide(const char* id, double* y_value, const ImVec4& col = IMPLOT_AUTO_COL, float thickness = 1);
 // Shows a draggable vertical guide line. #col defaults to ImGuiCol_Text.
 IMPLOT_API bool VerticalGuide(const char* id, double* x_value, const ImVec4& col = IMPLOT_AUTO_COL, float thickness = 1);
+// Shows a draggable anchor point. #col defaults to ImGuiCol_Text.
+IMPLOT_API bool AnchorPoint(const char* id, double* x, double* y, const ImVec4& col = IMPLOT_AUTO_COL, float radius = 5);
+
+// Returns true if the current plot is being queried. Query must be enabled with ImPlotFlags_Query.
+IMPLOT_API bool IsPlotQueried();
+// Returns the current plot query bounds. Query must be enabled with ImPlotFlags_Query.
+IMPLOT_API ImPlotLimits GetPlotQuery(int y_axis = IMPLOT_AUTO);
 
 //-----------------------------------------------------------------------------
 // Legend Utils and Tools

--- a/implot.h
+++ b/implot.h
@@ -459,6 +459,11 @@ IMPLOT_API bool IsPlotQueried();
 // Returns the current plot query bounds.
 IMPLOT_API ImPlotLimits GetPlotQuery(int y_axis = IMPLOT_AUTO);
 
+// Shows a draggable horizontal guide line.
+IMPLOT_API bool HorizontalGuide(const char* id, double* value, const ImVec4& col = IMPLOT_AUTO_COL, float thickness = 2);
+// Shows a draggable vertical guide line.
+IMPLOT_API bool VerticalGuide(const char* id, double* value, const ImVec4& col = IMPLOT_AUTO_COL, float thickness = 2);
+
 //-----------------------------------------------------------------------------
 // Plot and Item Styling
 //-----------------------------------------------------------------------------

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -823,7 +823,7 @@ void ShowDemoWindow(bool* p_open) {
             ImPlot::SetPlotYAxis(0);
             double xs[1000], ys[1000];
             for (int i = 0; i < 1000; ++i) {
-                xs[i] = (x2+x1)/2+abs(x2-x1)*(i/990.0f - 0.5f);
+                xs[i] = (x2+x1)/2+abs(x2-x1)*(i/1000.0f - 0.5f);
                 ys[i] = (y1+y2)/2+abs(y2-y1)/2*sin(f*i/10);
             }
             ImPlot::PlotLine("Why Not?", xs, ys, 1000);

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1218,6 +1218,38 @@ void ShowDemoWindow(bool* p_open) {
         }
     }
     //-------------------------------------------------------------------------
+    if (ImGui::CollapsingHeader("Custom Dragable Lines")) {
+        static float line_value = 0.5f;
+        const float line_width = 3.0f;
+        const float grabbable_width = 5.0f;
+        if (ImPlot::BeginPlot("Dragable Lines")) {
+
+            auto x0 = ImPlot::GetPlotPos().x;
+            auto x1 = ImPlot::GetPlotPos().x + ImPlot::GetPlotSize().x;
+            auto y = ImPlot::PlotToPixels(0, line_value).y;
+            ImPlot::PushPlotClipRect();
+            ImPlot::GetPlotDrawList()->AddLine({ x0, y }, { x1, y }, IM_COL32_WHITE, line_width);
+            ImPlot::PopPlotClipRect();
+
+            ImVec2 old_cursor_pos = ImGui::GetCursorScreenPos();
+            ImVec2 new_cursor_pos = ImVec2(x0, y - grabbable_width / 2.0f);
+            ImGui::SetItemAllowOverlap();
+            ImGui::SetCursorScreenPos(new_cursor_pos);
+            ImGui::InvisibleButton("horizontal_line", ImVec2(x1 - x0, grabbable_width));
+            ImGui::SetCursorScreenPos(old_cursor_pos);
+
+            if (ImGui::IsItemHovered() || ImGui::IsItemActive()) {
+                ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
+            }
+
+            if (ImGui::IsItemActive() && ImGui::IsMouseDragging(0)) {
+                line_value = ImPlot::GetPlotMousePos().y;
+            }
+
+            ImPlot::EndPlot();
+        }
+    }
+    //-------------------------------------------------------------------------
     ImGui::End();
 }
 

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -785,6 +785,23 @@ void ShowDemoWindow(bool* p_open) {
         }
     }
     //-------------------------------------------------------------------------
+    if (ImGui::CollapsingHeader("Guide Lines")) {
+        static double v1 = 0.2;
+        static double v2 = 0.6;
+        static double h1 = 0.25;
+        static double h2 = 0.75;
+        static double h3 = 0.5;
+        if (ImPlot::BeginPlot("##guides",0,0,ImVec2(-1,0),ImPlotFlags_YAxis2)) {            
+            ImPlot::VerticalGuide("v1",&v1, ImVec4(0,1,0,1));
+            ImPlot::VerticalGuide("v2",&v2, ImVec4(0,1,0,1));
+            ImPlot::HorizontalGuide("h1",&h1, ImVec4(1,0,0,1));
+            ImPlot::HorizontalGuide("h2",&h2, ImVec4(1,0,0,1));
+            ImPlot::SetPlotYAxis(1);
+            ImPlot::HorizontalGuide("h3",&h3, ImVec4(1,1,0,1));
+            ImPlot::EndPlot();
+        }
+    }
+    //-------------------------------------------------------------------------
     if (ImGui::CollapsingHeader("Drag and Drop")) {
         const int K_CHANNELS = 9;
         srand((int)(10000000 * DEMO_TIME));
@@ -1214,38 +1231,6 @@ void ShowDemoWindow(bool* p_open) {
         ImPlot::SetNextPlotLimits(1546300800, 1571961600, 1250, 1600);
         if (ImPlot::BeginPlot("Candlestick Chart","Day","USD",ImVec2(-1,0),0,ImPlotAxisFlags_Time)) {
             MyImPlot::PlotCandlestick("GOOGL",dates, opens, closes, lows, highs, 218, tooltip, 0.25f, bullCol, bearCol);
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Custom Dragable Lines")) {
-        static float line_value = 0.5f;
-        const float line_width = 3.0f;
-        const float grabbable_width = 5.0f;
-        if (ImPlot::BeginPlot("Dragable Lines")) {
-
-            auto x0 = ImPlot::GetPlotPos().x;
-            auto x1 = ImPlot::GetPlotPos().x + ImPlot::GetPlotSize().x;
-            auto y = ImPlot::PlotToPixels(0, line_value).y;
-            ImPlot::PushPlotClipRect();
-            ImPlot::GetPlotDrawList()->AddLine({ x0, y }, { x1, y }, IM_COL32_WHITE, line_width);
-            ImPlot::PopPlotClipRect();
-
-            ImVec2 old_cursor_pos = ImGui::GetCursorScreenPos();
-            ImVec2 new_cursor_pos = ImVec2(x0, y - grabbable_width / 2.0f);
-            ImGui::SetItemAllowOverlap();
-            ImGui::SetCursorScreenPos(new_cursor_pos);
-            ImGui::InvisibleButton("horizontal_line", ImVec2(x1 - x0, grabbable_width));
-            ImGui::SetCursorScreenPos(old_cursor_pos);
-
-            if (ImGui::IsItemHovered() || ImGui::IsItemActive()) {
-                ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
-            }
-
-            if (ImGui::IsItemActive() && ImGui::IsMouseDragging(0)) {
-                line_value = ImPlot::GetPlotMousePos().y;
-            }
-
             ImPlot::EndPlot();
         }
     }

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -805,7 +805,7 @@ void ShowDemoWindow(bool* p_open) {
         }
     }
     //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Guide Lines")) {
+    if (ImGui::CollapsingHeader("Guides and Anchors")) {
         ImGui::BulletText("Click and drag the horizontal and vertical guide lines.");
         static double x1 = 0.2;
         static double x2 = 0.8;
@@ -827,6 +827,36 @@ void ShowDemoWindow(bool* p_open) {
                 ys[i] = (y1+y2)/2+abs(y2-y1)/2*sin(f*i/10);
             }
             ImPlot::PlotLine("Why Not?", xs, ys, 1000);
+            ImPlot::EndPlot();
+        }
+        ImGui::BulletText("Click and drag the anchor points.");
+        ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels | ImPlotAxisFlags_NoTickMarks;
+        ImPlot::SetNextPlotLimits(0,1,0,1,ImGuiCond_Always);
+        if (ImPlot::BeginPlot("##Bezier",0,0,ImVec2(-1,0),ImPlotFlags_CanvasOnly|ImPlotFlags_NoChild,flags,flags)) {
+            static ImPlotPoint P[] = {ImPlotPoint(0,0), ImPlotPoint(0.2,0.4),  ImPlotPoint(0.8,0.6),  ImPlotPoint(1,1)};
+            static ImPlotPoint B[100];
+            for (int i = 0; i < 100; ++i) {
+                double t  = i / 99.0;
+                double u  = 1 - t;
+                double w1 = u*u*u;
+                double w2 = 3*u*u*t;
+                double w3 = 3*u*t*t;
+                double w4 = t*t*t;
+                B[i] = ImPlotPoint(w1*P[0].x + w2*P[1].x + w3*P[2].x + w4*P[3].x, w1*P[0].y + w2*P[1].y + w3*P[2].y + w4*P[3].y);
+            }
+            static ImVec4 gray = ImVec4(0.5f,0.5f,0.5f,1.0f);
+            ImPlot::SetNextFillStyle(ImVec4(0,1,0,0.25f));
+            ImPlot::PlotShaded("##bez",&B[0].x, &B[0].y, 100, 0, 0, sizeof(ImPlotPoint));
+            ImPlot::SetNextLineStyle(ImVec4(0,1,0,1), 2);
+            ImPlot::PlotLine("##bez",&B[0].x, &B[0].y, 100, 0, sizeof(ImPlotPoint));
+            ImPlot::SetNextLineStyle(gray, 2);
+            ImPlot::PlotLine("##h1",&P[0].x, &P[0].y, 2, 0, sizeof(ImPlotPoint));
+            ImPlot::SetNextLineStyle(gray, 2);
+            ImPlot::PlotLine("##h2",&P[2].x, &P[2].y, 2, 0, sizeof(ImPlotPoint));
+            ImPlot::AnchorPoint("P0",&P[0].x,&P[0].y,gray);
+            ImPlot::AnchorPoint("P1",&P[1].x,&P[1].y,gray);        
+            ImPlot::AnchorPoint("P2",&P[2].x,&P[2].y,gray);
+            ImPlot::AnchorPoint("P3",&P[3].x,&P[3].y,gray);       
             ImPlot::EndPlot();
         }
     }

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -805,7 +805,7 @@ void ShowDemoWindow(bool* p_open) {
         }
     }
     //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Guides and Anchors")) {
+    if (ImGui::CollapsingHeader("Grab Lines and Points")) {
         ImGui::BulletText("Click and drag the horizontal and vertical guide lines.");
         static double x1 = 0.2;
         static double x2 = 0.8;
@@ -813,12 +813,12 @@ void ShowDemoWindow(bool* p_open) {
         static double y2 = 0.75;
         static double f = 0.1;
         if (ImPlot::BeginPlot("##guides",0,0,ImVec2(-1,0),ImPlotFlags_YAxis2)) {
-            ImPlot::VerticalGuide("x1",&x1);
-            ImPlot::VerticalGuide("x2",&x2);
-            ImPlot::HorizontalGuide("y1",&y1);
-            ImPlot::HorizontalGuide("y2",&y2);
+            ImPlot::GrabLineV("x1",&x1);
+            ImPlot::GrabLineV("x2",&x2);
+            ImPlot::GrabLineH("y1",&y1);
+            ImPlot::GrabLineH("y2",&y2);
             ImPlot::SetPlotYAxis(1);
-            ImPlot::HorizontalGuide("f",&f, ImVec4(1,0.5f,1,1));
+            ImPlot::GrabLineH("f",&f, ImVec4(1,0.5f,1,1));
 
             ImPlot::SetPlotYAxis(0);
             double xs[1000], ys[1000];
@@ -829,9 +829,10 @@ void ShowDemoWindow(bool* p_open) {
             ImPlot::PlotLine("Why Not?", xs, ys, 1000);
             ImPlot::EndPlot();
         }
+
         ImGui::BulletText("Click and drag the anchor points.");
         ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels | ImPlotAxisFlags_NoTickMarks;
-        ImPlot::SetNextPlotLimits(0,1,0,1,ImGuiCond_Always);
+        // ImPlot::SetNextPlotLimits(0,1,0,1,ImGuiCond_Always);
         if (ImPlot::BeginPlot("##Bezier",0,0,ImVec2(-1,0),ImPlotFlags_CanvasOnly|ImPlotFlags_NoChild,flags,flags)) {
             static ImPlotPoint P[] = {ImPlotPoint(0,0), ImPlotPoint(0.2,0.4),  ImPlotPoint(0.8,0.6),  ImPlotPoint(1,1)};
             static ImPlotPoint B[100];
@@ -853,10 +854,10 @@ void ShowDemoWindow(bool* p_open) {
             ImPlot::PlotLine("##h1",&P[0].x, &P[0].y, 2, 0, sizeof(ImPlotPoint));
             ImPlot::SetNextLineStyle(gray, 2);
             ImPlot::PlotLine("##h2",&P[2].x, &P[2].y, 2, 0, sizeof(ImPlotPoint));
-            ImPlot::AnchorPoint("P0",&P[0].x,&P[0].y,gray);
-            ImPlot::AnchorPoint("P1",&P[1].x,&P[1].y,gray);        
-            ImPlot::AnchorPoint("P2",&P[2].x,&P[2].y,gray);
-            ImPlot::AnchorPoint("P3",&P[3].x,&P[3].y,gray);       
+            ImPlot::GrabPoint("P0",&P[0].x,&P[0].y,gray);
+            ImPlot::GrabPoint("P1",&P[1].x,&P[1].y,gray);
+            ImPlot::GrabPoint("P2",&P[2].x,&P[2].y,gray);
+            ImPlot::GrabPoint("P3",&P[3].x,&P[3].y,gray);
             ImPlot::EndPlot();
         }
     }

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -806,18 +806,27 @@ void ShowDemoWindow(bool* p_open) {
     }
     //-------------------------------------------------------------------------
     if (ImGui::CollapsingHeader("Guide Lines")) {
-        static double v1 = 0.2;
-        static double v2 = 0.6;
-        static double h1 = 0.25;
-        static double h2 = 0.75;
-        static double h3 = 0.5;
-        if (ImPlot::BeginPlot("##guides",0,0,ImVec2(-1,0),ImPlotFlags_YAxis2)) {            
-            ImPlot::VerticalGuide("v1",&v1, ImVec4(0,1,0,1));
-            ImPlot::VerticalGuide("v2",&v2, ImVec4(0,1,0,1));
-            ImPlot::HorizontalGuide("h1",&h1, ImVec4(1,0,0,1));
-            ImPlot::HorizontalGuide("h2",&h2, ImVec4(1,0,0,1));
+        ImGui::BulletText("Click and drag the horizontal and vertical guide lines.");
+        static double x1 = 0.2;
+        static double x2 = 0.8;
+        static double y1 = 0.25;
+        static double y2 = 0.75;
+        static double f = 0.1;
+        if (ImPlot::BeginPlot("##guides",0,0,ImVec2(-1,0),ImPlotFlags_YAxis2)) {
+            ImPlot::VerticalGuide("x1",&x1);
+            ImPlot::VerticalGuide("x2",&x2);
+            ImPlot::HorizontalGuide("y1",&y1);
+            ImPlot::HorizontalGuide("y2",&y2);
             ImPlot::SetPlotYAxis(1);
-            ImPlot::HorizontalGuide("h3",&h3, ImVec4(1,1,0,1));
+            ImPlot::HorizontalGuide("f",&f, ImVec4(1,0.5f,1,1));
+
+            ImPlot::SetPlotYAxis(0);
+            double xs[1000], ys[1000];
+            for (int i = 0; i < 1000; ++i) {
+                xs[i] = (x2+x1)/2+abs(x2-x1)*(i/990.0f - 0.5f);
+                ys[i] = (y1+y2)/2+abs(y2-y1)/2*sin(f*i/10);
+            }
+            ImPlot::PlotLine("Why Not?", xs, ys, 1000);
             ImPlot::EndPlot();
         }
     }


### PR DESCRIPTION
For my application I needed a horizontal reference line that could be adjusted by dragging it with the mouse. To do this I added an invisible button and detect when that button is being dragged. In order for this to work I needed to modify ImPlot to tell `ImGui::ItemAdd` what our ID is, and then check for if `HoveredIdPreviousFrame` matches our ID. If it does not match that indicates that the mouse is actually hovering a widget added on top of us. I'm not sure why `ImGui::ItemHoverable` does not check this by default?

I've included a demo of a horizontal line movable via click and drag.