### PR TITLE
Add CMake integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(implot)
+
+option(BUILD_IMPLOT_SHARED "Build implot shared library" ON)
+option(BUILD_IMPLOT_STATIC "Build implot static library" ON)
+option(BUILD_IMPLOT_DEMO "Build implot demo" OFF)
+
+SET(IMPLOT_SOURCES
+    implot.cpp
+    implot_items.cpp)
+
+if (BUILD_IMPLOT_DEMO)
+    message(STATUS "Building with implot demo.")
+    SET(IMPLOT_SOURCES
+        ${IMPLOT_SOURCES}
+        implot_demo.cpp)
+endif ()
+
+if (BUILD_IMPLOT_SHARED)
+    message(STATUS "Building implot as a shared library.")
+    add_library(implot_shared SHARED
+        ${IMPLOT_SOURCES})
+endif ()
+
+if (BUILD_IMPLOT_STATIC)
+    message(STATUS "Building implot as a static library.")
+    add_library(implot STATIC
+        ${IMPLOT_SOURCES})
+endif ()

--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ An online version of the demo is hosted [here](https://traineq.org/implot_demo/s
 ## Integration
 
 0) Set up an [ImGui](https://github.com/ocornut/imgui) environment if you don't already have one. 
-1) Add `implot.h`, `implot_internal.h`, `implot.cpp`, `implot_items.cpp` and optionally `implot_demo.cpp` to your sources. Alternatively, you can get ImPlot using [vcpkg](https://github.com/microsoft/vcpkg/tree/master/ports/implot). 
+1) Add `implot.h`, `implot_internal.h`, `implot.cpp`, `implot_items.cpp` and optionally `implot_demo.cpp` to your sources. Alternatively, you can get ImPlot using [vcpkg](https://github.com/microsoft/vcpkg/tree/master/ports/implot). If you are using CMake, you can integrate ImPlot to your project by adding the following to a `CMakeLists.txt` file in your project:
+
+```cpp
+include_directories(path/to/implot/)
+add_subdirectory(path/to/implot/)
+```
+
 2) Create and destroy an `ImPlotContext` wherever you do so for your `ImGuiContext`:
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -65,12 +65,7 @@ An online version of the demo is hosted [here](https://traineq.org/implot_demo/s
 ## Integration
 
 0) Set up an [ImGui](https://github.com/ocornut/imgui) environment if you don't already have one. 
-1) Add `implot.h`, `implot_internal.h`, `implot.cpp`, `implot_items.cpp` and optionally `implot_demo.cpp` to your sources. Alternatively, you can get ImPlot using [vcpkg](https://github.com/microsoft/vcpkg/tree/master/ports/implot). If you are using CMake, you can integrate ImPlot to your project by adding the following to a `CMakeLists.txt` file in your project:
-
-```cpp
-include_directories(path/to/implot/)
-add_subdirectory(path/to/implot/)
-```
+1) Add `implot.h`, `implot_internal.h`, `implot.cpp`, `implot_items.cpp` and optionally `implot_demo.cpp` to your sources. Alternatively, you can get ImPlot using [vcpkg](https://github.com/microsoft/vcpkg/tree/master/ports/implot).
 
 2) Create and destroy an `ImPlotContext` wherever you do so for your `ImGuiContext`:
 
@@ -85,6 +80,39 @@ ImGui::DestroyContext();
 You should be good to go!  
 
 If you want to test ImPlot quickly, consider trying [mahi-gui](https://github.com/mahilab/mahi-gui), which bundles ImGui, ImPlot, and several other packages for you.
+
+### CMake Integration
+
+If you are using CMake, you can integrate ImPlot to your project by adding the following to a `CMakeLists.txt` file in your project:
+
+```cmake
+include_directories(path/to/implot/)
+add_subdirectory(path/to/implot/)
+```
+
+You can then link ImPlot to a target executable by doing
+
+```cmake
+target_link_libraries(<target executable>
+    implot
+    <other libraries>)
+```
+
+if you want to link the static version of ImPlot, or
+
+```cmake
+target_link_libraries(<target executable>
+    implot_shared
+    <other libraries>)
+```
+
+if you want to link the shared version.
+
+The following are the available build options which you can toggle on or off by setting their value to either `ON` or `OFF`, respectively:
+
+* `BUILD_IMPLOT_SHARED` - builds a shared library version of ImPlot; turned on by default
+* `BUILD_IMPLOT_STATIC` - builds a static library version of ImPlot; turned on by default
+* `BUILD_IMPLOT_DEMO` - includes the demo in the library; turned off by default
 
 ## Special Notes
 

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1425,7 +1425,7 @@ void StyleSeaborn() {
 // into the public API and expose the necessary building blocks to fully support
 // custom plotters. For now, proceed at your own risk!
 
-#include <implot_internal.h>
+#include "implot_internal.h"
 
 namespace MyImPlot {
 


### PR DESCRIPTION
I am using ImPlot in a project of mine. My project uses CMake, and having CMake support in dependencies that I obtain from repositories makes it easier for me to use them in my project. As such, I have added a `CMakeLists.txt` to my fork of ImPlot so that I can integrate it more easily to my project. I am writing this PR in the hopes that my modifications might be helpful to other developers.

Developers can integrate ImPlot to their CMake project by adding the following lines in a `CMakeLists.txt` file:

```cmake
include_directories(path/to/implot/)
add_subdirectory(path/to/implot/)
```

And then link ImPlot to their executable by doing

```cmake
target_link_libraries(<target executable>
    implot
    <other libraries>)
```

if they want to link the static version of ImPlot, or

```cmake
target_link_libraries(<target executable>
    implot_shared
    <other libraries>)
```

if they want to the shared version.

I have added three options in the `CMakeLists.txt` file that can be toggled on or off by setting their values to either `ON` or `OFF`, respectively:

* `BUILD_IMPLOT_SHARED` - builds a shared library version of ImPlot; turned on by default
* `BUILD_IMPLOT_STATIC` - builds a static library version of ImPlot; turned on by default
* `BUILD_IMPLOT_DEMO` - includes the demo in the library; turned off by default

I've also updated the README to include the documentation for CMake integration.