### PR TITLE
render x-axis drag/drop hover

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -2221,6 +2221,16 @@ void EndPlot() {
         }
     }
 
+    // render x-axis drag/drop hover
+    if (plot.XAxis.Present && ImGui::IsDragDropPayloadBeingAccepted()) {
+        if (plot.XAxis.ExtHovered) {
+            float y_loc = plot.XAxis.HoverRect.Min.y;
+            ImVec2 p1(plot.XAxis.HoverRect.Min.x - 5, y_loc - 5);
+            ImVec2 p2(plot.XAxis.HoverRect.Max.x + 5, y_loc + 5);
+            DrawList.AddRect(p1, p2, ImGui::GetColorU32(ImGuiCol_DragDropTarget), 0.0f,  ImDrawCornerFlags_All, 2.0f);
+        }
+    }
+
     PushPlotClipRect();
     // render selection/query
     if (plot.Selecting) {


### PR DESCRIPTION
Similar to your Drag and Drop demo I have a drag and drop plot setup where the user can select from a number of variables to plot. I want them to be able to drop one variable on the x-axis (and use that as the x variable). For that I thought highlighting the x-axis like the y-axes would be good.
I'm not insisting on this pull request being merged. I can maintain that patch in my project, no problem. But I thought it could be useful thing to have.
I'm not sure how that fits your concept. Perhaps you'd prefer this to be an option (ImPlotFlags or ImPlotAxisFlags perhaps)?
Please advise.
