### PR TITLE
Adds ImPlotAxisFlags_RangeFit and ImPlotAxisFlags_Foreground

### DIFF
--- a/implot.h
+++ b/implot.h
@@ -89,13 +89,15 @@ enum ImPlotAxisFlags_ {
     ImPlotAxisFlags_NoGridLines   = 1 << 1,  // no grid lines will be displayed
     ImPlotAxisFlags_NoTickMarks   = 1 << 2,  // no tick marks will be displayed
     ImPlotAxisFlags_NoTickLabels  = 1 << 3,  // no text labels will be displayed
-    ImPlotAxisFlags_LogScale      = 1 << 4,  // a logartithmic (base 10) axis scale will be used (mutually exclusive with ImPlotAxisFlags_Time)
-    ImPlotAxisFlags_Time          = 1 << 5,  // axis will display date/time formatted labels (mutually exclusive with ImPlotAxisFlags_LogScale)
-    ImPlotAxisFlags_Invert        = 1 << 6,  // the axis will be inverted
-    ImPlotAxisFlags_NoInitialFit  = 1 << 7,  // axis will not be initially fit to data extents on the first rendered frame (also the case if SetNextPlotLimits explicitly called)
-    ImPlotAxisFlags_AutoFit       = 1 << 8,  // axis will be auto-fitting to data extents
-    ImPlotAxisFlags_LockMin       = 1 << 9,  // the axis minimum value will be locked when panning/zooming
-    ImPlotAxisFlags_LockMax       = 1 << 10, // the axis maximum value will be locked when panning/zooming
+    ImPlotAxisFlags_Foreground    = 1 << 4,  // grid lines will be displayed in the foreground (i.e. on top of data) in stead of the background
+    ImPlotAxisFlags_LogScale      = 1 << 5,  // a logartithmic (base 10) axis scale will be used (mutually exclusive with ImPlotAxisFlags_Time)
+    ImPlotAxisFlags_Time          = 1 << 6,  // axis will display date/time formatted labels (mutually exclusive with ImPlotAxisFlags_LogScale)
+    ImPlotAxisFlags_Invert        = 1 << 7,  // the axis will be inverted
+    ImPlotAxisFlags_NoInitialFit  = 1 << 8,  // axis will not be initially fit to data extents on the first rendered frame (also the case if SetNextPlotLimits explicitly called)
+    ImPlotAxisFlags_AutoFit       = 1 << 9,  // axis will be auto-fitting to data extents
+    ImPlotAxisFlags_RangeFit      = 1 << 10, // axis will only fit points if the point is in the visible range of the **orthoganol** axis
+    ImPlotAxisFlags_LockMin       = 1 << 11, // the axis minimum value will be locked when panning/zooming
+    ImPlotAxisFlags_LockMax       = 1 << 12, // the axis maximum value will be locked when panning/zooming
     ImPlotAxisFlags_Lock          = ImPlotAxisFlags_LockMin | ImPlotAxisFlags_LockMax,
     ImPlotAxisFlags_NoDecorations = ImPlotAxisFlags_NoLabel | ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_NoTickMarks | ImPlotAxisFlags_NoTickLabels
 };
@@ -808,8 +810,8 @@ IMPLOT_API void ColormapIcon(ImPlotColormap cmap);
 
 // Get the plot draw list for custom rendering to the current plot area. Call between Begin/EndPlot.
 IMPLOT_API ImDrawList* GetPlotDrawList();
