### PR TITLE
Fix for draw corners renames in imgui master + fix misuse of ImGui::Value()

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -76,6 +76,11 @@ You can read releases logs https://github.com/epezent/implot/releases for more d
 #define sprintf sprintf_s
 #endif
 
+// Support for pre-1.82 version. Users on 1.82+ can use 0 (default) flags to mean "all corners" but in order to support older versions we are more explicit.
+#if (IMGUI_VERSION_NUM < 18102) && !defined(ImDrawFlags_RoundCornersAll)
+#define ImDrawFlags_RoundCornersAll ImDrawCornerFlags_All
+#endif
+
 // Global plot context
 ImPlotContext* GImPlot = NULL;
 
@@ -2426,7 +2431,7 @@ void EndPlot() {
 
     // render border
     if (gp.Style.PlotBorderSize > 0)
-        DrawList.AddRect(plot.PlotRect.Min, plot.PlotRect.Max, GetStyleColorU32(ImPlotCol_PlotBorder), 0, ImDrawCornerFlags_All, gp.Style.PlotBorderSize);
+        DrawList.AddRect(plot.PlotRect.Min, plot.PlotRect.Max, GetStyleColorU32(ImPlotCol_PlotBorder), 0, ImDrawFlags_RoundCornersAll, gp.Style.PlotBorderSize);
 
     // FIT DATA --------------------------------------------------------------
     const bool axis_equal = ImHasFlag(plot.Flags, ImPlotFlags_Equal);
@@ -3902,7 +3907,7 @@ void ShowMetricsWindow(bool* p_popen) {
                             ImGui::Bullet(); ImGui::ColorEdit4("Color",&item->Color.x, ImGuiColorEditFlags_NoInputs);
                             ImGui::Bullet(); ImGui::Text("NameOffset: %d",item->NameOffset);
                             ImGui::Bullet(); ImGui::Text("Name:       %s", item->NameOffset != -1 ? plot->LegendData.Labels.Buf.Data + item->NameOffset : "N/A");
-                            ImGui::Bullet(); ImGui::Value("Hovered:   %s",item->LegendHovered ? "true" : "false");
+                            ImGui::Bullet(); ImGui::Text("Hovered:    %s", item->LegendHovered ? "true" : "false");
                             ImGui::TreePop();
                         }
                         ImGui::PopID();

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -42,6 +42,11 @@
         }                                                                                          \
     }
 
+// Support for pre-1.82 version. Users on 1.82+ can use 0 (default) flags to mean "all corners" but in order to support older versions we are more explicit.
+#if (IMGUI_VERSION_NUM < 18102) && !defined(ImDrawFlags_RoundCornersAll)
+#define ImDrawFlags_RoundCornersAll ImDrawCornerFlags_All
+#endif
+
 namespace ImPlot {
 
 //-----------------------------------------------------------------------------
@@ -1277,7 +1282,7 @@ void PlotBarsEx(const char* label_id, const Getter& getter, double width) {
             if (s.RenderFill)
                 DrawList.AddRectFilled(a, b, col_fill);
             if (rend_line)
-                DrawList.AddRect(a, b, col_line, 0, ImDrawCornerFlags_All, s.LineWeight);
+                DrawList.AddRect(a, b, col_line, 0, ImDrawFlags_RoundCornersAll, s.LineWeight);
         }
         EndItem();
     }
@@ -1356,7 +1361,7 @@ void PlotBarsHEx(const char* label_id, const Getter& getter, THeight height) {
             if (s.RenderFill)
                 DrawList.AddRectFilled(a, b, col_fill);
             if (rend_line)
-                DrawList.AddRect(a, b, col_line, 0, ImDrawCornerFlags_All, s.LineWeight);
+                DrawList.AddRect(a, b, col_line, 0, ImDrawFlags_RoundCornersAll, s.LineWeight);
         }
         EndItem();
     }


### PR DESCRIPTION
- Fix to support recently renamed flags ImDrawCornerFlags_All -> ImDrawFlags_RoundCornersAll.
In order to support codebases with IMGUI_DISABLE_OBSOLETE_FUNCTIONS we attempt to use the new symbol when available, else define new name to old name. Fix is not required is user doesn't set IMGUI_DISABLE_OBSOLETE_FUNCTIONS .
Note that for this specific change, code designed for 1.82+ (aka regular user code) can now use the default 0 to signify "all round corners". As I imagine implot wants to target older versions we keep the explicit flags.

- Fix one misuse of `ImGui::Value()` in Metrics (was calling the const char* + bool version erroneously, I guess leading to the `%s` bit being displayed to user.

