### PR TITLE
fix compiler warning re. 'if does not guard...'

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -2085,15 +2085,15 @@ void ShowPlotContextMenu(ImPlotPlot& plot) {
                 plot.LegendOrientation = ImPlotOrientation_Vertical;
             ImGui::Checkbox("Outside", &plot.LegendOutside);
             ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(1,1));
-            if (ImGui::Button("##NW",ImVec2(1.5f*s,s))) plot.LegendLocation = ImPlotLocation_NorthWest; ImGui::SameLine();
-            if (ImGui::Button("##N", ImVec2(1.5f*s,s))) plot.LegendLocation = ImPlotLocation_North;     ImGui::SameLine();
-            if (ImGui::Button("##NE",ImVec2(1.5f*s,s))) plot.LegendLocation = ImPlotLocation_NorthEast;
-            if (ImGui::Button("##W", ImVec2(1.5f*s,s))) plot.LegendLocation = ImPlotLocation_West;      ImGui::SameLine();
-            if (ImGui::Button("##C", ImVec2(1.5f*s,s))) plot.LegendLocation = ImPlotLocation_Center;    ImGui::SameLine();
-            if (ImGui::Button("##E", ImVec2(1.5f*s,s))) plot.LegendLocation = ImPlotLocation_East;
-            if (ImGui::Button("##SW",ImVec2(1.5f*s,s))) plot.LegendLocation = ImPlotLocation_SouthWest; ImGui::SameLine();
-            if (ImGui::Button("##S", ImVec2(1.5f*s,s))) plot.LegendLocation = ImPlotLocation_South;      ImGui::SameLine();
-            if (ImGui::Button("##SE",ImVec2(1.5f*s,s))) plot.LegendLocation = ImPlotLocation_SouthEast;
+            if (ImGui::Button("##NW",ImVec2(1.5f*s,s))) { plot.LegendLocation = ImPlotLocation_NorthWest; } ImGui::SameLine();
+            if (ImGui::Button("##N", ImVec2(1.5f*s,s))) { plot.LegendLocation = ImPlotLocation_North;     } ImGui::SameLine();
+            if (ImGui::Button("##NE",ImVec2(1.5f*s,s))) { plot.LegendLocation = ImPlotLocation_NorthEast; }
+            if (ImGui::Button("##W", ImVec2(1.5f*s,s))) { plot.LegendLocation = ImPlotLocation_West;      } ImGui::SameLine();
+            if (ImGui::Button("##C", ImVec2(1.5f*s,s))) { plot.LegendLocation = ImPlotLocation_Center;    } ImGui::SameLine();
+            if (ImGui::Button("##E", ImVec2(1.5f*s,s))) { plot.LegendLocation = ImPlotLocation_East;      }
+            if (ImGui::Button("##SW",ImVec2(1.5f*s,s))) { plot.LegendLocation = ImPlotLocation_SouthWest; } ImGui::SameLine();
+            if (ImGui::Button("##S", ImVec2(1.5f*s,s))) { plot.LegendLocation = ImPlotLocation_South;     } ImGui::SameLine();
+            if (ImGui::Button("##SE",ImVec2(1.5f*s,s))) { plot.LegendLocation = ImPlotLocation_SouthEast; }
             ImGui::PopStyleVar();
             ImGui::EndMenu();
         }


### PR DESCRIPTION
My compiler (or the settings I use) throws some "if does not guard..." warnings here and insists on putting explicit {} blocks.
I like it better that way, too. :-)
Feel free to use or discard.