### PR TITLE
Option for not rendering the title of the graph.

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -1407,8 +1407,11 @@ bool BeginPlot(const char* title, const char* x_label, const char* y_label, cons
     // plot bb
 
     // (1) calc top/bot padding and plot height
-    const ImVec2 title_size = ImGui::CalcTextSize(title, NULL, true);
-    const float txt_height  = ImGui::GetTextLineHeight();
+    ImVec2 title_size = ImVec2(0.0f, 0.0f);
+    const float txt_height = ImGui::GetTextLineHeight();
+    if (!ImHasFlag(plot.Flags, ImPlotFlags_NoTitle)){
+         title_size = ImGui::CalcTextSize(title, NULL, true);
+    }
 
     const float pad_top = title_size.x > 0.0f ? txt_height + gp.Style.LabelPadding.y : 0;
     const float pad_bot = (gp.X.HasLabels ? txt_height + gp.Style.LabelPadding.y + (gp.X.IsTime ? txt_height + gp.Style.LabelPadding.y : 0) : 0)
@@ -1783,7 +1786,7 @@ bool BeginPlot(const char* title, const char* x_label, const char* y_label, cons
     PopPlotClipRect();
 
     // render title
-    if (title_size.x > 0.0f) {
+    if (title_size.x > 0.0f && !ImHasFlag(plot.Flags, ImPlotFlags_NoTitle)) {
         ImU32 col = GetStyleColorU32(ImPlotCol_TitleText);
         const char* title_end = ImGui::FindRenderedTextEnd(title, NULL);
         DrawList.AddText(ImVec2(gp.BB_Canvas.GetCenter().x - title_size.x * 0.5f, gp.BB_Canvas.Min.y),col,title,title_end);

--- a/implot.h
+++ b/implot.h
@@ -76,7 +76,7 @@ enum ImPlotFlags_ {
     ImPlotFlags_Query         = 1 << 8,  // the user will be able to draw query rects with middle-mouse
     ImPlotFlags_Crosshairs    = 1 << 9,  // the default mouse cursor will be replaced with a crosshair when hovered
     ImPlotFlags_AntiAliased   = 1 << 10, // plot lines will be software anti-aliased (not recommended for density plots, prefer MSAA)
-    ImPlotFlags_NoTitle       = 1 << 11, // Removes the title the from plot
+    ImPlotFlags_NoTitle       = 1 << 11, // Removes the title from the plot
     ImPlotFlags_CanvasOnly    = ImPlotFlags_NoLegend | ImPlotFlags_NoMenus | ImPlotFlags_NoBoxSelect | ImPlotFlags_NoMousePos
 };
 

--- a/implot.h
+++ b/implot.h
@@ -76,6 +76,7 @@ enum ImPlotFlags_ {
     ImPlotFlags_Query         = 1 << 8,  // the user will be able to draw query rects with middle-mouse
     ImPlotFlags_Crosshairs    = 1 << 9,  // the default mouse cursor will be replaced with a crosshair when hovered
     ImPlotFlags_AntiAliased   = 1 << 10, // plot lines will be software anti-aliased (not recommended for density plots, prefer MSAA)
+    ImPlotFlags_NoTitle       = 1 << 11, // Removes the title the from plot
     ImPlotFlags_CanvasOnly    = ImPlotFlags_NoLegend | ImPlotFlags_NoMenus | ImPlotFlags_NoBoxSelect | ImPlotFlags_NoMousePos
 };
 


### PR DESCRIPTION
Option for not rendering the title of the graph.

I needed a small form factor bar chart. Setting the flag results in:

![image](https://user-images.githubusercontent.com/1578820/98082971-ebbf7000-1e79-11eb-9aab-d42f60f2e98e.png)