-// Push clip rect for rendering to current plot area. Call between Begin/EndPlot.
-IMPLOT_API void PushPlotClipRect();
+// Push clip rect for rendering to current plot area. The rect can be expanded or contracted by #expand pixels. Call between Begin/EndPlot.
+IMPLOT_API void PushPlotClipRect(float expand=0);
 // Pop plot clip rect. Call between Begin/EndPlot.
 IMPLOT_API void PopPlotClipRect();
 

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -654,8 +654,9 @@ void ShowDemoWindow(bool* p_open) {
         static NormalDistribution<500000> dist1(1, 2);
         static NormalDistribution<500000> dist2(1, 1);
         double max_count = 0;
-        ImPlot::PushColormap("Twilight");
-        if (ImPlot::BeginPlot("##Hist2D",0,0,ImVec2(ImGui::GetContentRegionAvail().x-100-ImGui::GetStyle().ItemSpacing.x,0),0,ImPlotAxisFlags_AutoFit,ImPlotAxisFlags_AutoFit)) {
+        ImPlotAxisFlags flags = ImPlotAxisFlags_AutoFit|ImPlotAxisFlags_Foreground;
+        ImPlot::PushColormap("Hot");
+        if (ImPlot::BeginPlot("##Hist2D",0,0,ImVec2(ImGui::GetContentRegionAvail().x-100-ImGui::GetStyle().ItemSpacing.x,0),0,flags,flags)) {
             max_count = ImPlot::PlotHistogram2D("Hist2D",dist1.Data,dist2.Data,count,xybins[0],xybins[1],density2,ImPlotLimits(-6,6,-6,6));
             ImPlot::EndPlot();
         }
@@ -950,6 +951,35 @@ void ShowDemoWindow(bool* p_open) {
             ImPlot::PlotLine("Circle",xs,ys,1000);
             ImPlot::EndPlot();
         }
+    }
+    //-------------------------------------------------------------------------
+    if (ImGui::CollapsingHeader("Auto-Fitting Data")) {
+
+        ImGui::BulletText("The Y-axis has been configured to auto-fit to only the data visible in X-axis range.");
+        ImGui::BulletText("Zoom and pan the X-axis. Disable Stems to see a difference in fit.");
+        ImGui::BulletText("If ImPlotAxisFlags_RangeFit is disabled, the axis will fit ALL data.");
+
+        static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
+        static ImPlotAxisFlags yflags = ImPlotAxisFlags_AutoFit|ImPlotAxisFlags_RangeFit;
+
+        ImGui::TextUnformatted("X: "); ImGui::SameLine();
+        ImGui::CheckboxFlags("ImPlotAxisFlags_AutoFit##X", (unsigned int*)&xflags, ImPlotAxisFlags_AutoFit); ImGui::SameLine();
+        ImGui::CheckboxFlags("ImPlotAxisFlags_RangeFit##X", (unsigned int*)&xflags, ImPlotAxisFlags_RangeFit);
+
+        ImGui::TextUnformatted("Y: "); ImGui::SameLine();
+        ImGui::CheckboxFlags("ImPlotAxisFlags_AutoFit##Y", (unsigned int*)&yflags, ImPlotAxisFlags_AutoFit); ImGui::SameLine();
+        ImGui::CheckboxFlags("ImPlotAxisFlags_RangeFit##Y", (unsigned int*)&yflags, ImPlotAxisFlags_RangeFit);
+
+        static double data[101];
+        srand(0);
+        for (int i = 0; i < 101; ++i)
+            data[i] = 1 + sin(i/10.0f);
+
+        if (ImPlot::BeginPlot("##DataFitting","X","Y",ImVec2(-1,0),0,xflags,yflags)) {
+            ImPlot::PlotLine("Line",data,101);
+            ImPlot::PlotStems("Stems",data,101);
+            ImPlot::EndPlot();
+        };
     }
     //-------------------------------------------------------------------------
     if (ImGui::CollapsingHeader("Querying")) {

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -987,12 +987,37 @@ static inline ImPlotScale GetCurrentScale() { return GImPlot->Scales[GetCurrentY
 
 // Returns true if the user has requested data to be fit.
 static inline bool FitThisFrame() { return GImPlot->FitThisFrame; }
-// Extends the current plot's axes so that it encompasses point p
-IMPLOT_API void FitPoint(const ImPlotPoint& p);
+// Extend the the extents of an axis on current plot so that it encompes v
+static inline void FitPointAxis(ImPlotAxis& axis, ImPlotRange& ext, double v) {
+    if (!ImNanOrInf(v) && !(ImHasFlag(axis.Flags, ImPlotAxisFlags_LogScale) && v <= 0)) {
+        ext.Min = v < ext.Min ? v : ext.Min;
+        ext.Max = v > ext.Max ? v : ext.Max;
+    }
+}
+// Extend the the extents of an axis on current plot so that it encompes v
+static inline void FitPointMultiAxis(ImPlotAxis& axis, ImPlotAxis& alt, ImPlotRange& ext, double v, double v_alt) {
+    if (ImHasFlag(axis.Flags, ImPlotAxisFlags_RangeFit) && !alt.Range.Contains(v_alt))
+        return;
+    if (!ImNanOrInf(v) && !(ImHasFlag(axis.Flags, ImPlotAxisFlags_LogScale) && v <= 0)) {
+        ext.Min = v < ext.Min ? v : ext.Min;
+        ext.Max = v > ext.Max ? v : ext.Max;
+    }
+}
 // Extends the current plot's axes so that it encompasses a vertical line at x
-IMPLOT_API void FitPointX(double x);
+static inline void FitPointX(double x) {
+    FitPointAxis(GImPlot->CurrentPlot->XAxis, GImPlot->ExtentsX, x);
+}
 // Extends the current plot's axes so that it encompasses a horizontal line at y
-IMPLOT_API void FitPointY(double y);
+static inline void FitPointY(double y) {
+    const ImPlotYAxis y_axis  = GImPlot->CurrentPlot->CurrentYAxis;
+    FitPointAxis(GImPlot->CurrentPlot->YAxis[y_axis], GImPlot->ExtentsY[y_axis], y);
+}
+// Extends the current plot's axes so that it encompasses point p
+static inline void FitPoint(const ImPlotPoint& p) {
+    const ImPlotYAxis y_axis  = GImPlot->CurrentPlot->CurrentYAxis;
+    FitPointMultiAxis(GImPlot->CurrentPlot->XAxis, GImPlot->CurrentPlot->YAxis[y_axis], GImPlot->ExtentsX, p.x, p.y);
+    FitPointMultiAxis(GImPlot->CurrentPlot->YAxis[y_axis], GImPlot->CurrentPlot->XAxis, GImPlot->ExtentsY[y_axis], p.y, p.x);
+}
 
 // Returns true if two ranges overlap
 static inline bool RangesOverlap(const ImPlotRange& r1, const ImPlotRange& r2)

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -918,6 +918,8 @@ inline void PlotLineEx(const char* label_id, const Getter& getter) {
         }
         // render markers
         if (s.Marker != ImPlotMarker_None) {
+            PopPlotClipRect();
+            PushPlotClipRect(s.MarkerSize);
             const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
             const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
             switch (GetCurrentScale()) {
@@ -989,6 +991,8 @@ inline void PlotScatterEx(const char* label_id, const Getter& getter) {
         // render markers
         ImPlotMarker marker = s.Marker == ImPlotMarker_None ? ImPlotMarker_Circle : s.Marker;
         if (marker != ImPlotMarker_None) {
+            PopPlotClipRect();
+            PushPlotClipRect(s.MarkerSize);
             const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
             const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
             switch (GetCurrentScale()) {
@@ -1068,6 +1072,8 @@ inline void PlotStairsEx(const char* label_id, const Getter& getter) {
         }
         // render markers
         if (s.Marker != ImPlotMarker_None) {
+            PopPlotClipRect();
+            PushPlotClipRect(s.MarkerSize);
             const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
             const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
             switch (GetCurrentScale()) {
@@ -1550,6 +1556,8 @@ inline void PlotStemsEx(const char* label_id, const GetterM& get_mark, const Get
         // render markers
         ImPlotMarker marker = s.Marker == ImPlotMarker_None ? ImPlotMarker_Circle : s.Marker;
         if (marker != ImPlotMarker_None) {
+            PopPlotClipRect();
+            PushPlotClipRect(s.MarkerSize);
             const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
             const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
             switch (GetCurrentScale()) {


### PR DESCRIPTION
This PR addresses the needs of #192, #199, and https://github.com/epezent/implot/issues/165#issuecomment-797124733. It adds a new flag `ImPlotAxisFlags_RangeFit` that when enabled will force the axis to only fit data that is within the range of the *orthogonal* axis. When used in conjunction with `ImPlotAxisFlags_AutoFit`, the following behavior can be achieved:

![rangefit](https://user-images.githubusercontent.com/29577475/112765844-fb278d00-8fc3-11eb-9dae-edfaba4403ad.gif)

@yamen, @peterwilson136, @G-Alevizos

Additionally, this PR adds `ImPlotAxisFlags_Foreground` which allows grid lines to be rendered on top of data:

![image](https://user-images.githubusercontent.com/29577475/112765911-3e81fb80-8fc4-11eb-9164-f55192703577.png)
