### PR TITLE
Fixed bounds computation for heatmap labels

### DIFF
--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -1684,7 +1684,7 @@ void RenderHeatmap(Transformer transformer, ImDrawList& DrawList, const T* value
             for (int c = 0; c < cols; ++c) {
                 ImPlotPoint p;
                 p.x = bounds_min.x + 0.5*w + c*w;
-                p.y = bounds_min.y + 1 - (0.5*h + r*h);
+                p.y = bounds_max.y - (0.5*h + r*h);
                 ImVec2 px = transformer(p);
                 char buff[32];
                 sprintf(buff, fmt, values[i]);


### PR DESCRIPTION
Hi there, 

While creating bindings for the heatmap plots, I noticed that the labels don't seem to get drawn in the right place when I change the bounds. The (-1,-1) and (0,0) case shows up properly, like in your demo code:

![image](https://user-images.githubusercontent.com/67376761/99192844-84f15f00-2775-11eb-97ab-746978d8e300.png)

however, if I for example change the bounds to (-1,-1) and (1,1), I get this picture:

![image](https://user-images.githubusercontent.com/67376761/99192870-a6524b00-2775-11eb-8330-87c4a0816354.png)

If I make the change of this PR, it shows up as expected:

![image](https://user-images.githubusercontent.com/67376761/99192895-c550dd00-2775-11eb-9740-7b0ebfbdb340.png)

Note that I didn't think about this for a long time, I just copied the computation you use for the `px` of  points themselves and tried out a few cases. I'm also trying this out from the Rust bindings (https://github.com/4bb4/implot-rs says hi!), so there is a chance that I messed up on the integration side and didn't find the issue. If that is the case, apologies in advance :+1: 