### PR TITLE
Added function for plotting colormap icon.

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -3448,6 +3448,21 @@ void ShowColormapScale(double scale_min, double scale_max, const ImVec2& size) {
     ImGui::PopClipRect();
 }
 
+void ShowColormapIcon(const ImVec2& size){
+    const ImGuiContext &G = *GImGui;
+    ImGuiWindow * Window = G.CurrentWindow;
+    ImPlotContext& gp = *GImPlot;
+    ImDrawList &DrawList = *Window->DrawList;
+    ImRect bb_frame = ImRect(Window->DC.CursorPos + ImVec2{0,-2}, Window->DC.CursorPos + ImVec2{size.x+2,size.y});
+    ImGui::ItemSize({size.x,size.y});
+    ImRect bb_grad(bb_frame.Min, bb_frame.Max);
+    ImGui::PushClipRect(bb_frame.Min, bb_frame.Max, true);
+    ImPlotColormap map = gp.Style.Colormap;
+    RenderColorBar(gp.ColormapData.GetKeys(map), gp.ColormapData.GetKeyCount(map), 
+        DrawList, bb_grad, true, true, !gp.ColormapData.IsQual(map));
+    DrawList.AddRect(bb_grad.Min, bb_grad.Max, GetStyleColorU32(ImPlotCol_PlotBorder));
+    ImGui::PopClipRect();
+}
 
 //-----------------------------------------------------------------------------
 // Style Editor etc.

--- a/implot.h
+++ b/implot.h
@@ -700,6 +700,9 @@ IMPLOT_API const char* GetColormapName(ImPlotColormap cmap);
 // Renders a vertical color scale using the current color map. Call this before or after Begin/EndPlot.
 IMPLOT_API void ShowColormapScale(double scale_min, double scale_max, const ImVec2& size = ImVec2(0,0));
 
+// Render colormap in a rectangle of given size
+IMPLOT_API void ShowColormapIcon(const ImVec2& size = {ImGui::GetFontSize(),ImGui::GetFontSize()});
+
 //-----------------------------------------------------------------------------
 // Miscellaneous
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
In order to create a dropdown menu for selecting colormaps (see screenshot), I added a function for generating a miniature version of the active colormapscale. Please check if I have done everything properly as I have copy pasted most of the code from the ShowColormapScale function and I'm not yet fully familiar with ImPlot's internal workings. The offset of 2 was needed to vertically center the icon with the text.
![image](https://user-images.githubusercontent.com/78733220/111231865-474cf780-85ea-11eb-94c4-40fbadddf820.png)
