### PR TITLE
Center constant data when fitting.

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -2393,8 +2393,8 @@ void EndPlot() {
             if (!ImHasFlag(plot.XAxis.Flags, ImPlotAxisFlags_LockMax) && !ImNanOrInf(gp.ExtentsX.Max))
                 plot.XAxis.Range.Max = (gp.ExtentsX.Max);
             if (ImAlmostEqual(plot.XAxis.Range.Max, plot.XAxis.Range.Min))  {
-                plot.XAxis.Range.Max += plot.XAxis.Range.Max * 1.01;
-                plot.XAxis.Range.Min -= plot.XAxis.Range.Max * 1.01;
+                plot.XAxis.Range.Max += 0.5;
+                plot.XAxis.Range.Min -= 0.5;
             }
             plot.XAxis.Constrain();
             if (axis_equal && !gp.FitY[0])
@@ -2410,8 +2410,8 @@ void EndPlot() {
                 if (!ImHasFlag(plot.YAxis[i].Flags, ImPlotAxisFlags_LockMax) && !ImNanOrInf(gp.ExtentsY[i].Max))
                     plot.YAxis[i].Range.Max = (gp.ExtentsY[i].Max);
                 if (ImAlmostEqual(plot.YAxis[i].Range.Max, plot.YAxis[i].Range.Min)) {
-                    plot.YAxis[i].Range.Max += plot.YAxis[i].Range.Max * 1.01;
-                    plot.YAxis[i].Range.Min -= plot.YAxis[i].Range.Max * 1.01;
+                    plot.YAxis[i].Range.Max += 0.5;
+                    plot.YAxis[i].Range.Min -= 0.5;
                 }
                 plot.YAxis[i].Constrain();
                 if (i == 0 && axis_equal && !gp.FitX)


### PR DESCRIPTION
This is an extremely simple fix, I am open to changing it. The reason the current logic does not work is that if the `plot.XAxis.Range.Max` happens to be zero, nothing will happen. I reasoned that we don't really need to shift ranges by some percentage of the max value, we just center it.