### PR TITLE
Subplots

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ ImPlot is an immediate mode, GPU accelerated plotting library for [Dear ImGui](h
     - and more likely to come
 - mix/match multiple plot items on a single plot
 - configurable axes ranges and scaling (linear/log)
+- subplots
 - time formatted x-axes (US formatted or ISO 8601)
 - reversible and lockable axes
 - up to three independent y-axes

--- a/README.md
+++ b/README.md
@@ -66,11 +66,15 @@ ImGui::End();
 ![Usage](https://raw.githubusercontent.com/wiki/epezent/implot/screenshots3/example.PNG)
 
 
-Of course, there's much more you can do with ImPlot. Consult `implot_demo.cpp` for a comprehensive example of ImPlot's features.
+Of course, there's much more you can do with ImPlot... 
 
-## Interactive Demo
+## Demos
+
+A comprehensive example of ImPlot's features can be found in `implot_demo.h`. Add this file to your sources and call `ImPlot::ShowDemoWindow()` somewhere in your update loop. You are encouraged to use this file as a reference when needing to implement various plot types. The demo is always updated to show new plot types and features as they are added, so check back with each release!
 
 An online version of the demo is hosted [here](https://traineq.org/implot_demo/src/implot_demo.html). You can view the plots and the source code that generated them. Note that this demo may not always be up to date and is not as performant as a desktop implementation, but it should give you a general taste of what's possible with ImPlot. Special thanks to [pthom](https://github.com/pthom) for creating and hosting this!
+
+More sophisticated demos requiring lengthier code and/or third-party libraries can be found in a separate repository: [implot_demos](https://github.com/epezent/implot_demos). Here, you will find advanced signal processing and ImPlot usage in action. Please read the `Contributing` section of that repository if you have an idea for a new demo!
 
 ## Integration
 

--- a/implot.cpp
+++ b/implot.cpp
@@ -2770,7 +2770,7 @@ ImPlotLimits GetPlotQuery(ImPlotYAxis y_axis) {
 
 void SetPlotQuery(const ImPlotLimits& query, ImPlotYAxis y_axis) {
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(y_axis_in >= -1 && y_axis_in < IMPLOT_Y_AXES, "y_axis needs to between -1 and IMPLOT_Y_AXES");
+    IM_ASSERT_USER_ERROR(y_axis >= -1 && y_axis < IMPLOT_Y_AXES, "y_axis needs to between -1 and IMPLOT_Y_AXES");
     IM_ASSERT_USER_ERROR(gp.CurrentPlot != NULL, "GetPlotQuery() needs to be called between BeginPlot() and EndPlot()!");
     ImPlotPlot& plot = *gp.CurrentPlot;
     y_axis = y_axis >= 0 ? y_axis : gp.CurrentPlot->CurrentYAxis;

--- a/implot.cpp
+++ b/implot.cpp
@@ -1282,6 +1282,17 @@ void UpdateAxisColors(int axis_flag, ImPlotAxis* axis) {
 }
 
 //-----------------------------------------------------------------------------
+// RENDERING
+//-----------------------------------------------------------------------------
+
+static inline void RenderSelectionRect(ImDrawList& DrawList, const ImVec2& p_min, const ImVec2& p_max, const ImVec4& col) {
+    const ImU32 col_bg = ImGui::GetColorU32(col * ImVec4(1,1,1,0.25f));
+    const ImU32 col_bd = ImGui::GetColorU32(col);
+    DrawList.AddRectFilled(p_min, p_max, col_bg);
+    DrawList.AddRect(p_min, p_max, col_bd);    
+}
+
+//-----------------------------------------------------------------------------
 // BeginPlot()
 //-----------------------------------------------------------------------------
 
@@ -2342,13 +2353,9 @@ void EndPlot() {
         DrawList.AddText(pos + gp.Style.AnnotationPadding, an.ColorFg, txt);
     }
     // render selection
-    if (plot.Selected) {
-        const ImVec4 col   = GetStyleColorVec4(ImPlotCol_Selection);
-        const ImU32 col_bg = ImGui::GetColorU32(col * ImVec4(1,1,1,0.25f));
-        const ImU32 col_bd = ImGui::GetColorU32(col);
-        DrawList.AddRectFilled(plot.SelectRect.Min + plot.PlotRect.Min, plot.SelectRect.Max + plot.PlotRect.Min, col_bg);
-        DrawList.AddRect(      plot.SelectRect.Min + plot.PlotRect.Min, plot.SelectRect.Max + plot.PlotRect.Min, col_bd);
-    }
+    if (plot.Selected) 
+        RenderSelectionRect(DrawList, plot.SelectRect.Min + plot.PlotRect.Min, plot.SelectRect.Max + plot.PlotRect.Min, GetStyleColorVec4(ImPlotCol_Selection));
+    
     // render query
     if (plot.Queried) {
         const ImVec4 col   = GetStyleColorVec4(ImPlotCol_Query);

--- a/implot.cpp
+++ b/implot.cpp
@@ -1350,13 +1350,6 @@ static inline void RenderSelectionRect(ImDrawList& DrawList, const ImVec2& p_min
 }
 
 //-----------------------------------------------------------------------------
-// Utils
-//-----------------------------------------------------------------------------
-
-
-
-
-//-----------------------------------------------------------------------------
 // BeginPlot()
 //-----------------------------------------------------------------------------
 
@@ -2017,19 +2010,6 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
     if (title_size.x > 0.0f && !ImHasFlag(plot.Flags, ImPlotFlags_NoTitle)) {
         ImU32 col = GetStyleColorU32(ImPlotCol_TitleText);
         AddTextCentered(&DrawList,ImVec2(plot.PlotRect.GetCenter().x, plot.CanvasRect.Min.y),col,title);
-
-        // const char* title_beg = title;
-        // const char* title_end = ImGui::FindRenderedTextEnd(title);
-        // ImVec2 text_size;
-        // float  y = 0;
-        // while (const char* tmp = (const char*)memchr(title_beg, '\n', title_end-title_beg)) {
-        //     text_size = ImGui::CalcTextSize(title_beg,tmp,true);
-        //     DrawList.AddText(ImVec2(plot.PlotRect.GetCenter().x - text_size.x * 0.5f, plot.CanvasRect.Min.y+y),col,title_beg,tmp);
-        //     title_beg = tmp + 1;
-        //     y += txt_height;
-        // }
-        // text_size = ImGui::CalcTextSize(title_beg,title_end,true);
-        // DrawList.AddText(ImVec2(plot.PlotRect.GetCenter().x - text_size.x * 0.5f, plot.CanvasRect.Min.y+y),col,title_beg,title_end);
     }
 
     // render axis labels
@@ -2654,11 +2634,12 @@ void NextSubplot() {
         gp.CurrentAlignmentH = NULL;
         gp.CurrentAlignmentV = NULL;
     }
+    // if next plot is the last, pop items spacing
     ImGui::PopID();
     ImGui::PushID(subplot.CurrentIdx);
 }
 
-bool BeginSubplots(const char* id, int rows, int cols, const ImVec2& size, ImPlotSubplotFlags flags) {
+bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, ImPlotSubplotFlags flags) {
     IM_ASSERT_USER_ERROR(GImPlot != NULL, "No current context. Did you call ImPlot::CreateContext() or ImPlot::SetCurrentContext()?");
     IM_ASSERT_USER_ERROR(GImPlot->CurrentSubplot == NULL, "Mismatched BeginSubplot()/EndSubplot()!");
     ImPlotContext& gp = *GImPlot;
@@ -2666,12 +2647,19 @@ bool BeginSubplots(const char* id, int rows, int cols, const ImVec2& size, ImPlo
     ImGuiWindow * Window = G.CurrentWindow;
     if (Window->SkipItems)
         return false;
-    const ImGuiID ID = Window->GetID(id);
+    const ImGuiID ID = Window->GetID(title);
     gp.CurrentSubplot = gp.Subplots.GetOrAddByKey(ID);
     ImPlotSubplot& subplot = *gp.CurrentSubplot;
-    
     subplot.ID    = ID;
     subplot.Flags = flags;
+
+    ImVec2 title_size(0.0f, 0.0f);
+    const float txt_height = ImGui::GetTextLineHeight();
+    if (!ImHasFlag(flags, ImPlotSubplotFlags_NoTitle))
+         title_size = ImGui::CalcTextSize(title, NULL, true);    
+    const float pad_top = title_size.x > 0.0f ? title_size.y + gp.Style.LabelPadding.y : 0;
+    
+
     if (subplot.Rows != rows || subplot.Cols != cols) {
         subplot.RowAlignmentData.resize(rows);
         subplot.RowLinkData.resize(rows);

--- a/implot.cpp
+++ b/implot.cpp
@@ -1828,9 +1828,8 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
         ResetCtxForNextPlot(GImPlot);
         return false;
     }
-    plot.FrameHovered = ImGui::ItemHoverable(plot.FrameRect, ID);
-    if (G.HoveredIdPreviousFrame != 0 && G.HoveredIdPreviousFrame != ID)
-        plot.FrameHovered = false;
+    // NB: ImGuiButtonFlags_AllowItemOverlap and SetItemAllowOverlap() required for DragLine and DragPoint
+    ImGui::ButtonBehavior(plot.FrameRect,plot.ID,&plot.FrameHovered,&plot.FrameHeld,ImGuiButtonFlags_AllowItemOverlap);
     ImGui::SetItemAllowOverlap();
 
     // canvas/axes bb
@@ -2843,7 +2842,7 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
             bool active = subplot.ActiveSeparator == separator;
             ypos += subplot.RowRatios[r] * subplot.GridRect.GetHeight();
             if ((subplot.ActiveSeparator == -1 || active) && !pass) {
-                if ((mouse.y > ypos-5 && mouse.y < ypos+5 && subplot.GridRect.Contains(mouse)) || active) {
+                if ((mouse.y > ypos-4 && mouse.y < ypos+4 && subplot.GridRect.Contains(mouse)) || active) {
                     if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
                         float p = (subplot.RowRatios[r] + subplot.RowRatios[r+1])/2;
                         subplot.RowRatios[r]   = p;
@@ -2866,7 +2865,9 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
                             subplot.RowRatios[r+1] = subplot.TempSizes[1] - dp;
                         }
                     }
-                    DrawList.AddLine(ImVec2(subplot.GridRect.Min.x,ypos),ImVec2(subplot.GridRect.Max.x,ypos),active ? act_col : hov_col,2.0f);
+                    DrawList.AddLine(ImVec2(IM_ROUND(subplot.GridRect.Min.x),IM_ROUND(ypos)),
+                                     ImVec2(IM_ROUND(subplot.GridRect.Max.x),IM_ROUND(ypos)),
+                                     active ? act_col : hov_col, 1.0f);
                     ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
                     pass = true;
                 }
@@ -2877,7 +2878,7 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
             bool active = subplot.ActiveSeparator == separator;
             xpos += subplot.ColRatios[c] * subplot.GridRect.GetWidth();
             if ((subplot.ActiveSeparator == -1 || active) && !pass) {
-                if ((mouse.x > xpos-5 && mouse.x < xpos+5 && subplot.GridRect.Contains(mouse)) || active) {
+                if ((mouse.x > xpos-4 && mouse.x < xpos+4 && subplot.GridRect.Contains(mouse)) || active) {
                     if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
                         float p = (subplot.ColRatios[c] + subplot.ColRatios[c+1])/2;
                         subplot.ColRatios[c]   = p;
@@ -2900,7 +2901,10 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
                             subplot.ColRatios[c+1] = subplot.TempSizes[1] - dp;
                         }
                     }
-                    DrawList.AddLine(ImVec2(xpos,subplot.GridRect.Min.y),ImVec2(xpos,subplot.GridRect.Max.y),active ? act_col : hov_col,2.0f);
+                    
+                    DrawList.AddLine(ImVec2(IM_ROUND(xpos),IM_ROUND(subplot.GridRect.Min.y)),
+                                     ImVec2(IM_ROUND(xpos),IM_ROUND(subplot.GridRect.Max.y)),
+                                    active ? act_col : hov_col,1.0f);
                     ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
                     pass = true;
                 }

--- a/implot.cpp
+++ b/implot.cpp
@@ -474,7 +474,7 @@ void ResetCtxForNextPlot(ImPlotContext* ctx) {
     // nullify plot
     ctx->CurrentPlot  = NULL;
     ctx->CurrentItem  = NULL;
-    ctx->PreviousItem = NULL; 
+    ctx->PreviousItem = NULL;
 }
 
 void ResetCtxForNextAlignedPlots(ImPlotContext* ctx) {
@@ -657,7 +657,7 @@ bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool hov
         label_bb.Max = top_left + ImVec2(label_width + icon_size, icon_size);
         ImU32 col_txt_hl;
         ImU32 col_item = ImAlphaU32(item->Color,1);
-        
+
         // ImGui::ItemAdd(icon_bb, item->ID, &icon_bb);
         // ImGui::KeepAliveID(item->ID);
 
@@ -676,12 +676,12 @@ bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool hov
             col_txt_hl = ImGui::GetColorU32(col_txt);
         }
         ImU32 col_icon;
-        if (icon_hld) 
-            col_icon = item->Show ? ImAlphaU32(col_item,0.5f) : ImGui::GetColorU32(ImGuiCol_TextDisabled, 0.5f);  
-        else if (icon_hov) 
-            col_icon = item->Show ? ImAlphaU32(col_item,0.75f) : ImGui::GetColorU32(ImGuiCol_TextDisabled, 0.75f);      
-        else 
-            col_icon = item->Show ? col_item : col_txt_dis;      
+        if (icon_hld)
+            col_icon = item->Show ? ImAlphaU32(col_item,0.5f) : ImGui::GetColorU32(ImGuiCol_TextDisabled, 0.5f);
+        else if (icon_hov)
+            col_icon = item->Show ? ImAlphaU32(col_item,0.75f) : ImGui::GetColorU32(ImGuiCol_TextDisabled, 0.75f);
+        else
+            col_icon = item->Show ? col_item : col_txt_dis;
 
         DrawList.AddRectFilled(icon_bb.Min, icon_bb.Max, col_icon, 1);
         const char* text_display_end = ImGui::FindRenderedTextEnd(label, NULL);
@@ -1893,7 +1893,7 @@ void ShowPlotContextMenu(ImPlotPlot& plot) {
                 ImFlipFlag(GImPlot->CurrentSubplot->Flags, ImPlotSubplotFlags_NoLegend);
         }
         ImGui::EndMenu();
-    }    
+    }
     if ((ImGui::BeginMenu("Settings"))) {
         if (ImGui::MenuItem("Anti-Aliased Lines",NULL,ImHasFlag(plot.Flags, ImPlotFlags_AntiAliased)))
             ImFlipFlag(plot.Flags, ImPlotFlags_AntiAliased);
@@ -2090,10 +2090,10 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
 
     // frame size
     ImVec2 frame_size;
-    if (gp.CurrentSubplot != NULL) 
-        frame_size = gp.CurrentSubplot->CellSize;    
-    else 
-        frame_size = ImGui::CalcItemSize(size, gp.Style.PlotDefaultSize.x, gp.Style.PlotDefaultSize.y);    
+    if (gp.CurrentSubplot != NULL)
+        frame_size = gp.CurrentSubplot->CellSize;
+    else
+        frame_size = ImGui::CalcItemSize(size, gp.Style.PlotDefaultSize.x, gp.Style.PlotDefaultSize.y);
 
     if (frame_size.x < gp.Style.PlotMinSize.x && (size.x < 0.0f || gp.CurrentSubplot != NULL))
         frame_size.x = gp.Style.PlotMinSize.x;
@@ -2166,9 +2166,9 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
                   + (show_x_label ? txt_height + gp.Style.LabelPadding.y : 0);
 
     // (1*) align plots group
-    if (gp.CurrentAlignmentH) 
-        gp.CurrentAlignmentH->Update(pad_top,pad_bot);    
-    
+    if (gp.CurrentAlignmentH)
+        gp.CurrentAlignmentH->Update(pad_top,pad_bot);
+
     const float plot_height = plot.CanvasRect.GetHeight() - pad_top - pad_bot;
 
     // (2) get y tick labels (needed for left/right pad)
@@ -2195,8 +2195,8 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
                             + ((plot.YAxis[2].Present && show_y3_label) ? txt_height + gp.Style.LabelPadding.x : 0);
 
     // (3*) align plots group
-    if (gp.CurrentAlignmentV) 
-        gp.CurrentAlignmentV->Update(pad_left,pad_right);    
+    if (gp.CurrentAlignmentV)
+        gp.CurrentAlignmentV->Update(pad_left,pad_right);
 
     const float plot_width = plot.CanvasRect.GetWidth() - pad_left - pad_right;
 
@@ -2247,7 +2247,7 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
 
     // INPUT ------------------------------------------------------------------
     HandlePlotInput(plot);
-    
+
 
     UpdateTransformCache();
 
@@ -2346,8 +2346,8 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
     // clear legend (TODO: put elsewhere)
     plot.Items.Legend.Reset();
     // setup items (or dont)
-    if (gp.CurrentItems == NULL) 
-        gp.CurrentItems = &plot.Items;    
+    if (gp.CurrentItems == NULL)
+        gp.CurrentItems = &plot.Items;
     // push ID to see item hashes
     ImGui::PushOverrideID(gp.CurrentItems->ID);
     return true;
@@ -2665,7 +2665,7 @@ void EndPlot() {
         plot.ContextLocked = false;
 
     // remove items
-    if (gp.CurrentItems == &plot.Items)   
+    if (gp.CurrentItems == &plot.Items)
         gp.CurrentItems = NULL;
     // reset the plot items for the next frame
     for (int i = 0; i < plot.Items.GetItemCount(); ++i) {
@@ -2682,7 +2682,7 @@ void EndPlot() {
     // setup next subplot
     if (gp.CurrentSubplot != NULL) {
         ImGui::PopID();
-        SubplotNextCell();        
+        SubplotNextCell();
     }
 }
 
@@ -2690,8 +2690,8 @@ void EndPlot() {
 // BEGIN/END SUBPLOT
 //-----------------------------------------------------------------------------
 
-static const float SUBPLOT_BORDER_SIZE             = 1.0f;   
-static const float SUBPLOT_SPLITTER_HALF_THICKNESS = 4.0f;   
+static const float SUBPLOT_BORDER_SIZE             = 1.0f;
+static const float SUBPLOT_SPLITTER_HALF_THICKNESS = 4.0f;
 static const float SUBPLOT_SPLITTER_FEEDBACK_TIMER = 0.06f;
 
 void SubplotSetCell(int row, int col) {
@@ -2728,7 +2728,7 @@ void SubplotSetCell(int row, int col) {
         gp.CurrentAlignmentV = &subplot.ColAlignmentData[col];
     }
     // set idx
-    if (ImHasFlag(subplot.Flags, ImPlotSubplotFlags_ColMajor)) 
+    if (ImHasFlag(subplot.Flags, ImPlotSubplotFlags_ColMajor))
         subplot.CurrentIdx = col * subplot.Rows + row;
     else
         subplot.CurrentIdx = row * subplot.Cols + col;
@@ -2754,7 +2754,7 @@ void SubplotSetCell(int idx) {
 void SubplotNextCell() {
     ImPlotContext& gp      = *GImPlot;
     ImPlotSubplot& subplot = *gp.CurrentSubplot;
-    SubplotSetCell(++subplot.CurrentIdx);    
+    SubplotSetCell(++subplot.CurrentIdx);
 }
 
 bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, ImPlotSubplotFlags flags, float* row_sizes, float* col_sizes) {
@@ -2773,24 +2773,24 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
     subplot.ID       = ID;
     subplot.Items.ID = ID;
     // push ID
-    ImGui::PushID(ID); 
+    ImGui::PushID(ID);
 
-    if (just_created) 
-        subplot.Flags = flags;    
+    if (just_created)
+        subplot.Flags = flags;
     else if (flags != subplot.PreviousFlags)
         subplot.Flags = flags;
-    subplot.PreviousFlags = flags;  
+    subplot.PreviousFlags = flags;
 
     // check for change in rows and cols
     if (subplot.Rows != rows || subplot.Cols != cols) {
         subplot.RowAlignmentData.resize(rows);
         subplot.RowLinkData.resize(rows);
         subplot.RowRatios.resize(rows);
-        for (int r = 0; r < rows; ++r) {            
-            subplot.RowAlignmentData[r].Reset();  
-            subplot.RowLinkData[r] = ImPlotRange(0,1);   
+        for (int r = 0; r < rows; ++r) {
+            subplot.RowAlignmentData[r].Reset();
+            subplot.RowLinkData[r] = ImPlotRange(0,1);
             subplot.RowRatios[r] = 1.0f / rows;
-        }   
+        }
         subplot.ColAlignmentData.resize(cols);
         subplot.ColLinkData.resize(cols);
         subplot.ColRatios.resize(cols);
@@ -2804,12 +2804,12 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
     float row_sum = 0, col_sum = 0;
     if (row_sizes != NULL) {
         row_sum = ImSum(row_sizes, rows);
-        for (int r = 0; r < rows; ++r)           
+        for (int r = 0; r < rows; ++r)
             subplot.RowRatios[r] = row_sizes[r] / row_sum;
     }
     if (col_sizes != NULL) {
         col_sum = ImSum(col_sizes, cols);
-        for (int c = 0; c < cols; ++c)           
+        for (int c = 0; c < cols; ++c)
             subplot.ColRatios[c] = col_sizes[c] / col_sum;
     }
     subplot.Rows = rows;
@@ -2819,7 +2819,7 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
     ImVec2 title_size(0.0f, 0.0f);
     const float txt_height = ImGui::GetTextLineHeight();
     if (!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoTitle))
-         title_size = ImGui::CalcTextSize(title, NULL, true);    
+         title_size = ImGui::CalcTextSize(title, NULL, true);
     const float pad_top = title_size.x > 0.0f ? title_size.y + gp.Style.LabelPadding.y : 0;
     const ImVec2 half_pad = gp.Style.PlotPadding/2;
     const ImVec2 frame_size = ImGui::CalcItemSize(size, gp.Style.PlotDefaultSize.x, gp.Style.PlotDefaultSize.y);
@@ -2839,14 +2839,14 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
         const bool north = ImHasFlag(subplot.Items.Legend.Location, ImPlotLocation_North) && !ImHasFlag(subplot.Items.Legend.Location, ImPlotLocation_South);
         const bool south = ImHasFlag(subplot.Items.Legend.Location, ImPlotLocation_South) && !ImHasFlag(subplot.Items.Legend.Location, ImPlotLocation_North);
         const bool horz = subplot.Items.Legend.Orientation == ImPlotOrientation_Horizontal;
-        if ((west && !horz) || (west && horz && !north && !south)) 
-            subplot.GridRect.Min.x += (legend_size.x + gp.Style.LegendPadding.x);        
-        if ((east && !horz) || (east && horz && !north && !south)) 
-            subplot.GridRect.Max.x -= (legend_size.x + gp.Style.LegendPadding.x);        
-        if ((north && horz) || (north && !horz && !west && !east)) 
-            subplot.GridRect.Min.y += (legend_size.y + gp.Style.LegendPadding.y);        
-        if ((south && horz) || (south && !horz && !west && !east)) 
-            subplot.GridRect.Max.y -= (legend_size.y + gp.Style.LegendPadding.y);        
+        if ((west && !horz) || (west && horz && !north && !south))
+            subplot.GridRect.Min.x += (legend_size.x + gp.Style.LegendPadding.x);
+        if ((east && !horz) || (east && horz && !north && !south))
+            subplot.GridRect.Max.x -= (legend_size.x + gp.Style.LegendPadding.x);
+        if ((north && horz) || (north && !horz && !west && !east))
+            subplot.GridRect.Min.y += (legend_size.y + gp.Style.LegendPadding.y);
+        if ((south && horz) || (south && !horz && !west && !east))
+            subplot.GridRect.Max.y -= (legend_size.y + gp.Style.LegendPadding.y);
     }
 
     // render single background frame
@@ -2895,7 +2895,7 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
                                  ImVec2(IM_ROUND(subplot.GridRect.Max.x),IM_ROUND(ypos)),
                                  sep_hld ? act_col : hov_col, SUBPLOT_BORDER_SIZE);
                 ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
-            } 
+            }
             separator++;
         }
         for (int c = 0; c < subplot.Cols-1; ++c) {
@@ -2925,18 +2925,18 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
                                  ImVec2(IM_ROUND(xpos),IM_ROUND(subplot.GridRect.Max.y)),
                                  sep_hld ? act_col : hov_col, SUBPLOT_BORDER_SIZE);
                 ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-            } 
+            }
             separator++;
         }
-    }  
+    }
 
     // set outgoing sizes
     if (row_sizes != NULL) {
-        for (int r = 0; r < rows; ++r)           
+        for (int r = 0; r < rows; ++r)
             row_sizes[r] = subplot.RowRatios[r] * row_sum;
     }
     if (col_sizes != NULL) {
-        for (int c = 0; c < cols; ++c)           
+        for (int c = 0; c < cols; ++c)
             col_sizes[c] = subplot.ColRatios[c] * col_sum;
     }
 
@@ -2944,7 +2944,7 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
     PushStyleColor(ImPlotCol_FrameBg, IM_COL32_BLACK_TRANS);
     PushStyleVar(ImPlotStyleVar_PlotPadding, half_pad);
     PushStyleVar(ImPlotStyleVar_PlotMinSize, ImVec2(0,0));
-    ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize,0);  
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize,0);
 
     // set initial cursor pos
     Window->DC.CursorPos = subplot.GridRect.Min;
@@ -2971,7 +2971,7 @@ void EndSubplots() {
     for (int c = 0; c < subplot.Cols; ++c)
         subplot.ColAlignmentData[c].End();
     // pop styling
-    PopStyleColor(); 
+    PopStyleColor();
     PopStyleVar();
     PopStyleVar();
     ImGui::PopStyleVar();
@@ -3001,20 +3001,20 @@ void EndSubplots() {
             if (ShowLegendContextMenu(subplot.Items.Legend, !ImHasFlag(subplot.Flags, ImPlotFlags_NoLegend)))
                 ImFlipFlag(subplot.Flags, ImPlotFlags_NoLegend);
             ImGui::EndPopup();
-        }    
+        }
     }
     else {
         subplot.Items.Legend.Rect = ImRect();
     }
     // remove items
-    if (gp.CurrentItems == &subplot.Items)   
+    if (gp.CurrentItems == &subplot.Items)
         gp.CurrentItems = NULL;
     // reset the plot items for the next frame (TODO: put this elswhere)
     for (int i = 0; i < subplot.Items.GetItemCount(); ++i) {
         subplot.Items.GetItemByIndex(i)->SeenThisFrame = false;
     }
     // pop id
-    ImGui::PopID(); 
+    ImGui::PopID();
     // set DC back correctly
     GImGui->CurrentWindow->DC.CursorPos = subplot.FrameRect.Min;
     ImGui::Dummy(subplot.FrameRect.GetSize());
@@ -3042,7 +3042,7 @@ bool BeginAlignedPlots(const char* group_id, ImPlotOrientation orientation) {
         gp.CurrentAlignmentV = alignment;
     if (alignment->Orientation != orientation)
         alignment->Reset();
-    alignment->Orientation = orientation;   
+    alignment->Orientation = orientation;
     alignment->Begin();
     return true;
 }
@@ -3052,7 +3052,7 @@ void EndAlignedPlots() {
     IM_ASSERT_USER_ERROR(GImPlot->CurrentAlignmentH != NULL || GImPlot->CurrentAlignmentV != NULL, "Mismatched BeginAlignedPlots()/EndAlignedPlots()!");
     ImPlotContext& gp = *GImPlot;
     ImPlotAlignmentData* alignment = gp.CurrentAlignmentH != NULL ? gp.CurrentAlignmentH : (gp.CurrentAlignmentV != NULL ? gp.CurrentAlignmentV : NULL);
-    if (alignment) 
+    if (alignment)
         alignment->End();
     ResetCtxForNextAlignedPlots(GImPlot);
 }
@@ -3894,7 +3894,7 @@ ImU32 NextColormapColorU32() {
     int idx = gp.CurrentItems->ColormapIdx % gp.ColormapData.GetKeyCount(gp.Style.Colormap);
     ImU32 col  = gp.ColormapData.GetKeyColor(gp.Style.Colormap, idx);
     gp.CurrentItems->ColormapIdx++;
-    return col;    
+    return col;
 }
 
 ImVec4 NextColormapColor() {
@@ -4480,10 +4480,10 @@ void ShowMetricsWindow(bool* p_popen) {
         if (show_axes_rects) {
             fg.AddRect(plot->XAxis.HoverRect.Min, plot->XAxis.HoverRect.Max, IM_COL32(0,255,0,255));
             fg.AddRect(plot->YAxis[0].HoverRect.Min, plot->YAxis[0].HoverRect.Max, IM_COL32(0,255,0,255));
-            if (ImHasFlag(plot->Flags, ImPlotFlags_YAxis2)) 
-                fg.AddRect(plot->YAxis[1].HoverRect.Min, plot->YAxis[1].HoverRect.Max, IM_COL32(0,255,0,255));                
-            if (ImHasFlag(plot->Flags, ImPlotFlags_YAxis3)) 
-                fg.AddRect(plot->YAxis[3].HoverRect.Min, plot->YAxis[2].HoverRect.Max, IM_COL32(0,255,0,255));                
+            if (ImHasFlag(plot->Flags, ImPlotFlags_YAxis2))
+                fg.AddRect(plot->YAxis[1].HoverRect.Min, plot->YAxis[1].HoverRect.Max, IM_COL32(0,255,0,255));
+            if (ImHasFlag(plot->Flags, ImPlotFlags_YAxis3))
+                fg.AddRect(plot->YAxis[3].HoverRect.Min, plot->YAxis[2].HoverRect.Max, IM_COL32(0,255,0,255));
         }
     }
     for (int p = 0; p < n_subplots; ++p) {
@@ -4546,7 +4546,7 @@ void ShowMetricsWindow(bool* p_popen) {
                 ImGui::Bullet(); ImGui::Text("PlotHovered: %s", plot->PlotHovered ? "true" : "false");
                 ImGui::Bullet(); ImGui::Text("LegendHovered: %s", plot->Items.Legend.Hovered ? "true" : "false");
                 ImGui::TreePop();
-            }            
+            }
             ImGui::PopID();
         }
         ImGui::TreePop();
@@ -4583,7 +4583,7 @@ void ShowMetricsWindow(bool* p_popen) {
                 ImGui::Bullet(); ImGui::Text("FrameHovered: %s", plot->FrameHovered ? "true" : "false");
                 ImGui::Bullet(); ImGui::Text("LegendHovered: %s", plot->Items.Legend.Hovered ? "true" : "false");
                 ImGui::TreePop();
-            }            
+            }
             ImGui::PopID();
         }
         ImGui::TreePop();

--- a/implot.cpp
+++ b/implot.cpp
@@ -335,6 +335,21 @@ void AddTextVertical(ImDrawList *DrawList, ImVec2 pos, ImU32 col, const char *te
     DrawList->PrimUnreserve(chars_skp*6, chars_skp*4);
 }
 
+void AddTextCentered(ImDrawList* DrawList, ImVec2 top_center, ImU32 col, const char* text_begin, const char* text_end) {
+    float txt_ht = ImGui::GetTextLineHeight();
+    const char* title_end = ImGui::FindRenderedTextEnd(text_begin, text_end);
+    ImVec2 text_size;
+    float  y = 0;
+    while (const char* tmp = (const char*)memchr(text_begin, '\n', title_end-text_begin)) {
+        text_size = ImGui::CalcTextSize(text_begin,tmp,true);
+        DrawList->AddText(ImVec2(top_center.x - text_size.x * 0.5f, top_center.y+y),col,text_begin,tmp);
+        text_begin = tmp + 1;
+        y += txt_ht;
+    }
+    text_size = ImGui::CalcTextSize(text_begin,title_end,true);
+    DrawList->AddText(ImVec2(top_center.x - text_size.x * 0.5f, top_center.y+y),col,text_begin,title_end);
+}
+
 double NiceNum(double x, bool round) {
     double f;  /* fractional part of x */
     double nf; /* nice, rounded fraction */
@@ -1559,7 +1574,7 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
 
     const bool show_x_label = x_label && !ImHasFlag(plot.XAxis.Flags, ImPlotAxisFlags_NoLabel);
 
-    float pad_top = title_size.x > 0.0f ? txt_height + gp.Style.LabelPadding.y : 0;
+    float pad_top = title_size.x > 0.0f ? title_size.y + gp.Style.LabelPadding.y : 0;
     float pad_bot = (plot.XAxis.IsLabeled() ? txt_height + gp.Style.LabelPadding.y + (plot.XAxis.IsTime() ? txt_height + gp.Style.LabelPadding.y : 0) : 0)
                         + (show_x_label ? txt_height + gp.Style.LabelPadding.y : 0);
 
@@ -1978,8 +1993,20 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
     // render title
     if (title_size.x > 0.0f && !ImHasFlag(plot.Flags, ImPlotFlags_NoTitle)) {
         ImU32 col = GetStyleColorU32(ImPlotCol_TitleText);
-        const char* title_end = ImGui::FindRenderedTextEnd(title);
-        DrawList.AddText(ImVec2(plot.PlotRect.GetCenter().x - title_size.x * 0.5f, plot.CanvasRect.Min.y),col,title,title_end);
+        AddTextCentered(&DrawList,ImVec2(plot.PlotRect.GetCenter().x, plot.CanvasRect.Min.y),col,title);
+
+        // const char* title_beg = title;
+        // const char* title_end = ImGui::FindRenderedTextEnd(title);
+        // ImVec2 text_size;
+        // float  y = 0;
+        // while (const char* tmp = (const char*)memchr(title_beg, '\n', title_end-title_beg)) {
+        //     text_size = ImGui::CalcTextSize(title_beg,tmp,true);
+        //     DrawList.AddText(ImVec2(plot.PlotRect.GetCenter().x - text_size.x * 0.5f, plot.CanvasRect.Min.y+y),col,title_beg,tmp);
+        //     title_beg = tmp + 1;
+        //     y += txt_height;
+        // }
+        // text_size = ImGui::CalcTextSize(title_beg,title_end,true);
+        // DrawList.AddText(ImVec2(plot.PlotRect.GetCenter().x - text_size.x * 0.5f, plot.CanvasRect.Min.y+y),col,title_beg,title_end);
     }
 
     // render axis labels

--- a/implot.cpp
+++ b/implot.cpp
@@ -474,10 +474,7 @@ void ResetCtxForNextPlot(ImPlotContext* ctx) {
     // nullify plot
     ctx->CurrentPlot  = NULL;
     ctx->CurrentItem  = NULL;
-    ctx->PreviousItem = NULL;
-    // subplot
-    if (ctx->CurrentSubplot != NULL)  
-        NextSubplot();
+    ctx->PreviousItem = NULL; 
 }
 
 void ResetCtxForNextAlignedPlots(ImPlotContext* ctx) {
@@ -2055,7 +2052,7 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
             ImPlotTick *xt = &gp.XTicks.Ticks[t];
             if (xt->ShowLabel && xt->PixelPos >= plot.PlotRect.Min.x - 1 && xt->PixelPos <= plot.PlotRect.Max.x + 1)
                 DrawList.AddText(ImVec2(xt->PixelPos - xt->LabelSize.x * 0.5f, plot.PlotRect.Max.y + gp.Style.LabelPadding.y + xt->Level * (txt_height + gp.Style.LabelPadding.y)),
-                xt->Major ? plot.XAxis.ColorTxt : plot.XAxis.ColorTxt, gp.XTicks.GetText(t));
+                                 plot.XAxis.ColorTxt, gp.XTicks.GetText(t));
         }
     }
     for (int i = 0; i < IMPLOT_Y_AXES; i++) {
@@ -2065,7 +2062,7 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
                 ImPlotTick *yt = &gp.YTicks[i].Ticks[t];
                 if (yt->ShowLabel && yt->PixelPos >= plot.PlotRect.Min.y - 1 && yt->PixelPos <= plot.PlotRect.Max.y + 1) {
                     ImVec2 start(x_start, yt->PixelPos - 0.5f * yt->LabelSize.y);
-                    DrawList.AddText(start, yt->Major ? plot.YAxis[i].ColorTxt : plot.YAxis[i].ColorTxt, gp.YTicks[i].GetText(t));
+                    DrawList.AddText(start, plot.YAxis[i].ColorTxt, gp.YTicks[i].GetText(t));
                 }
             }
         }
@@ -2677,6 +2674,10 @@ void EndPlot() {
     ImGui::PopID();
     // Reset context for next plot
     ResetCtxForNextPlot(GImPlot);
+
+    // setup next subplot
+    if (gp.CurrentSubplot != NULL)  
+        NextSubplot();
 }
 
 //-----------------------------------------------------------------------------

--- a/implot.cpp
+++ b/implot.cpp
@@ -2757,7 +2757,7 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
     }
 
     // render separators
-    if (subplot.FrameHovered) {
+    if (!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoSplitters) && subplot.FrameHovered) {
         ImDrawList& DrawList = *ImGui::GetWindowDrawList();
         const ImU32 nrm_col = ImGui::ColorConvertFloat4ToU32(GImGui->Style.Colors[ImGuiCol_Separator]);
         const ImU32 hov_col = ImGui::ColorConvertFloat4ToU32(GImGui->Style.Colors[ImGuiCol_SeparatorHovered]);
@@ -2853,6 +2853,7 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
     // push styling
     PushStyleColor(ImPlotCol_FrameBg, IM_COL32_BLACK_TRANS);
     PushStyleVar(ImPlotStyleVar_PlotPadding, half_pad);
+    PushStyleVar(ImPlotStyleVar_PlotMinSize, ImVec2(0,0));
     ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize,0);  
     // push ID
     ImGui::PushID(ID); 
@@ -2885,6 +2886,7 @@ void EndSubplots() {
         subplot.ColAlignmentData[c].End();
     // pop styling
     PopStyleColor(); 
+    PopStyleVar();
     PopStyleVar();
     ImGui::PopStyleVar();
     // legend

--- a/implot.cpp
+++ b/implot.cpp
@@ -31,43 +31,43 @@ Below is a change-log of API breaking changes only. If you are using one of the 
 When you are not sure about a old symbol or function name, try using the Search/Find function of your IDE to look for comments or references in all implot files.
 You can read releases logs https://github.com/epezent/implot/releases for more details.
 
-- 2021/03/08 (0.9) - SetColormap and PushColormap(ImVec4*) were removed. Use AddColormap for custom colormap support. LerpColormap was changed to SampleColormap.
-                     ShowColormapScale was changed to ColormapScale and requires additional arguments.
-- 2021/03/07 (0.9) - The signature of ShowColormapScale was modified to accept a ImVec2 size.
-- 2021/02/28 (0.9) - BeginLegendDragDropSource was changed to BeginDragDropSourceItem with a number of other drag and drop improvements.
-- 2021/01/18 (0.9) - The default behavior for opening context menus was change from double right-click to single right-click. ImPlotInputMap and related functions were moved
-                     to implot_internal.h due to its immaturity.
-- 2020/10/16 (0.8) - ImPlotStyleVar_InfoPadding was changed to ImPlotStyleVar_MousePosPadding
-- 2020/09/10 (0.8) - The single array versions of PlotLine, PlotScatter, PlotStems, and PlotShaded were given additional arguments for x-scale and x0.
-- 2020/09/07 (0.8) - Plotting functions which accept a custom getter function pointer have been post-fixed with a G (e.g. PlotLineG)
-- 2020/09/06 (0.7) - Several flags under ImPlotFlags and ImPlotAxisFlags were inverted (e.g. ImPlotFlags_Legend -> ImPlotFlags_NoLegend) so that the default flagset
-                     is simply 0. This more closely matches ImGui's style and makes it easier to enable non-default but commonly used flags (e.g. ImPlotAxisFlags_Time).
-- 2020/08/28 (0.5) - ImPlotMarker_ can no longer be combined with bitwise OR, |. This features caused unecessary slow-down, and almost no one used it.
-- 2020/08/25 (0.5) - ImPlotAxisFlags_Scientific was removed. Logarithmic axes automatically uses scientific notation.
-- 2020/08/17 (0.5) - PlotText was changed so that text is centered horizontally and vertically about the desired point.
-- 2020/08/16 (0.5) - An ImPlotContext must be explicitly created and destroyed now with `CreateContext` and `DestroyContext`. Previously, the context was statically initialized in this source file.
-- 2020/06/13 (0.4) - The flags `ImPlotAxisFlag_Adaptive` and `ImPlotFlags_Cull` were removed. Both are now done internally by default.
-- 2020/06/03 (0.3) - The signature and behavior of PlotPieChart was changed so that data with sum less than 1 can optionally be normalized. The label format can now be specified as well.
-- 2020/06/01 (0.3) - SetPalette was changed to `SetColormap` for consistency with other plotting libraries. `RestorePalette` was removed. Use `SetColormap(ImPlotColormap_Default)`.
-- 2020/05/31 (0.3) - Plot functions taking custom ImVec2* getters were removed. Use the ImPlotPoint* getter versions instead.
-- 2020/05/29 (0.3) - The signature of ImPlotLimits::Contains was changed to take two doubles instead of ImVec2
-- 2020/05/16 (0.2) - All plotting functions were reverted to being prefixed with "Plot" to maintain a consistent VerbNoun style. `Plot` was split into `PlotLine`
-                     and `PlotScatter` (however, `PlotLine` can still be used to plot scatter points as `Plot` did before.). `Bar` is not `PlotBars`, to indicate
-                     that multiple bars will be plotted.
-- 2020/05/13 (0.2) - `ImMarker` was change to `ImPlotMarker` and `ImAxisFlags` was changed to `ImPlotAxisFlags`.
-- 2020/05/11 (0.2) - `ImPlotFlags_Selection` was changed to `ImPlotFlags_BoxSelect`
-- 2020/05/11 (0.2) - The namespace ImGui:: was replaced with ImPlot::. As a result, the following additional changes were made:
-                     - Functions that were prefixed or decorated with the word "Plot" have been truncated. E.g., `ImGui::PlotBars` is now just `ImPlot::Bar`.
-                       It should be fairly obvious what was what.
-                     - Some functions have been given names that would have otherwise collided with the ImGui namespace. This has been done to maintain a consistent
-                       style with ImGui. E.g., 'ImGui::PushPlotStyleVar` is now 'ImPlot::PushStyleVar'.
-- 2020/05/10 (0.2) - The following function/struct names were changes:
-                    - ImPlotRange       -> ImPlotLimits
-                    - GetPlotRange()    -> GetPlotLimits()
-                    - SetNextPlotRange  -> SetNextPlotLimits
-                    - SetNextPlotRangeX -> SetNextPlotLimitsX
-                    - SetNextPlotRangeY -> SetNextPlotLimitsY
-- 2020/05/10 (0.2) - Plot queries are pixel based by default. Query rects that maintain relative plot position have been removed. This was done to support multi-y-axis.
+- 2021/03/08 (0.9)  - SetColormap and PushColormap(ImVec4*) were removed. Use AddColormap for custom colormap support. LerpColormap was changed to SampleColormap.
+                      ShowColormapScale was changed to ColormapScale and requires additional arguments.
+- 2021/03/07 (0.9)  - The signature of ShowColormapScale was modified to accept a ImVec2 size.
+- 2021/02/28 (0.9)  - BeginLegendDragDropSource was changed to BeginDragDropSourceItem with a number of other drag and drop improvements.
+- 2021/01/18 (0.9)  - The default behavior for opening context menus was change from double right-click to single right-click. ImPlotInputMap and related functions were moved
+                      to implot_internal.h due to its immaturity.
+- 2020/10/16 (0.8)  - ImPlotStyleVar_InfoPadding was changed to ImPlotStyleVar_MousePosPadding
+- 2020/09/10 (0.8)  - The single array versions of PlotLine, PlotScatter, PlotStems, and PlotShaded were given additional arguments for x-scale and x0.
+- 2020/09/07 (0.8)  - Plotting functions which accept a custom getter function pointer have been post-fixed with a G (e.g. PlotLineG)
+- 2020/09/06 (0.7)  - Several flags under ImPlotFlags and ImPlotAxisFlags were inverted (e.g. ImPlotFlags_Legend -> ImPlotFlags_NoLegend) so that the default flagset
+                      is simply 0. This more closely matches ImGui's style and makes it easier to enable non-default but commonly used flags (e.g. ImPlotAxisFlags_Time).
+- 2020/08/28 (0.5)  - ImPlotMarker_ can no longer be combined with bitwise OR, |. This features caused unecessary slow-down, and almost no one used it.
+- 2020/08/25 (0.5)  - ImPlotAxisFlags_Scientific was removed. Logarithmic axes automatically uses scientific notation.
+- 2020/08/17 (0.5)  - PlotText was changed so that text is centered horizontally and vertically about the desired point.
+- 2020/08/16 (0.5)  - An ImPlotContext must be explicitly created and destroyed now with `CreateContext` and `DestroyContext`. Previously, the context was statically initialized in this source file.
+- 2020/06/13 (0.4)  - The flags `ImPlotAxisFlag_Adaptive` and `ImPlotFlags_Cull` were removed. Both are now done internally by default.
+- 2020/06/03 (0.3)  - The signature and behavior of PlotPieChart was changed so that data with sum less than 1 can optionally be normalized. The label format can now be specified as well.
+- 2020/06/01 (0.3)  - SetPalette was changed to `SetColormap` for consistency with other plotting libraries. `RestorePalette` was removed. Use `SetColormap(ImPlotColormap_Default)`.
+- 2020/05/31 (0.3)  - Plot functions taking custom ImVec2* getters were removed. Use the ImPlotPoint* getter versions instead.
+- 2020/05/29 (0.3)  - The signature of ImPlotLimits::Contains was changed to take two doubles instead of ImVec2
+- 2020/05/16 (0.2)  - All plotting functions were reverted to being prefixed with "Plot" to maintain a consistent VerbNoun style. `Plot` was split into `PlotLine`
+                      and `PlotScatter` (however, `PlotLine` can still be used to plot scatter points as `Plot` did before.). `Bar` is not `PlotBars`, to indicate
+                      that multiple bars will be plotted.
+- 2020/05/13 (0.2)  - `ImMarker` was change to `ImPlotMarker` and `ImAxisFlags` was changed to `ImPlotAxisFlags`.
+- 2020/05/11 (0.2)  - `ImPlotFlags_Selection` was changed to `ImPlotFlags_BoxSelect`
+- 2020/05/11 (0.2)  - The namespace ImGui:: was replaced with ImPlot::. As a result, the following additional changes were made:
+                      - Functions that were prefixed or decorated with the word "Plot" have been truncated. E.g., `ImGui::PlotBars` is now just `ImPlot::Bar`.
+                        It should be fairly obvious what was what.
+                      - Some functions have been given names that would have otherwise collided with the ImGui namespace. This has been done to maintain a consistent
+                        style with ImGui. E.g., 'ImGui::PushPlotStyleVar` is now 'ImPlot::PushStyleVar'.
+- 2020/05/10 (0.2)  - The following function/struct names were changes:
+                     - ImPlotRange       -> ImPlotLimits
+                     - GetPlotRange()    -> GetPlotLimits()
+                     - SetNextPlotRange  -> SetNextPlotLimits
+                     - SetNextPlotRangeX -> SetNextPlotLimitsX
+                     - SetNextPlotRangeY -> SetNextPlotLimitsY
+- 2020/05/10 (0.2)  - Plot queries are pixel based by default. Query rects that maintain relative plot position have been removed. This was done to support multi-y-axis.
 
 */
 
@@ -489,7 +489,6 @@ void ResetCtxForNextSubplot(ImPlotContext* ctx) {
     ctx->CurrentSubplot      = NULL;
     ctx->CurrentAlignmentH   = NULL;
     ctx->CurrentAlignmentV   = NULL;
-    ctx->DisableUserInput    = false;
 }
 
 //-----------------------------------------------------------------------------
@@ -659,31 +658,35 @@ bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool hov
         ImRect label_bb;
         label_bb.Min = top_left;
         label_bb.Max = top_left + ImVec2(label_width + icon_size, icon_size);
-        ImU32 col_hl_txt;
+        ImU32 col_txt_hl;
         ImU32 col_item = ImAlphaU32(item->Color,1);
-        if (hovered && (icon_bb.Contains(IO.MousePos) || label_bb.Contains(IO.MousePos))) {
+        
+        bool icon_hov = false;
+        bool icon_hld = false;
+        bool icon_clk = ImGui::ButtonBehavior(icon_bb, item->ID, &icon_hov, &icon_hld);
+        if (icon_clk)
+            item->Show = !item->Show;
+
+        if (icon_hov || label_bb.Contains(IO.MousePos)) {
             item->LegendHovered = true;
-            col_hl_txt = ImMixU32(col_txt, col_item, 64);
+            col_txt_hl = ImMixU32(col_txt, col_item, 64);
             any_item_hovered = true;
         }
         else {
-            // item->LegendHovered = false;
-            col_hl_txt = ImGui::GetColorU32(col_txt);
+            col_txt_hl = ImGui::GetColorU32(col_txt);
         }
-        ImU32 iconColor;
-        if (hovered && icon_bb.Contains(IO.MousePos)) {
-            ImU32 col_alpha = ImAlphaU32(col_item,0.5f);
-            iconColor     = item->Show ? col_alpha : ImGui::GetColorU32(ImGuiCol_TextDisabled, 0.5f);
-            if (IO.MouseClicked[0])
-                item->Show = !item->Show;
-        }
-        else {
-            iconColor = item->Show ? col_item : col_txt_dis;
-        }
-        DrawList.AddRectFilled(icon_bb.Min, icon_bb.Max, iconColor, 1);
+        ImU32 col_icon;
+        if (icon_hld) 
+            col_icon = item->Show ? ImAlphaU32(col_item,0.5f) : ImGui::GetColorU32(ImGuiCol_TextDisabled, 0.5f);  
+        else if (icon_hov) 
+            col_icon = item->Show ? ImAlphaU32(col_item,0.75f) : ImGui::GetColorU32(ImGuiCol_TextDisabled, 0.75f);      
+        else 
+            col_icon = item->Show ? col_item : col_txt_dis;      
+
+        DrawList.AddRectFilled(icon_bb.Min, icon_bb.Max, col_icon, 1);
         const char* text_display_end = ImGui::FindRenderedTextEnd(label, NULL);
         if (label != text_display_end)
-            DrawList.AddText(top_left + ImVec2(icon_size, 0), item->Show ? col_hl_txt  : col_txt_dis, label, text_display_end);
+            DrawList.AddText(top_left + ImVec2(icon_size, 0), item->Show ? col_txt_hl  : col_txt_dis, label, text_display_end);
     }
     return hovered && !any_item_hovered;
 }
@@ -1968,9 +1971,8 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
         plot.YAxis[i].Pixels = plot.PlotRect.GetHeight();
 
     // INPUT ------------------------------------------------------------------
-    if (!gp.DisableUserInput) {
-        HandlePlotInput(plot);
-    }
+    HandlePlotInput(plot);
+    
 
     UpdateTransformCache();
 
@@ -1991,14 +1993,14 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
     if (gp.RenderX) {
         for (int t = 0; t < gp.XTicks.Size; t++) {
             ImPlotTick *xt = &gp.XTicks.Ticks[t];
-            xt->PixelPos = PlotToPixels(xt->PlotPos, 0, 0).x;
+            xt->PixelPos = IM_ROUND(PlotToPixels(xt->PlotPos, 0, 0).x);
         }
     }
     for (int i = 0; i < IMPLOT_Y_AXES; i++) {
         if (gp.RenderY[i]) {
             for (int t = 0; t < gp.YTicks[i].Size; t++) {
                 ImPlotTick *yt = &gp.YTicks[i].Ticks[t];
-                yt->PixelPos = PlotToPixels(0, yt->PlotPos, i).y;
+                yt->PixelPos = IM_ROUND(PlotToPixels(0, yt->PlotPos, i).y);
             }
         }
     }
@@ -2250,13 +2252,6 @@ bool ShowLegendContextMenu(ImPlotLegendData& legend, bool visible) {
 }
 
 void ShowSubplotsContextMenu(ImPlotSubplot& subplot) {
-    if (ImHasFlag(subplot.Flags, ImPlotSubplotFlags_ShareItems)) {
-        if ((ImGui::BeginMenu("Legend"))) {
-            if (ShowLegendContextMenu(subplot.Items.Legend, !ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoLegend)))
-                ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_NoLegend);
-            ImGui::EndMenu();
-        }
-    }
     if ((ImGui::BeginMenu("Linking"))) {
         if (ImGui::MenuItem("Link Rows",NULL,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkRows)))
             ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_LinkRows);
@@ -2267,6 +2262,13 @@ void ShowSubplotsContextMenu(ImPlotSubplot& subplot) {
         if (ImGui::MenuItem("Link All Y",NULL,ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllY)))
             ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllY);
         ImGui::EndMenu();
+    }
+    if (ImHasFlag(subplot.Flags, ImPlotSubplotFlags_ShareItems)) {
+        if ((ImGui::BeginMenu("Legend"))) {
+            if (ShowLegendContextMenu(subplot.Items.Legend, !ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoLegend)))
+                ImFlipFlag(subplot.Flags, ImPlotSubplotFlags_NoLegend);
+            ImGui::EndMenu();
+        }
     }
     if ((ImGui::BeginMenu("Settings"))) {
         if (ImGui::MenuItem("Title",NULL,!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoTitle)))
@@ -2675,6 +2677,10 @@ void EndPlot() {
 // BEGIN/END SUBPLOT
 //-----------------------------------------------------------------------------
 
+static const float SUBPLOT_BORDER_SIZE             = 1.0f;   
+static const float SUBPLOT_SPLITTER_HALF_THICKNESS = 4.0f;   
+static const float SUBPLOT_SPLITTER_FEEDBACK_TIMER = 0.06f;
+
 void NextSubplot() {
     ImPlotContext& gp      = *GImPlot;
     ImPlotSubplot& subplot = *gp.CurrentSubplot;
@@ -2690,10 +2696,13 @@ void NextSubplot() {
         for (int r = 0; r < row; ++r)
             yoff += subplot.RowRatios[r];
         const ImVec2 grid_size = subplot.GridRect.GetSize();
-        ImGui::GetCurrentWindow()->DC.CursorPos = subplot.GridRect.Min + ImVec2(xoff*grid_size.x,yoff*grid_size.y); 
+        ImVec2 cpos      = subplot.GridRect.Min + ImVec2(xoff*grid_size.x,yoff*grid_size.y);
+        cpos.x = IM_ROUND(cpos.x);
+        cpos.y = IM_ROUND(cpos.y);
+        ImGui::GetCurrentWindow()->DC.CursorPos =  cpos;
         // set cell size
-        subplot.CellSize.x = subplot.GridRect.GetWidth()  * subplot.ColRatios[col];
-        subplot.CellSize.y = subplot.GridRect.GetHeight() * subplot.RowRatios[row];
+        subplot.CellSize.x = IM_ROUND(subplot.GridRect.GetWidth()  * subplot.ColRatios[col]);
+        subplot.CellSize.y = IM_ROUND(subplot.GridRect.GetHeight() * subplot.RowRatios[row]);
         // setup links
         const bool lx = ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllX);
         const bool ly = ImHasFlag(subplot.Flags, ImPlotSubplotFlags_LinkAllY);
@@ -2781,7 +2790,7 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
     // calc plot frame sizes
     ImVec2 title_size(0.0f, 0.0f);
     const float txt_height = ImGui::GetTextLineHeight();
-    if (!ImHasFlag(flags, ImPlotSubplotFlags_NoTitle))
+    if (!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoTitle))
          title_size = ImGui::CalcTextSize(title, NULL, true);    
     const float pad_top = title_size.x > 0.0f ? title_size.y + gp.Style.LabelPadding.y : 0;
     const ImVec2 half_pad = gp.Style.PlotPadding/2;
@@ -2820,15 +2829,8 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
         AddTextCentered(ImGui::GetWindowDrawList(),ImVec2(subplot.GridRect.GetCenter().x, subplot.GridRect.Min.y - pad_top + half_pad.y),col,title);
     }
 
-    // is it ok to show splitter? yes, this is ridiculous ;)
-    const bool ok_to_split  = !ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoSplitters) && 
-                              (subplot.FrameHovered || subplot.ActiveSeparator != -1)   &&
-                              !ImGui::IsPopupOpen(1, ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel) &&
-                              (subplot.ActiveSeparator != -1 || (!ImGui::IsMouseDragging(ImGuiMouseButton_Left) && 
-                                                                 !ImGui::IsMouseDragging(ImGuiMouseButton_Right) &&
-                                                                 !ImGui::IsMouseDragging(ImGuiMouseButton_Middle)));
     // render splitters
-    if (ok_to_split) {
+    if (!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoSplitters)) {
         ImDrawList& DrawList = *ImGui::GetWindowDrawList();
         const ImU32 nrm_col = ImGui::ColorConvertFloat4ToU32(GImGui->Style.Colors[ImGuiCol_Separator]);
         const ImU32 hov_col = ImGui::ColorConvertFloat4ToU32(GImGui->Style.Colors[ImGuiCol_SeparatorHovered]);
@@ -2836,86 +2838,69 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
         float xpos = subplot.GridRect.Min.x;
         float ypos = subplot.GridRect.Min.y;
         const ImVec2 mouse = ImGui::GetIO().MousePos;
-        int separator = 0;
-        bool pass = false;
+        int separator = 1;
+        // bool pass = false;
         for (int r = 0; r < subplot.Rows-1; ++r) {
-            bool active = subplot.ActiveSeparator == separator;
             ypos += subplot.RowRatios[r] * subplot.GridRect.GetHeight();
-            if ((subplot.ActiveSeparator == -1 || active) && !pass) {
-                if ((mouse.y > ypos-4 && mouse.y < ypos+4 && subplot.GridRect.Contains(mouse)) || active) {
-                    if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
-                        float p = (subplot.RowRatios[r] + subplot.RowRatios[r+1])/2;
-                        subplot.RowRatios[r]   = p;
-                        subplot.RowRatios[r+1] = p;                        
-                    }
-                    if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-                        subplot.ActiveSeparator = separator;
-                        active = true;
-                        subplot.TempSizes[0] = subplot.RowRatios[r];
-                        subplot.TempSizes[1] = subplot.RowRatios[r+1];
-                    }
-                    else if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
-                        subplot.ActiveSeparator = -1;
-                        active = false;
-                    }
-                    if (active) {
-                        float dp = ImGui::GetMouseDragDelta(0).y  / subplot.GridRect.GetHeight();
-                        if (subplot.TempSizes[0] + dp > 0.1f && subplot.TempSizes[1] - dp > 0.1f) {
-                            subplot.RowRatios[r]   = subplot.TempSizes[0] + dp;
-                            subplot.RowRatios[r+1] = subplot.TempSizes[1] - dp;
-                        }
-                    }
-                    DrawList.AddLine(ImVec2(IM_ROUND(subplot.GridRect.Min.x),IM_ROUND(ypos)),
-                                     ImVec2(IM_ROUND(subplot.GridRect.Max.x),IM_ROUND(ypos)),
-                                     active ? act_col : hov_col, 1.0f);
-                    ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
-                    pass = true;
+            const ImGuiID sep_id = subplot.ID + separator;
+            ImGui::KeepAliveID(sep_id);
+            const ImRect sep_bb = ImRect(subplot.GridRect.Min.x, ypos-SUBPLOT_SPLITTER_HALF_THICKNESS, subplot.GridRect.Max.x, ypos+SUBPLOT_SPLITTER_HALF_THICKNESS);
+            bool sep_hov = false, sep_hld = false;
+            const bool sep_clk = ImGui::ButtonBehavior(sep_bb, sep_id, &sep_hov, &sep_hld, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
+            if ((sep_hov && G.HoveredIdTimer > SUBPLOT_SPLITTER_FEEDBACK_TIMER) || sep_hld) {
+                if (sep_clk && ImGui::IsMouseDoubleClicked(0)) {
+                    float p = (subplot.RowRatios[r] + subplot.RowRatios[r+1])/2;
+                    subplot.RowRatios[r] = subplot.RowRatios[r+1] = p;
                 }
-            }
+                if (sep_clk) {
+                    subplot.TempSizes[0] = subplot.RowRatios[r];
+                    subplot.TempSizes[1] = subplot.RowRatios[r+1];
+                }
+                if (sep_hld) {
+                    float dp = ImGui::GetMouseDragDelta(0).y  / subplot.GridRect.GetHeight();
+                    if (subplot.TempSizes[0] + dp > 0.1f && subplot.TempSizes[1] - dp > 0.1f) {
+                        subplot.RowRatios[r]   = subplot.TempSizes[0] + dp;
+                        subplot.RowRatios[r+1] = subplot.TempSizes[1] - dp;
+                    }
+                }
+                DrawList.AddLine(ImVec2(IM_ROUND(subplot.GridRect.Min.x),IM_ROUND(ypos)),
+                                 ImVec2(IM_ROUND(subplot.GridRect.Max.x),IM_ROUND(ypos)),
+                                 sep_hld ? act_col : hov_col, SUBPLOT_BORDER_SIZE);
+                ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
+            } 
             separator++;
         }
         for (int c = 0; c < subplot.Cols-1; ++c) {
-            bool active = subplot.ActiveSeparator == separator;
             xpos += subplot.ColRatios[c] * subplot.GridRect.GetWidth();
-            if ((subplot.ActiveSeparator == -1 || active) && !pass) {
-                if ((mouse.x > xpos-4 && mouse.x < xpos+4 && subplot.GridRect.Contains(mouse)) || active) {
-                    if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
-                        float p = (subplot.ColRatios[c] + subplot.ColRatios[c+1])/2;
-                        subplot.ColRatios[c]   = p;
-                        subplot.ColRatios[c+1] = p;                        
-                    }
-                    if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-                        subplot.ActiveSeparator = separator;
-                        active = true;
-                        subplot.TempSizes[0] = subplot.ColRatios[c];
-                        subplot.TempSizes[1] = subplot.ColRatios[c+1];
-                    }
-                    else if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
-                        subplot.ActiveSeparator = -1;
-                        active = false;
-                    }
-                    if (active) {
-                        float dp = ImGui::GetMouseDragDelta(0).x / subplot.GridRect.GetWidth();
-                        if (subplot.TempSizes[0] + dp > 0.1f && subplot.TempSizes[1] - dp > 0.1f) {
-                            subplot.ColRatios[c]   = subplot.TempSizes[0] + dp;
-                            subplot.ColRatios[c+1] = subplot.TempSizes[1] - dp;
-                        }
-                    }
-                    
-                    DrawList.AddLine(ImVec2(IM_ROUND(xpos),IM_ROUND(subplot.GridRect.Min.y)),
-                                     ImVec2(IM_ROUND(xpos),IM_ROUND(subplot.GridRect.Max.y)),
-                                    active ? act_col : hov_col,1.0f);
-                    ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-                    pass = true;
+            const ImGuiID sep_id = subplot.ID + separator;
+            ImGui::KeepAliveID(sep_id);
+            const ImRect sep_bb = ImRect(xpos-SUBPLOT_SPLITTER_HALF_THICKNESS, subplot.GridRect.Min.y, xpos+SUBPLOT_SPLITTER_HALF_THICKNESS, subplot.GridRect.Max.y);
+            bool sep_hov = false, sep_hld = false;
+            const bool sep_clk = ImGui::ButtonBehavior(sep_bb, sep_id, &sep_hov, &sep_hld, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
+            if ((sep_hov && G.HoveredIdTimer > SUBPLOT_SPLITTER_FEEDBACK_TIMER) || sep_hld) {
+                if (sep_clk && ImGui::IsMouseDoubleClicked(0)) {
+                    float p = (subplot.ColRatios[c] + subplot.ColRatios[c+1])/2;
+                    subplot.ColRatios[c] = subplot.ColRatios[c+1] = p;
                 }
-            }
+                if (sep_clk) {
+                    subplot.TempSizes[0] = subplot.ColRatios[c];
+                    subplot.TempSizes[1] = subplot.ColRatios[c+1];
+                }
+                if (sep_hld) {
+                    float dp = ImGui::GetMouseDragDelta(0).x / subplot.GridRect.GetWidth();
+                    if (subplot.TempSizes[0] + dp > 0.1f && subplot.TempSizes[1] - dp > 0.1f) {
+                        subplot.ColRatios[c]   = subplot.TempSizes[0] + dp;
+                        subplot.ColRatios[c+1] = subplot.TempSizes[1] - dp;
+                    }
+                }
+                DrawList.AddLine(ImVec2(IM_ROUND(xpos),IM_ROUND(subplot.GridRect.Min.y)),
+                                 ImVec2(IM_ROUND(xpos),IM_ROUND(subplot.GridRect.Max.y)),
+                                 sep_hld ? act_col : hov_col, SUBPLOT_BORDER_SIZE);
+                ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+            } 
             separator++;
         }
-    }
-    else if (ImGui::IsMouseReleased(ImGuiMouseButton_Left) || !ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
-        subplot.ActiveSeparator = -1;
-    }
-  
+    }  
 
     // set outgoing sizes
     if (row_sizes != NULL) {
@@ -2927,9 +2912,6 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
             col_sizes[c] = subplot.ColRatios[c] * col_sum;
     }
 
-    // set flags
-    gp.DisableUserInput = subplot.ActiveSeparator != -1;
- 
     // push styling
     PushStyleColor(ImPlotCol_FrameBg, IM_COL32_BLACK_TRANS);
     PushStyleVar(ImPlotStyleVar_PlotPadding, half_pad);
@@ -4490,13 +4472,13 @@ void ShowMetricsWindow(bool* p_popen) {
             // plot
             ImPlotPlot* plot = gp.Plots.GetByIndex(p);
             ImGui::PushID(p);
-            if (ImGui::TreeNode("Plot", "Plot [ID=%u]", plot->ID)) {
+            if (ImGui::TreeNode("Plot", "Plot [ID=0x%08X]", plot->ID)) {
                 int n_items = plot->Items.GetItemCount();
                 if (ImGui::TreeNode("Items", "Items (%d)", n_items)) {
                     for (int i = 0; i < n_items; ++i) {
                         ImPlotItem* item = plot->Items.GetItemByIndex(i);
                         ImGui::PushID(i);
-                        if (ImGui::TreeNode("Item", "Item [ID=%u]", item->ID)) {
+                        if (ImGui::TreeNode("Item", "Item [ID=0x%08X]", item->ID)) {
                             ImGui::Bullet(); ImGui::Checkbox("Show", &item->Show);
                             ImGui::Bullet();
                             ImVec4 temp = ImGui::ColorConvertU32ToFloat4(item->Color);
@@ -4528,7 +4510,7 @@ void ShowMetricsWindow(bool* p_popen) {
                     ShowAxisMetrics(&plot->YAxis[2]);
                     ImGui::TreePop();
                 }
-                ImGui::Bullet(); ImGui::Text("Flags: %d", plot->Flags);
+                ImGui::Bullet(); ImGui::Text("Flags: 0x%08X", plot->Flags);
                 ImGui::Bullet(); ImGui::Text("Initialized: %s", plot->Initialized ? "true" : "false");
                 ImGui::Bullet(); ImGui::Text("Selecting: %s", plot->Selecting ? "true" : "false");
                 ImGui::Bullet(); ImGui::Text("Selected: %s", plot->Selected ? "true" : "false");
@@ -4549,13 +4531,13 @@ void ShowMetricsWindow(bool* p_popen) {
             // plot
             ImPlotSubplot* plot = gp.Subplots.GetByIndex(p);
             ImGui::PushID(p);
-            if (ImGui::TreeNode("Plot", "Plot [ID=%u]", plot->ID)) {
+            if (ImGui::TreeNode("Subplot", "Subplot [ID=%0x%08X]", plot->ID)) {
                 int n_items = plot->Items.GetItemCount();
                 if (ImGui::TreeNode("Items", "Items (%d)", n_items)) {
                     for (int i = 0; i < n_items; ++i) {
                         ImPlotItem* item = plot->Items.GetItemByIndex(i);
                         ImGui::PushID(i);
-                        if (ImGui::TreeNode("Item", "Item [ID=%u]", item->ID)) {
+                        if (ImGui::TreeNode("Item", "Item [ID=%0x%08X]", item->ID)) {
                             ImGui::Bullet(); ImGui::Checkbox("Show", &item->Show);
                             ImGui::Bullet();
                             ImVec4 temp = ImGui::ColorConvertU32ToFloat4(item->Color);
@@ -4571,9 +4553,9 @@ void ShowMetricsWindow(bool* p_popen) {
                     }
                     ImGui::TreePop();
                 }
-                ImGui::Bullet(); ImGui::Text("Flags: %d", plot->Flags);
+                ImGui::Bullet(); ImGui::Text("Flags: 0x%08X", plot->Flags);
                 ImGui::Bullet(); ImGui::Text("FrameHovered: %s", plot->FrameHovered ? "true" : "false");
-                // ImGui::Bullet(); ImGui::Text("LegendHovered: %s", plot->LegendHovered ? "true" : "false");
+                ImGui::Bullet(); ImGui::Text("LegendHovered: %s", plot->Items.Legend.Hovered ? "true" : "false");
                 ImGui::TreePop();
             }            
             ImGui::PopID();

--- a/implot.cpp
+++ b/implot.cpp
@@ -1344,6 +1344,13 @@ static inline void RenderSelectionRect(ImDrawList& DrawList, const ImVec2& p_min
 }
 
 //-----------------------------------------------------------------------------
+// Utils
+//-----------------------------------------------------------------------------
+
+
+
+
+//-----------------------------------------------------------------------------
 // BeginPlot()
 //-----------------------------------------------------------------------------
 
@@ -1496,7 +1503,7 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
     UpdateAxisColors(ImPlotCol_YAxis2, &plot.YAxis[1]);
     UpdateAxisColors(ImPlotCol_YAxis3, &plot.YAxis[2]);
 
-    // BB, PADDING, HOVER -----------------------------------------------------------
+    // SIZING, BB, PADDING, HOVER -----------------------------------------------------------
 
     // frame size
     ImVec2 frame_size;
@@ -1521,7 +1528,6 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
     if (G.HoveredIdPreviousFrame != 0 && G.HoveredIdPreviousFrame != ID)
         plot.FrameHovered = false;
     ImGui::SetItemAllowOverlap();
-    ImGui::RenderFrame(plot.FrameRect.Min, plot.FrameRect.Max, GetStyleColorU32(ImPlotCol_FrameBg), true, Style.FrameRounding);
 
     // canvas/axes bb
     plot.CanvasRect = ImRect(plot.FrameRect.Min + gp.Style.PlotPadding, plot.FrameRect.Max - gp.Style.PlotPadding);
@@ -1643,8 +1649,8 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
     // y axis regions bb and hover
     plot.YAxis[0].HoverRect = ImRect(ImVec2(plot.AxesRect.Min.x, plot.PlotRect.Min.y), ImVec2(plot.PlotRect.Min.x, plot.PlotRect.Max.y));
     plot.YAxis[1].HoverRect = plot.YAxis[2].Present
-                      ? ImRect(plot.PlotRect.GetTR(), ImVec2(gp.YAxisReference[2], plot.PlotRect.Max.y))
-                      : ImRect(plot.PlotRect.GetTR(), ImVec2(plot.AxesRect.Max.x, plot.PlotRect.Max.y));
+                            ? ImRect(plot.PlotRect.GetTR(), ImVec2(gp.YAxisReference[2], plot.PlotRect.Max.y))
+                            : ImRect(plot.PlotRect.GetTR(), ImVec2(plot.AxesRect.Max.x, plot.PlotRect.Max.y));
 
     plot.YAxis[2].HoverRect = ImRect(ImVec2(gp.YAxisReference[2], plot.PlotRect.Min.y), ImVec2(plot.AxesRect.Max.x, plot.PlotRect.Max.y));
 
@@ -1960,6 +1966,10 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
     }
 
     // RENDER -----------------------------------------------------------------
+
+    // render frame
+    ImGui::RenderFrame(plot.FrameRect.Min, plot.FrameRect.Max, GetStyleColorU32(ImPlotCol_FrameBg), true, Style.FrameRounding);
+
 
     // grid bg
     DrawList.AddRectFilled(plot.PlotRect.Min, plot.PlotRect.Max, GetStyleColorU32(ImPlotCol_PlotBg));

--- a/implot.h
+++ b/implot.h
@@ -513,19 +513,23 @@ IMPLOT_API void SetNextPlotLimits(double xmin, double xmax, double ymin, double 
 // Set the X axis range limits of the next plot. Call right before BeginPlot(). If ImGuiCond_Always is used, the X axis limits will be locked.
 IMPLOT_API void SetNextPlotLimitsX(double xmin, double xmax, ImGuiCond cond = ImGuiCond_Once);
 // Set the Y axis range limits of the next plot. Call right before BeginPlot(). If ImGuiCond_Always is used, the Y axis limits will be locked.
-IMPLOT_API void SetNextPlotLimitsY(double ymin, double ymax, ImGuiCond cond = ImGuiCond_Once, ImPlotYAxis y_axis = 0);
+IMPLOT_API void SetNextPlotLimitsY(double ymin, double ymax, ImGuiCond cond = ImGuiCond_Once, ImPlotYAxis y_axis = ImPlotYAxis_1);
 // Links the next plot limits to external values. Set to NULL for no linkage. The pointer data must remain valid until the matching call to EndPlot.
 IMPLOT_API void LinkNextPlotLimits(double* xmin, double* xmax, double* ymin, double* ymax, double* ymin2 = NULL, double* ymax2 = NULL, double* ymin3 = NULL, double* ymax3 = NULL);
 // Fits the next plot axes to all plotted data if they are unlocked (equivalent to double-clicks).
 IMPLOT_API void FitNextPlotAxes(bool x = true, bool y = true, bool y2 = true, bool y3 = true);
 
-// Set the X axis ticks and optionally the labels for the next plot. To keep the default ticks, set #show_default=true.
-IMPLOT_API void SetNextPlotTicksX(const double* values, int n_ticks, const char* const labels[] = NULL, bool show_default = false);
-IMPLOT_API void SetNextPlotTicksX(double x_min, double x_max, int n_ticks, const char* const labels[] = NULL, bool show_default = false);
+// Set the X axis ticks and optionally the labels for the next plot. To keep the default ticks, set #keep_default=true.
+IMPLOT_API void SetNextPlotTicksX(const double* values, int n_ticks, const char* const labels[] = NULL, bool keep_default = false);
+IMPLOT_API void SetNextPlotTicksX(double x_min, double x_max, int n_ticks, const char* const labels[] = NULL, bool keep_default = false);
+// Set the Y axis ticks and optionally the labels for the next plot. To keep the default ticks, set #keep_default=true.
+IMPLOT_API void SetNextPlotTicksY(const double* values, int n_ticks, const char* const labels[] = NULL, bool keep_default = false, ImPlotYAxis y_axis = ImPlotYAxis_1);
+IMPLOT_API void SetNextPlotTicksY(double y_min, double y_max, int n_ticks, const char* const labels[] = NULL, bool keep_default = false, ImPlotYAxis y_axis = ImPlotYAxis_1);
 
-// Set the Y axis ticks and optionally the labels for the next plot. To keep the default ticks, set #show_default=true.
-IMPLOT_API void SetNextPlotTicksY(const double* values, int n_ticks, const char* const labels[] = NULL, bool show_default = false, ImPlotYAxis y_axis = 0);
-IMPLOT_API void SetNextPlotTicksY(double y_min, double y_max, int n_ticks, const char* const labels[] = NULL, bool show_default = false, ImPlotYAxis y_axis = 0);
+// Set the format for numeric X axis labels (default="%g"). Formated values will be doubles (i.e. don't supply %d, %i, etc.). Not applicable if ImPlotAxisFlags_Time enabled.
+IMPLOT_API void SetNextPlotFormatX(const char* fmt);
+// Set the format for numeric Y axis labels (default="%g"). Formated values will be doubles (i.e. don't supply %d, %i, etc.).
+IMPLOT_API void SetNextPlotFormatY(const char* fmt, ImPlotYAxis y_axis=ImPlotYAxis_1);
 
 // The following functions MUST be called BETWEEN Begin/EndPlot!
 
@@ -778,7 +782,7 @@ IMPLOT_API ImVec4 GetColormapColor(int idx, ImPlotColormap cmap = IMPLOT_AUTO);
 IMPLOT_API ImVec4 SampleColormap(float t, ImPlotColormap cmap = IMPLOT_AUTO);
 
 // Shows a vertical color scale with linear spaced ticks using the specified color map. Use double hashes to hide label (e.g. "##NoLabel").
-IMPLOT_API void ColormapScale(const char* label, double scale_min, double scale_max, const ImVec2& size = ImVec2(0,0), ImPlotColormap cmap = IMPLOT_AUTO);
+IMPLOT_API void ColormapScale(const char* label, double scale_min, double scale_max, const ImVec2& size = ImVec2(0,0), ImPlotColormap cmap = IMPLOT_AUTO, const char* fmt = "%g");
 // Shows a horizontal slider with a colormap gradient background. Optionally returns the color sampled at t in [0 1].
 IMPLOT_API bool ColormapSlider(const char* label, float* t, ImVec4* out = NULL, const char* format = "", ImPlotColormap cmap = IMPLOT_AUTO);
 // Shows a button with a colormap gradient brackground.

--- a/implot.h
+++ b/implot.h
@@ -400,7 +400,7 @@ IMPLOT_API void EndPlot();
 //    ImPlot::PlotLine("line", &data[0].x, &data[0].y, 42, 0, sizeof(Vector2f)); // or sizeof(float)*2
 //
 // 2. Write a custom getter C function or C++ lambda and pass it and optionally your data to
-//    an ImPlot function post-fixed with a G (e.g. PlotScatterG). This has a slight performance 
+//    an ImPlot function post-fixed with a G (e.g. PlotScatterG). This has a slight performance
 //    cost, but probably not enough to worry about unless your data is very large. Examples:
 //
 //    ImPlotPoint MyDataGetter(void* data, int idx) {
@@ -741,10 +741,10 @@ IMPLOT_API const char* GetMarkerName(ImPlotMarker idx);
 //     2) Pushed an item style color using PushStyleColor().
 //     3) Set the next item style with a SetNextXXXStyle function.
 
-// Add a new colormap. The color data will be copied. The colormap can be used by pushing either the returned index or the 
-// string name with PushColormap. The colormap name must be unique and the size must be greater than 1. You will receive 
-// an assert otherwise! By default colormaps are considered to be qualitative (i.e. discrete). If you want to create a 
-// continuous colormap, set #qual=false. This will treat the colors you provide as keys, and ImPlot will build a linearly 
+// Add a new colormap. The color data will be copied. The colormap can be used by pushing either the returned index or the
+// string name with PushColormap. The colormap name must be unique and the size must be greater than 1. You will receive
+// an assert otherwise! By default colormaps are considered to be qualitative (i.e. discrete). If you want to create a
+// continuous colormap, set #qual=false. This will treat the colors you provide as keys, and ImPlot will build a linearly
 // interpolated lookup table. The memory footprint of this table will be exactly ((size-1)*255+1)*4 bytes.
 IMPLOT_API ImPlotColormap AddColormap(const char* name, const ImVec4* cols, int size, bool qual=true);
 IMPLOT_API ImPlotColormap AddColormap(const char* name, const ImU32*  cols, int size, bool qual=true);

--- a/implot.h
+++ b/implot.h
@@ -89,13 +89,15 @@ enum ImPlotAxisFlags_ {
     ImPlotAxisFlags_NoGridLines   = 1 << 1,  // no grid lines will be displayed
     ImPlotAxisFlags_NoTickMarks   = 1 << 2,  // no tick marks will be displayed
     ImPlotAxisFlags_NoTickLabels  = 1 << 3,  // no text labels will be displayed
-    ImPlotAxisFlags_LogScale      = 1 << 4,  // a logartithmic (base 10) axis scale will be used (mutually exclusive with ImPlotAxisFlags_Time)
-    ImPlotAxisFlags_Time          = 1 << 5,  // axis will display date/time formatted labels (mutually exclusive with ImPlotAxisFlags_LogScale)
-    ImPlotAxisFlags_Invert        = 1 << 6,  // the axis will be inverted
-    ImPlotAxisFlags_NoInitialFit  = 1 << 7,  // axis will not be initially fit to data extents on the first rendered frame (also the case if SetNextPlotLimits explicitly called)
-    ImPlotAxisFlags_AutoFit       = 1 << 8,  // axis will be auto-fitting to data extents
-    ImPlotAxisFlags_LockMin       = 1 << 9,  // the axis minimum value will be locked when panning/zooming
-    ImPlotAxisFlags_LockMax       = 1 << 10, // the axis maximum value will be locked when panning/zooming
+    ImPlotAxisFlags_Foreground    = 1 << 4,  // grid lines will be displayed in the foreground (i.e. on top of data) in stead of the background
+    ImPlotAxisFlags_LogScale      = 1 << 5,  // a logartithmic (base 10) axis scale will be used (mutually exclusive with ImPlotAxisFlags_Time)
+    ImPlotAxisFlags_Time          = 1 << 6,  // axis will display date/time formatted labels (mutually exclusive with ImPlotAxisFlags_LogScale)
+    ImPlotAxisFlags_Invert        = 1 << 7,  // the axis will be inverted
+    ImPlotAxisFlags_NoInitialFit  = 1 << 8,  // axis will not be initially fit to data extents on the first rendered frame (also the case if SetNextPlotLimits explicitly called)
+    ImPlotAxisFlags_AutoFit       = 1 << 9,  // axis will be auto-fitting to data extents
+    ImPlotAxisFlags_RangeFit      = 1 << 10, // axis will only fit points if the point is in the visible range of the **orthoganol** axis
+    ImPlotAxisFlags_LockMin       = 1 << 11, // the axis minimum value will be locked when panning/zooming
+    ImPlotAxisFlags_LockMax       = 1 << 12, // the axis maximum value will be locked when panning/zooming
     ImPlotAxisFlags_Lock          = ImPlotAxisFlags_LockMin | ImPlotAxisFlags_LockMax,
     ImPlotAxisFlags_NoDecorations = ImPlotAxisFlags_NoLabel | ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_NoTickMarks | ImPlotAxisFlags_NoTickLabels
 };
@@ -808,8 +810,8 @@ IMPLOT_API void ColormapIcon(ImPlotColormap cmap);
 
 // Get the plot draw list for custom rendering to the current plot area. Call between Begin/EndPlot.
 IMPLOT_API ImDrawList* GetPlotDrawList();
-// Push clip rect for rendering to current plot area. Call between Begin/EndPlot.
-IMPLOT_API void PushPlotClipRect();
+// Push clip rect for rendering to current plot area. The rect can be expanded or contracted by #expand pixels. Call between Begin/EndPlot.
+IMPLOT_API void PushPlotClipRect(float expand=0);
 // Pop plot clip rect. Call between Begin/EndPlot.
 IMPLOT_API void PopPlotClipRect();
 

--- a/implot.h
+++ b/implot.h
@@ -341,23 +341,24 @@ IMPLOT_API void SetImGuiContext(ImGuiContext* ctx);
 // Begin/End Plot
 //-----------------------------------------------------------------------------
 
-// Starts a 2D plotting context. If this function returns true, EndPlot() must
-// be called! You are encouraged to use the following call convention:
+// Starts a 2D plotting context. If this function returns true, EndPlot() MUST
+// be called! You are encouraged to use the following convention:
 //
 // if (BeginPlot(...)) {
 //     ImPlot::PlotLine(...);
+//     ...
 //     EndPlot();
 // }
 //
 // Important notes:
 //
-// - #title_id must be unique to the current ImGui window. If you need to avoid ID
+// - #title_id must be unique to the current ImGui ID scope. If you need to avoid ID
 //   collisions or don't want to display a title in the plot, use double hashes
-//   (e.g. "MyPlot##Hidden" or "##NoTitle").
+//   (e.g. "MyPlot##HiddenIdText" or "##NoTitle").
 // - If #x_label and/or #y_label are provided, axes labels will be displayed.
 // - #size is the **frame** size of the plot widget, not the plot area. The default
 //   size of plots (i.e. when ImVec2(0,0)) can be modified in your ImPlotStyle
-//   (default is 400x300).
+//   (default is 400x300 px).
 // - Auxiliary y-axes must be enabled with ImPlotFlags_YAxis2/3 to be displayed.
 // - See ImPlotFlags and ImPlotAxisFlags for more available options.
 
@@ -374,7 +375,7 @@ IMPLOT_API bool BeginPlot(const char* title_id,
                           const char* y3_label     = NULL);
 
 // Only call EndPlot() if BeginPlot() returns true! Typically called at the end
-// of an if statement conditioned on BeginPlot(). See above.
+// of an if statement conditioned on BeginPlot(). See example above.
 IMPLOT_API void EndPlot();
 
 //-----------------------------------------------------------------------------
@@ -398,9 +399,9 @@ IMPLOT_API void EndPlot();
 //    Vector2f data[42];
 //    ImPlot::PlotLine("line", &data[0].x, &data[0].y, 42, 0, sizeof(Vector2f)); // or sizeof(float)*2
 //
-// 2. Write a custom getter C function or C++ lambda and pass it and your data to
-//    an ImPlot function post-fixed with a G (e.g. PlotScatterG). This has a
-//    slight performance cost, but probably not enough to worry about. Example:
+// 2. Write a custom getter C function or C++ lambda and pass it and optionally your data to
+//    an ImPlot function post-fixed with a G (e.g. PlotScatterG). This has a slight performance 
+//    cost, but probably not enough to worry about unless your data is very large. Examples:
 //
 //    ImPlotPoint MyDataGetter(void* data, int idx) {
 //        MyData* my_data = (MyData*)data;
@@ -492,10 +493,10 @@ template <typename T> IMPLOT_API double PlotHistogram2D(const char* label_id, co
 template <typename T> IMPLOT_API void PlotDigital(const char* label_id, const T* xs, const T* ys, int count, int offset=0, int stride=sizeof(T));
                       IMPLOT_API void PlotDigitalG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, int offset=0);
 
-// Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinatse (y-up) and #uv0/uv1 are in texture coordinates (y-down).
+// Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinates (y-up) and #uv0/uv1 are in texture coordinates (y-down).
 IMPLOT_API void PlotImage(const char* label_id, ImTextureID user_texture_id, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, const ImVec2& uv0=ImVec2(0,0), const ImVec2& uv1=ImVec2(1,1), const ImVec4& tint_col=ImVec4(1,1,1,1));
 
-// Plots a centered text label at point x,y with optional pixel offset. Text color can be changed with ImPlot::PushStyleColor(ImPlotCol_InlayText, ...).
+// Plots a centered text label at point x,y with an optional pixel offset. Text color can be changed with ImPlot::PushStyleColor(ImPlotCol_InlayText, ...).
 IMPLOT_API void PlotText(const char* text, double x, double y, bool vertical=false, const ImVec2& pix_offset=ImVec2(0,0));
 
 // Plots a dummy item (i.e. adds a legend entry colored by ImPlotCol_Line)
@@ -513,16 +514,16 @@ IMPLOT_API void SetNextPlotLimits(double xmin, double xmax, double ymin, double 
 IMPLOT_API void SetNextPlotLimitsX(double xmin, double xmax, ImGuiCond cond = ImGuiCond_Once);
 // Set the Y axis range limits of the next plot. Call right before BeginPlot(). If ImGuiCond_Always is used, the Y axis limits will be locked.
 IMPLOT_API void SetNextPlotLimitsY(double ymin, double ymax, ImGuiCond cond = ImGuiCond_Once, ImPlotYAxis y_axis = 0);
-// Links the next plot limits to external values. Set to NULL for no linkage. The pointer data must remain valid until the matching call EndPlot.
+// Links the next plot limits to external values. Set to NULL for no linkage. The pointer data must remain valid until the matching call to EndPlot.
 IMPLOT_API void LinkNextPlotLimits(double* xmin, double* xmax, double* ymin, double* ymax, double* ymin2 = NULL, double* ymax2 = NULL, double* ymin3 = NULL, double* ymax3 = NULL);
 // Fits the next plot axes to all plotted data if they are unlocked (equivalent to double-clicks).
 IMPLOT_API void FitNextPlotAxes(bool x = true, bool y = true, bool y2 = true, bool y3 = true);
 
-// Set the X axis ticks and optionally the labels for the next plot.
+// Set the X axis ticks and optionally the labels for the next plot. To keep the default ticks, set #show_default=true.
 IMPLOT_API void SetNextPlotTicksX(const double* values, int n_ticks, const char* const labels[] = NULL, bool show_default = false);
 IMPLOT_API void SetNextPlotTicksX(double x_min, double x_max, int n_ticks, const char* const labels[] = NULL, bool show_default = false);
 
-// Set the Y axis ticks and optionally the labels for the next plot.
+// Set the Y axis ticks and optionally the labels for the next plot. To keep the default ticks, set #show_default=true.
 IMPLOT_API void SetNextPlotTicksY(const double* values, int n_ticks, const char* const labels[] = NULL, bool show_default = false, ImPlotYAxis y_axis = 0);
 IMPLOT_API void SetNextPlotTicksY(double y_min, double y_max, int n_ticks, const char* const labels[] = NULL, bool show_default = false, ImPlotYAxis y_axis = 0);
 
@@ -554,10 +555,17 @@ IMPLOT_API ImPlotPoint GetPlotMousePos(ImPlotYAxis y_axis = IMPLOT_AUTO);
 // Returns the current plot axis range. A negative y_axis uses the current value of SetPlotYAxis (ImPlotYAxis_1 initially).
 IMPLOT_API ImPlotLimits GetPlotLimits(ImPlotYAxis y_axis = IMPLOT_AUTO);
 
-// Returns true if the current plot is being queried. Query must be enabled with ImPlotFlags_Query.
+// Returns true if the current plot is being box selected.
+IMPLOT_API bool IsPlotSelected();
+// Returns the current plot box selection bounds.
+IMPLOT_API ImPlotLimits GetPlotSelection(ImPlotYAxis y_axis = IMPLOT_AUTO);
+
+// Returns true if the current plot is being queried or has an active query. Query must be enabled with ImPlotFlags_Query.
 IMPLOT_API bool IsPlotQueried();
 // Returns the current plot query bounds. Query must be enabled with ImPlotFlags_Query.
 IMPLOT_API ImPlotLimits GetPlotQuery(ImPlotYAxis y_axis = IMPLOT_AUTO);
+// Set the current plot query bounds. Query must be enabled with ImPlotFlags_Query.
+IMPLOT_API void SetPlotQuery(const ImPlotLimits& query, ImPlotYAxis y_axis = IMPLOT_AUTO);
 
 //-----------------------------------------------------------------------------
 // Plot Tools
@@ -619,7 +627,7 @@ IMPLOT_API bool BeginDragDropTargetLegend();
 // Ends a drag and drop target (currently just an alias for ImGui::EndDragDropTarget).
 IMPLOT_API void EndDragDropTarget();
 
-// NB: By default, plot and axes drag and drop sources require holding the Ctrl modifier to initiate the drag.
+// NB: By default, plot and axes drag and drop *sources* require holding the Ctrl modifier to initiate the drag.
 // You can change the modifier if desired. If ImGuiKeyModFlags_None is provided, the axes will be locked from panning.
 
 // Turns the current plot's plotting area into a drag and drop source. Don't forget to call EndDragDropSource!
@@ -650,7 +658,7 @@ IMPLOT_API void EndDragDropSource();
 //        color in the current colormap. Thus, every item will have a different
 //        color up to the number of colors in the colormap, at which point the
 //        colormap will roll over. For most use cases, you should not need to
-//        modify these style colors to anything but IMPLOT_COL_AUTO. You are
+//        set these style colors to anything but IMPLOT_COL_AUTO; you are
 //        probably better off changing the current colormap. However, if you
 //        need to explicitly color a particular item you may either Push/Pop
 //        the style color around the item in question, or use the SetNextXXXStyle
@@ -664,7 +672,7 @@ IMPLOT_API void EndDragDropSource();
 //        detailed above, and in general have been mapped to produce plots visually
 //        consistent with your current ImGui style. Of course, you are free to
 //        manually set these colors to whatever you like, and further can Push/Pop
-//        them around individual plots.
+//        them around individual plots for plot-specific styling (e.g. coloring axes).
 
 // Provides access to plot style structure for permanant modifications to colors, sizes, etc.
 IMPLOT_API ImPlotStyle& GetStyle();
@@ -733,15 +741,15 @@ IMPLOT_API const char* GetMarkerName(ImPlotMarker idx);
 //     2) Pushed an item style color using PushStyleColor().
 //     3) Set the next item style with a SetNextXXXStyle function.
 
-// Add a new colormap. The colormap can be used by pushing either the returned index or the string name with PushColormap.
-// The colormap name must be unique and the size must be greater than 1. You will receive an assert otherwise! By default
-// colormaps are considered to be qualitative (i.e. discrete). If you want to create a continuous colormap, set #qual=false.
-// This will treat the colors you provide as keys, and ImPlot will build a linearly interpolated lookup table that fills
-// in the gaps. The memory footprint of this table will be exactly ((size-1)*255+1)*4 bytes.
+// Add a new colormap. The color data will be copied. The colormap can be used by pushing either the returned index or the 
+// string name with PushColormap. The colormap name must be unique and the size must be greater than 1. You will receive 
+// an assert otherwise! By default colormaps are considered to be qualitative (i.e. discrete). If you want to create a 
+// continuous colormap, set #qual=false. This will treat the colors you provide as keys, and ImPlot will build a linearly 
+// interpolated lookup table. The memory footprint of this table will be exactly ((size-1)*255+1)*4 bytes.
 IMPLOT_API ImPlotColormap AddColormap(const char* name, const ImVec4* cols, int size, bool qual=true);
 IMPLOT_API ImPlotColormap AddColormap(const char* name, const ImU32*  cols, int size, bool qual=true);
 
-// Returns the number of available colormaps.
+// Returns the number of available colormaps (i.e. the built-in + user-added count).
 IMPLOT_API int GetColormapCount();
 // Returns a null terminated string name for a colormap given an index. Returns NULL if index is invalid.
 IMPLOT_API const char* GetColormapName(ImPlotColormap cmap);
@@ -750,7 +758,7 @@ IMPLOT_API ImPlotColormap GetColormapIndex(const char* name);
 
 // Temporarily switch to one of the built-in (i.e. ImPlotColormap_XXX) or user-added colormaps (i.e. a return value of AddColormap). Don't forget to call PopColormap!
 IMPLOT_API void PushColormap(ImPlotColormap cmap);
-// Push a colormap by string name. Use built-in names such as "Default", "Deep", "Jet", etc or a string you provided to AddColormap. Don't forget to call PopColormap!
+// Push a colormap by string name. Use built-in names such as "Default", "Deep", "Jet", etc. or a string you provided to AddColormap. Don't forget to call PopColormap!
 IMPLOT_API void PushColormap(const char* name);
 // Undo temporary colormap modification(s). Undo multiple pushes at once by increasing count.
 IMPLOT_API void PopColormap(int count = 1);
@@ -760,7 +768,7 @@ IMPLOT_API void PopColormap(int count = 1);
 IMPLOT_API ImVec4 NextColormapColor();
 
 // Colormap utils. If cmap = IMPLOT_AUTO (default), the current colormap is assumed.
-// Pass an explicit colormap index (built-in or user added) to specify otherwise.
+// Pass an explicit colormap index (built-in or user-added) to specify otherwise.
 
 // Returns the size of a colormap.
 IMPLOT_API int GetColormapSize(ImPlotColormap cmap = IMPLOT_AUTO);
@@ -778,11 +786,11 @@ IMPLOT_API bool ColormapButton(const char* label, const ImVec2& size = ImVec2(0,
 
 // When items in a plot sample their color from a colormap, the color is cached and does not change
 // unless explicitly overriden. Therefore, if you change the colormap after the item has already been plotted,
-// item colors will not update. If you need item colors to resample the new colormap, then use this
+// item colors will NOT update. If you need item colors to resample the new colormap, then use this
 // function to bust the cached colors. If #plot_title_id is NULL, then every item in EVERY existing plot
 // will be cache busted. Otherwise only the plot specified by #plot_title_id will be busted. For the
-// latter, this function must be called in the ImGui window that the plot is in. You should rarely if ever
-// need this function, but it is available for applications that require runtime swaps (see Heatmaps demo).
+// latter, this function must be called in the same ImGui ID scope that the plot is in. You should rarely if ever
+// need this function, but it is available for applications that require runtime colormap swaps (e.g. Heatmaps demo).
 IMPLOT_API void BustColorCache(const char* plot_title_id = NULL);
 
 //-----------------------------------------------------------------------------
@@ -809,14 +817,14 @@ IMPLOT_API bool ShowColormapSelector(const char* label);
 IMPLOT_API void ShowStyleEditor(ImPlotStyle* ref = NULL);
 // Add basic help/info block for end users (not a window).
 IMPLOT_API void ShowUserGuide();
-// Shows ImPlot metrics/debug information.
+// Shows ImPlot metrics/debug information window.
 IMPLOT_API void ShowMetricsWindow(bool* p_popen = NULL);
 
 //-----------------------------------------------------------------------------
 // Demo (add implot_demo.cpp to your sources!)
 //-----------------------------------------------------------------------------
 
-// Shows the ImPlot demo.
+// Shows the ImPlot demo window.
 IMPLOT_API void ShowDemoWindow(bool* p_open = NULL);
 
 }  // namespace ImPlot

--- a/implot.h
+++ b/implot.h
@@ -91,9 +91,9 @@ enum ImPlotSubplotFlags_ {
     ImPlotSubplotFlags_LinkCols         = 1 << 2, // min/max limits of each plot x-axis on each column will be automatically linked
     ImPlotSubplotFlags_LinkAllX         = 1 << 3, // link all x-axes in every plot (overrides _LinkCols)
     ImPlotSubplotFlags_LinkAllY         = 1 << 4, // link all y-axes in every plot (overrides _LinkRows)
-    ImPlotSubplotFlags_NoAlign          = 1 << 7,  // subplot edges will not be aligned vertically or horizontally
-    ImPlotSubplotFlags_SharedLegend     = 1 << 8,
-    ImPlotSubplotFlags_SharedCrosshairs = 1 << 9
+    ImPlotSubplotFlags_NoAlign          = 1 << 5, // subplot edges will not be aligned vertically or horizontally
+    ImPlotSubplotFlags_SharedLegend     = 1 << 6, // all subplots will share a common legend
+    ImPlotSubplotFlags_SharedCrosshairs = 1 << 7, 
 };
 
 // Options for plot axes (X and Y).
@@ -398,11 +398,27 @@ IMPLOT_API void EndPlot();
 // Begin/EndSubplots
 //-----------------------------------------------------------------------------
 
+// Starts a subdivided plotting context. If the function returns true,
+// EndSubplots() MUST be called! Call BeginPlot/EndPlot [rows*cols] times.
+// Plots are added in row major order. Example:
+
+// if (BeginSubplots("My Subplot",2,3, ImVec2(800,600)) {
+//     for (int i = 0; i < 6; ++i) {
+//         if (BeginPlot(...)) {
+//             ...
+//             EndPlot();
+//         }
+//     }
+//     EndSubplots();
+// }
+
 IMPLOT_API bool BeginSubplots(const char* title_id,
                              int rows,
                              int cols,
                              const ImVec2& size,
-                             ImPlotSubplotFlags flags = ImPlotSubplotFlags_None);
+                             ImPlotSubplotFlags flags = ImPlotSubplotFlags_None,
+                             float* row_sizes = NULL,
+                             float* col_sizes = NULL);
 
 IMPLOT_API void EndSubplots();
 

--- a/implot.h
+++ b/implot.h
@@ -85,16 +85,15 @@ enum ImPlotFlags_ {
 
 // Options for subplots
 enum ImPlotSubplotFlags_ {
-    ImPlotSubplotFlags_None         = 0,      // default
-    ImPlotSubplotFlags_NoTitle      = 1 << 0,
-    ImPlotSubplotFlags_LinkRows     = 1 << 1, // min/max limits of each plot y-axis on each row will be automatically linked
-    ImPlotSubplotFlags_LinkCols     = 1 << 2, // min/max limits of each plot x-axis on each column will be automatically linked
-    ImPlotSubplotFlags_LinkAllX     = 1 << 3, // link all x-axes in every plot (overrides _LinkCols)
-    ImPlotSubplotFlags_LinkAllY     = 1 << 4, // link all y-axes in every plot (overrides _LinkRows)
-    ImPlotSubplotFlags_MultiFrame   = 1 << 5, // a background frame will be rendered for each plot instead of a single frame
-    ImPlotSubplotFlags_Tight        = 1 << 6, // tight layout, i.e. no margines between plots
-    ImPlotSubplotFlags_NoAlign      = 1 << 7,  // subplot edges will not be aligned vertically or horizontally
-    ImPlotSubplotFlags_SharedLegend = 1 << 8,
+    ImPlotSubplotFlags_None             = 0,      // default
+    ImPlotSubplotFlags_NoTitle          = 1 << 0,
+    ImPlotSubplotFlags_LinkRows         = 1 << 1, // min/max limits of each plot y-axis on each row will be automatically linked
+    ImPlotSubplotFlags_LinkCols         = 1 << 2, // min/max limits of each plot x-axis on each column will be automatically linked
+    ImPlotSubplotFlags_LinkAllX         = 1 << 3, // link all x-axes in every plot (overrides _LinkCols)
+    ImPlotSubplotFlags_LinkAllY         = 1 << 4, // link all y-axes in every plot (overrides _LinkRows)
+    ImPlotSubplotFlags_NoAlign          = 1 << 7,  // subplot edges will not be aligned vertically or horizontally
+    ImPlotSubplotFlags_SharedLegend     = 1 << 8,
+    ImPlotSubplotFlags_SharedCrosshairs = 1 << 9
 };
 
 // Options for plot axes (X and Y).

--- a/implot.h
+++ b/implot.h
@@ -85,15 +85,16 @@ enum ImPlotFlags_ {
 
 // Options for subplots
 enum ImPlotSubplotFlags_ {
-    ImPlotSubplotFlags_None             = 0,      // default
-    ImPlotSubplotFlags_NoTitle          = 1 << 0,
-    ImPlotSubplotFlags_LinkRows         = 1 << 1, // min/max limits of each plot y-axis on each row will be automatically linked
-    ImPlotSubplotFlags_LinkCols         = 1 << 2, // min/max limits of each plot x-axis on each column will be automatically linked
-    ImPlotSubplotFlags_LinkAllX         = 1 << 3, // link all x-axes in every plot (overrides _LinkCols)
-    ImPlotSubplotFlags_LinkAllY         = 1 << 4, // link all y-axes in every plot (overrides _LinkRows)
-    ImPlotSubplotFlags_NoAlign          = 1 << 5, // subplot edges will not be aligned vertically or horizontally
-    ImPlotSubplotFlags_SharedLegend     = 1 << 6, // all subplots will share a common legend
-    ImPlotSubplotFlags_SharedCrosshairs = 1 << 7, 
+    ImPlotSubplotFlags_None        = 0,      // default
+    ImPlotSubplotFlags_NoTitle     = 1 << 0, // the subplot title will not be displayed (titles are also hidden if preceeded by double hashes, e.g. "##MySubplot")
+    ImPlotSubplotFlags_NoLegend    = 1 << 1, // the legend will not be displayed if 
+    ImPlotSubplotFlags_NoSplitters = 1 << 2, // resize splitters between subplot cells will be not be provided
+    ImPlotSubplotFlags_NoAlign     = 1 << 3, // subplot edges will not be aligned vertically or horizontally
+    ImPlotSubplotFlags_ShareItems  = 1 << 4, // items across all subplots will be shared and rendered into a single legend entry
+    ImPlotSubplotFlags_LinkRows    = 1 << 5, // min/max limits of each plot y-axis on each row will be automatically linked
+    ImPlotSubplotFlags_LinkCols    = 1 << 6, // min/max limits of each plot x-axis on each column will be automatically linked
+    ImPlotSubplotFlags_LinkAllX    = 1 << 7, // link all x-axes in every plot (overrides _LinkCols)
+    ImPlotSubplotFlags_LinkAllY    = 1 << 8, // link all y-axes in every plot (overrides _LinkRows)
 };
 
 // Options for plot axes (X and Y).
@@ -315,7 +316,7 @@ struct ImPlotStyle {
     ImVec2  AnnotationPadding;       // = 2,2     text padding around annotation labels
     ImVec2  FitPadding;              // = 0,0     additional fit padding as a percentage of the fit extents (e.g. ImVec2(0.1f,0.1f) adds 10% to the fit extents of X and Y)
     ImVec2  PlotDefaultSize;         // = 400,300 default size used when ImVec2(0,0) is passed to BeginPlot
-    ImVec2  PlotMinSize;             // = 300,225 minimum size plot frame can be when shrunk
+    ImVec2  PlotMinSize;             // = 200,150 minimum size plot frame can be when shrunk
     // style colors
     ImVec4  Colors[ImPlotCol_COUNT]; // Array of styling colors. Indexable with ImPlotCol_ enums.
     // colormap

--- a/implot.h
+++ b/implot.h
@@ -114,9 +114,7 @@ enum ImPlotSubplotFlags_ {
     ImPlotSubplotFlags_LinkRows    = 1 << 5,  // link the y-axis limits of all plots in each row (does not apply auxiliary y-axes)
     ImPlotSubplotFlags_LinkCols    = 1 << 6,  // link the x-axis limits of all plots in each column
     ImPlotSubplotFlags_LinkAllX    = 1 << 7,  // link the x-axis limits in every plot in the subplot
-    ImPlotSubplotFlags_LinkAllY    = 1 << 8,  // link the y-axis limits in every plot in the subplot (does not apply to auxiliary y-axes)
-    ImPlotSubplotFlags_EqualRows   = 1 << 9,  // heights of plots in rows will be visually equalized (ignores incoming row sizes and disables horizontal splitters)
-    ImPlotSubplotFlags_EqualCols   = 1 << 10, // widths of plots in columns will be visually equalized (ignores incoming col sizes and disables vertical splitters)
+    ImPlotSubplotFlags_LinkAllY    = 1 << 8   // link the y-axis limits in every plot in the subplot (does not apply to auxiliary y-axes)
 };
 
 // Plot styling colors.
@@ -646,10 +644,12 @@ IMPLOT_API void SetPlotQuery(const ImPlotLimits& query, ImPlotYAxis y_axis = IMP
 // Algined Plots
 //-----------------------------------------------------------------------------
 
+// Consider using Begin/EndSubplots first. They are more feature rich and 
+// accomplish the same behaviour by default. The functions below offer lower 
+// level control of plot alignment. 
+
 // Align axis padding over multiple plots in a single row or column. If this function returns true, EndAlignedPlots() must be called. #group_id must be unique.
 IMPLOT_API bool BeginAlignedPlots(const char* group_id, ImPlotOrientation orientation = ImPlotOrientation_Vertical);
-// Align axis padding over multiple plots in a 2D grid. If this function returns true, EndAlignedPlots() must be called. #group_id must be unique.
-IMPLOT_API bool BeginAlignedPlots(const char* group_id, int rows, int cols);
 // Only call EndAlignedPlots() if BeginAlignedPlots() returns true!
 IMPLOT_API void EndAlignedPlots();
 
@@ -684,7 +684,7 @@ IMPLOT_API bool DragPoint(const char* id, double* x, double* y, bool show_label 
 
 // The following functions MUST be called BETWEEN Begin/EndPlot!
 
-// Set the location of the current plot's legend (default = North|West).
+// Set the location of the current plot's (or subplot's) legend.
 IMPLOT_API void SetLegendLocation(ImPlotLocation location, ImPlotOrientation orientation = ImPlotOrientation_Vertical, bool outside = false);
 // Set the location of the current plot's mouse position text (default = South|East).
 IMPLOT_API void SetMousePosLocation(ImPlotLocation location);

--- a/implot.h
+++ b/implot.h
@@ -402,8 +402,8 @@ IMPLOT_API void EndPlot();
 //-----------------------------------------------------------------------------
 
 // Starts a subdivided plotting context. If the function returns true,
-// EndSubplots() MUST be called! Call BeginPlot/EndPlot AT MOST [rows*cols] 
-// times in  between the begining and end of the subplot context. Plots are 
+// EndSubplots() MUST be called! Call BeginPlot/EndPlot AT MOST [rows*cols]
+// times in  between the begining and end of the subplot context. Plots are
 // added in row major order.
 //
 // Example:
@@ -420,7 +420,7 @@ IMPLOT_API void EndPlot();
 // }
 //
 // Procudes:
-// 
+//
 // [0][1][2]
 // [3][4][5]
 //
@@ -431,18 +431,18 @@ IMPLOT_API void EndPlot();
 //   (e.g. "MyPlot##HiddenIdText" or "##NoTitle").
 // - #rows and #cols must be greater than 0.
 // - #size is the size of the entire grid of subplots, not the individual plots
-// - #row_ratios and #col_ratios must have AT LEAST #rows and #cols elements, 
+// - #row_ratios and #col_ratios must have AT LEAST #rows and #cols elements,
 //   respectively. These are the sizes of the rows and columns expressed in ratios.
 //   If the user adjusts the dimensions, the arrays are updated with new ratios.
 //
 // Important notes regarding BeginPlot from inside of BeginSubplots:
 //
-// - The #title_id parameter of _BeginPlot_ (see above) does NOT have to be 
+// - The #title_id parameter of _BeginPlot_ (see above) does NOT have to be
 //   unique when called inside of a subplot context. Subplot IDs are hashed
 //   for your convenience so you don't have call PushID or generate unique title
 //   strings. Simply pass an empty string to BeginPlot unless you want to title
 //   each subplot.
-// - The #size parameter of _BeginPlot_ (see above) is ignored when inside of a 
+// - The #size parameter of _BeginPlot_ (see above) is ignored when inside of a
 //   subplot context. The actual size of the subplot will be based on the
 //   #size value you pass to _BeginSubplots_ and #row/#col_ratios if provided.
 
@@ -655,9 +655,9 @@ IMPLOT_API void SetPlotQuery(const ImPlotLimits& query, ImPlotYAxis y_axis = IMP
 // Algined Plots
 //-----------------------------------------------------------------------------
 
-// Consider using Begin/EndSubplots first. They are more feature rich and 
-// accomplish the same behaviour by default. The functions below offer lower 
-// level control of plot alignment. 
+// Consider using Begin/EndSubplots first. They are more feature rich and
+// accomplish the same behaviour by default. The functions below offer lower
+// level control of plot alignment.
 
 // Align axis padding over multiple plots in a single row or column. If this function returns true, EndAlignedPlots() must be called. #group_id must be unique.
 IMPLOT_API bool BeginAlignedPlots(const char* group_id, ImPlotOrientation orientation = ImPlotOrientation_Vertical);

--- a/implot.h
+++ b/implot.h
@@ -109,7 +109,7 @@ enum ImPlotSubplotFlags_ {
     ImPlotSubplotFlags_NoTitle     = 1 << 0,  // the subplot title will not be displayed (titles are also hidden if preceeded by double hashes, e.g. "##MySubplot")
     ImPlotSubplotFlags_NoLegend    = 1 << 1,  // the legend will not be displayed (only applicable if ImPlotSubplotFlags_ShareItems is enabled)
     ImPlotSubplotFlags_NoMenus     = 1 << 2,  // the user will not be able to open context menus with right-click
-    ImPlotSubplotFlags_NoSplitters = 1 << 3,  // resize splitters between subplot cells will be not be provided
+    ImPlotSubplotFlags_NoResize    = 1 << 3,  // resize splitters between subplot cells will be not be provided
     ImPlotSubplotFlags_NoAlign     = 1 << 4,  // subplot edges will not be aligned vertically or horizontally
     ImPlotSubplotFlags_ShareItems  = 1 << 5,  // items across all subplots will be shared and rendered into a single legend entry
     ImPlotSubplotFlags_LinkRows    = 1 << 6,  // link the y-axis limits of all plots in each row (does not apply auxiliary y-axes)
@@ -403,7 +403,7 @@ IMPLOT_API void EndPlot();
 // Starts a subdivided plotting context. If the function returns true,
 // EndSubplots() MUST be called! Call BeginPlot/EndPlot AT MOST [rows*cols] 
 // times in  between the begining and end of the subplot context. Plots are 
-// added in row major order. 
+// added in row major order.
 //
 // Example:
 //
@@ -433,8 +433,17 @@ IMPLOT_API void EndPlot();
 // - #row_ratios and #col_ratios must have AT LEAST #rows and #cols elements, 
 //   respectively. These are the sizes of the rows and columns expressed in ratios.
 //   If the user adjusts the dimensions, the arrays are updated with new ratios.
-// - The #size parameter of _BeginPlot_ (see above) is ignored when used inside
-//   of a subplot context since each subplot is sized automatically.
+//
+// Important notes regarding BeginPlot from inside of BeginSubplots:
+//
+// - The #title_id parameter of _BeginPlot_ (see above) does NOT have to be 
+//   unique when called inside of a subplot context. Subplot IDs are hashed
+//   for your convenience so you don't have call PushID or generate unique title
+//   strings. Simply pass an empty string to BeginPlot unless you want to title
+//   each subplot.
+// - The #size parameter of _BeginPlot_ (see above) is ignored when inside of a 
+//   subplot context. The actual size of the subplot will be based on the
+//   #size value you pass to _BeginSubplots_ and #row/#col_ratios if provided.
 
 IMPLOT_API bool BeginSubplots(const char* title_id,
                              int rows,

--- a/implot.h
+++ b/implot.h
@@ -88,7 +88,7 @@ enum ImPlotSubplotFlags_ {
     ImPlotSubplotFlags_None     = 0,      // default
     ImPlotSubplotFlags_LinkRows = 1 << 0, // min/max limits of each plot y-axis on each row will be automatically linked
     ImPlotSubplotFlags_LinkCols = 1 << 1, // min/max limits of each plot x-axis on each column will be automatically linked
-    ImPlotSubplotFlags_MultiBg  = 1 << 2, // a background frame will be rendered for each plot instead of a single frame
+    ImPlotSubplotFlags_MultiFrame  = 1 << 2, // a background frame will be rendered for each plot instead of a single frame
 };
 
 // Options for plot axes (X and Y).

--- a/implot.h
+++ b/implot.h
@@ -85,9 +85,9 @@ enum ImPlotFlags_ {
 
 // Options for subplots
 enum ImPlotSubplotFlags_ {
-    ImPlotSubplotFlags_None     = 0,      // default
-    ImPlotSubplotFlags_LinkRows = 1 << 0, // min/max limits of each plot y-axis on each row will be automatically linked
-    ImPlotSubplotFlags_LinkCols = 1 << 1, // min/max limits of each plot x-axis on each column will be automatically linked
+    ImPlotSubplotFlags_None        = 0,      // default
+    ImPlotSubplotFlags_LinkRows    = 1 << 0, // min/max limits of each plot y-axis on each row will be automatically linked
+    ImPlotSubplotFlags_LinkCols    = 1 << 1, // min/max limits of each plot x-axis on each column will be automatically linked
     ImPlotSubplotFlags_MultiFrame  = 1 << 2, // a background frame will be rendered for each plot instead of a single frame
 };
 

--- a/implot.h
+++ b/implot.h
@@ -445,7 +445,7 @@ IMPLOT_API bool BeginSubplots(const char* title_id,
                              float* col_ratios        = NULL);
 
 // Only call EndSubplots() if BeginSubplots() returns true! Typically called at the end
-// of an if statement conditioned on BeginPlot(). See example above.
+// of an if statement conditioned on BeginSublots(). See example above.
 IMPLOT_API void EndSubplots();
 
 //-----------------------------------------------------------------------------

--- a/implot.h
+++ b/implot.h
@@ -108,13 +108,14 @@ enum ImPlotSubplotFlags_ {
     ImPlotSubplotFlags_None        = 0,       // default
     ImPlotSubplotFlags_NoTitle     = 1 << 0,  // the subplot title will not be displayed (titles are also hidden if preceeded by double hashes, e.g. "##MySubplot")
     ImPlotSubplotFlags_NoLegend    = 1 << 1,  // the legend will not be displayed (only applicable if ImPlotSubplotFlags_ShareItems is enabled)
-    ImPlotSubplotFlags_NoSplitters = 1 << 2,  // resize splitters between subplot cells will be not be provided
-    ImPlotSubplotFlags_NoAlign     = 1 << 3,  // subplot edges will not be aligned vertically or horizontally
-    ImPlotSubplotFlags_ShareItems  = 1 << 4,  // items across all subplots will be shared and rendered into a single legend entry
-    ImPlotSubplotFlags_LinkRows    = 1 << 5,  // link the y-axis limits of all plots in each row (does not apply auxiliary y-axes)
-    ImPlotSubplotFlags_LinkCols    = 1 << 6,  // link the x-axis limits of all plots in each column
-    ImPlotSubplotFlags_LinkAllX    = 1 << 7,  // link the x-axis limits in every plot in the subplot
-    ImPlotSubplotFlags_LinkAllY    = 1 << 8   // link the y-axis limits in every plot in the subplot (does not apply to auxiliary y-axes)
+    ImPlotSubplotFlags_NoMenus     = 1 << 2,  // the user will not be able to open context menus with right-click
+    ImPlotSubplotFlags_NoSplitters = 1 << 3,  // resize splitters between subplot cells will be not be provided
+    ImPlotSubplotFlags_NoAlign     = 1 << 4,  // subplot edges will not be aligned vertically or horizontally
+    ImPlotSubplotFlags_ShareItems  = 1 << 5,  // items across all subplots will be shared and rendered into a single legend entry
+    ImPlotSubplotFlags_LinkRows    = 1 << 6,  // link the y-axis limits of all plots in each row (does not apply auxiliary y-axes)
+    ImPlotSubplotFlags_LinkCols    = 1 << 7,  // link the x-axis limits of all plots in each column
+    ImPlotSubplotFlags_LinkAllX    = 1 << 8,  // link the x-axis limits in every plot in the subplot
+    ImPlotSubplotFlags_LinkAllY    = 1 << 9   // link the y-axis limits in every plot in the subplot (does not apply to auxiliary y-axes)
 };
 
 // Plot styling colors.

--- a/implot.h
+++ b/implot.h
@@ -85,14 +85,16 @@ enum ImPlotFlags_ {
 
 // Options for subplots
 enum ImPlotSubplotFlags_ {
-    ImPlotSubplotFlags_None        = 0,      // default
-    ImPlotSubplotFlags_LinkRows    = 1 << 0, // min/max limits of each plot y-axis on each row will be automatically linked
-    ImPlotSubplotFlags_LinkCols    = 1 << 1, // min/max limits of each plot x-axis on each column will be automatically linked
-    ImPlotSubplotFlags_LinkAllX    = 1 << 2, // link all x-axes in every plot (overrides _LinkCols)
-    ImPlotSubplotFlags_LinkAllY    = 1 << 3, // link all y-axes in every plot (overrides _LinkRows)
-    ImPlotSubplotFlags_MultiFrame  = 1 << 4, // a background frame will be rendered for each plot instead of a single frame
-    ImPlotSubplotFlags_Tight       = 1 << 5, // tight layout, i.e. no margines between plots
-    ImPlotSubplotFlags_NoAlign     = 1 << 6  // subplot edges will not be aligned vertically or horizontally
+    ImPlotSubplotFlags_None         = 0,      // default
+    ImPlotSubplotFlags_NoTitle      = 1 << 0,
+    ImPlotSubplotFlags_LinkRows     = 1 << 1, // min/max limits of each plot y-axis on each row will be automatically linked
+    ImPlotSubplotFlags_LinkCols     = 1 << 2, // min/max limits of each plot x-axis on each column will be automatically linked
+    ImPlotSubplotFlags_LinkAllX     = 1 << 3, // link all x-axes in every plot (overrides _LinkCols)
+    ImPlotSubplotFlags_LinkAllY     = 1 << 4, // link all y-axes in every plot (overrides _LinkRows)
+    ImPlotSubplotFlags_MultiFrame   = 1 << 5, // a background frame will be rendered for each plot instead of a single frame
+    ImPlotSubplotFlags_Tight        = 1 << 6, // tight layout, i.e. no margines between plots
+    ImPlotSubplotFlags_NoAlign      = 1 << 7,  // subplot edges will not be aligned vertically or horizontally
+    ImPlotSubplotFlags_SharedLegend = 1 << 8,
 };
 
 // Options for plot axes (X and Y).
@@ -397,7 +399,7 @@ IMPLOT_API void EndPlot();
 // Begin/EndSubplots
 //-----------------------------------------------------------------------------
 
-IMPLOT_API bool BeginSubplots(const char* id,
+IMPLOT_API bool BeginSubplots(const char* title_id,
                              int rows,
                              int cols,
                              const ImVec2& size,

--- a/implot.h
+++ b/implot.h
@@ -115,7 +115,8 @@ enum ImPlotSubplotFlags_ {
     ImPlotSubplotFlags_LinkRows    = 1 << 6,  // link the y-axis limits of all plots in each row (does not apply auxiliary y-axes)
     ImPlotSubplotFlags_LinkCols    = 1 << 7,  // link the x-axis limits of all plots in each column
     ImPlotSubplotFlags_LinkAllX    = 1 << 8,  // link the x-axis limits in every plot in the subplot
-    ImPlotSubplotFlags_LinkAllY    = 1 << 9   // link the y-axis limits in every plot in the subplot (does not apply to auxiliary y-axes)
+    ImPlotSubplotFlags_LinkAllY    = 1 << 9 , // link the y-axis limits in every plot in the subplot (does not apply to auxiliary y-axes)
+    ImPlotSubplotFlags_ColMajor    = 1 << 10  // subplots are added in column major order instead of the default row major order
 };
 
 // Plot styling colors.

--- a/implot.h
+++ b/implot.h
@@ -52,16 +52,17 @@
 struct ImPlotContext;          // ImPlot context (opaque struct, see implot_internal.h)
 
 // Enums/Flags
-typedef int ImPlotFlags;       // -> enum ImPlotFlags_
-typedef int ImPlotAxisFlags;   // -> enum ImPlotAxisFlags_
-typedef int ImPlotCol;         // -> enum ImPlotCol_
-typedef int ImPlotStyleVar;    // -> enum ImPlotStyleVar_
-typedef int ImPlotMarker;      // -> enum ImPlotMarker_
-typedef int ImPlotColormap;    // -> enum ImPlotColormap_
-typedef int ImPlotLocation;    // -> enum ImPlotLocation_
-typedef int ImPlotOrientation; // -> enum ImPlotOrientation_
-typedef int ImPlotYAxis;       // -> enum ImPlotYAxis_;
-typedef int ImPlotBin;         // -> enum ImPlotBin_
+typedef int ImPlotFlags;        // -> enum ImPlotFlags_
+typedef int ImPlotAxisFlags;    // -> enum ImPlotAxisFlags_
+typedef int ImPlotSubplotFlags; // -> enum ImPlotSubplotFlags_
+typedef int ImPlotCol;          // -> enum ImPlotCol_
+typedef int ImPlotStyleVar;     // -> enum ImPlotStyleVar_
+typedef int ImPlotMarker;       // -> enum ImPlotMarker_
+typedef int ImPlotColormap;     // -> enum ImPlotColormap_
+typedef int ImPlotLocation;     // -> enum ImPlotLocation_
+typedef int ImPlotOrientation;  // -> enum ImPlotOrientation_
+typedef int ImPlotYAxis;        // -> enum ImPlotYAxis_;
+typedef int ImPlotBin;          // -> enum ImPlotBin_
 
 // Options for plots.
 enum ImPlotFlags_ {
@@ -80,6 +81,14 @@ enum ImPlotFlags_ {
     ImPlotFlags_Crosshairs    = 1 << 11, // the default mouse cursor will be replaced with a crosshair when hovered
     ImPlotFlags_AntiAliased   = 1 << 12, // plot lines will be software anti-aliased (not recommended for high density plots, prefer MSAA)
     ImPlotFlags_CanvasOnly    = ImPlotFlags_NoTitle | ImPlotFlags_NoLegend | ImPlotFlags_NoMenus | ImPlotFlags_NoBoxSelect | ImPlotFlags_NoMousePos
+};
+
+// Options for subplots
+enum ImPlotSubplotFlags_ {
+    ImPlotSubplotFlags_None     = 0,      // default
+    ImPlotSubplotFlags_LinkRows = 1 << 0, // min/max limits of each plot y-axis on each row will be automatically linked
+    ImPlotSubplotFlags_LinkCols = 1 << 1, // min/max limits of each plot x-axis on each column will be automatically linked
+    ImPlotSubplotFlags_MultiBg  = 1 << 2, // a background frame will be rendered for each plot instead of a single frame
 };
 
 // Options for plot axes (X and Y).
@@ -379,6 +388,18 @@ IMPLOT_API bool BeginPlot(const char* title_id,
 // Only call EndPlot() if BeginPlot() returns true! Typically called at the end
 // of an if statement conditioned on BeginPlot(). See example above.
 IMPLOT_API void EndPlot();
+
+//-----------------------------------------------------------------------------
+// Begin/EndSubplot
+//-----------------------------------------------------------------------------
+
+IMPLOT_API bool BeginSubplot(const char* id,
+                             int rows,
+                             int cols,
+                             const ImVec2& size,
+                             ImPlotSubplotFlags flags = ImPlotSubplotFlags_None);
+
+IMPLOT_API void EndSubplot();
 
 //-----------------------------------------------------------------------------
 // Plot Items

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1420,8 +1420,11 @@ void ShowDemoWindow(bool* p_open) {
     }
     //-------------------------------------------------------------------------
     if (ImGui::CollapsingHeader("Custom Ticks##")) {
-        static bool custom_ticks  = true;
+        static bool custom_fmt    = true;
+        static bool custom_ticks  = false;
         static bool custom_labels = true;
+        ImGui::Checkbox("Show Custom Format", &custom_fmt);
+        ImGui::SameLine();
         ImGui::Checkbox("Show Custom Ticks", &custom_ticks);
         if (custom_ticks) {
             ImGui::SameLine();
@@ -1433,11 +1436,17 @@ void ShowDemoWindow(bool* p_open) {
         static const char*  ylabels[] = {"One","Three","Seven","Nine"};
         static double yticks_aux[] = {0.2,0.4,0.6};
         static const char* ylabels_aux[] = {"A","B","C","D","E","F"};
+        if (custom_fmt) {
+            ImPlot::SetNextPlotFormatX("%g ms");
+            ImPlot::SetNextPlotFormatY("%g Hz", ImPlotYAxis_1);
+            ImPlot::SetNextPlotFormatY("%g dB", ImPlotYAxis_2);
+            ImPlot::SetNextPlotFormatY("%g km", ImPlotYAxis_3);
+        }
         if (custom_ticks) {
             ImPlot::SetNextPlotTicksX(&pi,1,custom_labels ? pi_str : NULL, true);
-            ImPlot::SetNextPlotTicksY(yticks, 4, custom_labels ? ylabels : NULL);
-            ImPlot::SetNextPlotTicksY(yticks_aux, 3, custom_labels ? ylabels_aux : NULL, false, 1);
-            ImPlot::SetNextPlotTicksY(0, 1, 6, custom_labels ? ylabels_aux : NULL, false, 2);
+            ImPlot::SetNextPlotTicksY(yticks, 4, custom_labels ? ylabels : NULL, ImPlotYAxis_1);
+            ImPlot::SetNextPlotTicksY(yticks_aux, 3, custom_labels ? ylabels_aux : NULL, false, ImPlotYAxis_2);
+            ImPlot::SetNextPlotTicksY(0, 1, 6, custom_labels ? ylabels_aux : NULL, false, ImPlotYAxis_3);
         }
         ImPlot::SetNextPlotLimits(2.5,5,0,10);
         if (ImPlot::BeginPlot("Custom Ticks", NULL, NULL, ImVec2(-1,0), ImPlotFlags_YAxis2 | ImPlotFlags_YAxis3)) {
@@ -1545,8 +1554,9 @@ void ShowDemoWindow(bool* p_open) {
         ImGui::SameLine(); ImGui::ColorEdit4("##Bull", &bullCol.x, ImGuiColorEditFlags_NoInputs);
         ImGui::SameLine(); ImGui::ColorEdit4("##Bear", &bearCol.x, ImGuiColorEditFlags_NoInputs);
         ImPlot::GetStyle().UseLocalTime = false;
+        ImPlot::SetNextPlotFormatY("$%.0f");
         ImPlot::SetNextPlotLimits(1546300800, 1571961600, 1250, 1600);
-        if (ImPlot::BeginPlot("Candlestick Chart","Day","USD",ImVec2(-1,0),0,ImPlotAxisFlags_Time)) {
+        if (ImPlot::BeginPlot("Candlestick Chart",NULL,NULL,ImVec2(-1,0),0,ImPlotAxisFlags_Time)) {
             MyImPlot::PlotCandlestick("GOOGL",dates, opens, closes, lows, highs, 218, tooltip, 0.25f, bullCol, bearCol);
             ImPlot::EndPlot();
         }

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -248,11 +248,6 @@ void ShowDemoWindow(bool* p_open) {
         ImGui::BulletText("ImGuiBackendFlags_RendererHasVtxOffset: %s", (ImGui::GetIO().BackendFlags & ImGuiBackendFlags_RendererHasVtxOffset) ? "True" : "False");
         ImGui::Unindent();
         ImGui::Unindent();
-#ifdef IMPLOT_DEMO_USE_DOUBLE
-        ImGui::BulletText("The demo data precision is: double");
-#else
-        ImGui::BulletText("The demo data precision is: float");
-#endif
         ImGui::Separator();
         ImGui::Text("USER GUIDE:");
         ShowUserGuide();
@@ -595,7 +590,7 @@ void ShowDemoWindow(bool* p_open) {
         static bool outliers   = true;
         static double mu       = 5;
         static double sigma    = 2;
-  
+
         ImGui::SetNextItemWidth(200);
         if (ImGui::RadioButton("Sqrt",bins==ImPlotBin_Sqrt))       { bins = ImPlotBin_Sqrt;    } ImGui::SameLine();
         if (ImGui::RadioButton("Sturges",bins==ImPlotBin_Sturges)) { bins = ImPlotBin_Sturges; } ImGui::SameLine();
@@ -759,19 +754,20 @@ void ShowDemoWindow(bool* p_open) {
         rdata1.Span = history;
         rdata2.Span = history;
 
-        static ImPlotAxisFlags rt_axis = ImPlotAxisFlags_NoTickLabels;
+        static ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
         ImPlot::SetNextPlotLimitsX(t - history, t, ImGuiCond_Always);
         ImPlot::SetNextPlotLimitsY(0,1);
-        if (ImPlot::BeginPlot("##Scrolling", NULL, NULL, ImVec2(-1,150), 0, rt_axis, rt_axis | ImPlotAxisFlags_LockMin)) {
-            ImPlot::PlotShaded("Data 1", &sdata1.Data[0].x, &sdata1.Data[0].y, sdata1.Data.size(), 0, sdata1.Offset, 2 * sizeof(float));
-            ImPlot::PlotLine("Data 2", &sdata2.Data[0].x, &sdata2.Data[0].y, sdata2.Data.size(), sdata2.Offset, 2*sizeof(float));
+        if (ImPlot::BeginPlot("##Scrolling", NULL, NULL, ImVec2(-1,150), 0, flags, flags)) {
+            ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL,0.5f);
+            ImPlot::PlotShaded("Mouse X", &sdata1.Data[0].x, &sdata1.Data[0].y, sdata1.Data.size(), -INFINITY, sdata1.Offset, 2 * sizeof(float));
+            ImPlot::PlotLine("Mouse Y", &sdata2.Data[0].x, &sdata2.Data[0].y, sdata2.Data.size(), sdata2.Offset, 2*sizeof(float));
             ImPlot::EndPlot();
         }
         ImPlot::SetNextPlotLimitsX(0, history, ImGuiCond_Always);
         ImPlot::SetNextPlotLimitsY(0,1);
-        if (ImPlot::BeginPlot("##Rolling", NULL, NULL, ImVec2(-1,150), 0, rt_axis, rt_axis)) {
-            ImPlot::PlotLine("Data 1", &rdata1.Data[0].x, &rdata1.Data[0].y, rdata1.Data.size(), 0, 2 * sizeof(float));
-            ImPlot::PlotLine("Data 2", &rdata2.Data[0].x, &rdata2.Data[0].y, rdata2.Data.size(), 0, 2 * sizeof(float));
+        if (ImPlot::BeginPlot("##Rolling", NULL, NULL, ImVec2(-1,150), 0, flags, flags)) {
+            ImPlot::PlotLine("Mouse X", &rdata1.Data[0].x, &rdata1.Data[0].y, rdata1.Data.size(), 0, 2 * sizeof(float));
+            ImPlot::PlotLine("Mouse Y", &rdata2.Data[0].x, &rdata2.Data[0].y, rdata2.Data.size(), 0, 2 * sizeof(float));
             ImPlot::EndPlot();
         }
     }
@@ -958,7 +954,7 @@ void ShowDemoWindow(bool* p_open) {
     //-------------------------------------------------------------------------
     if (ImGui::CollapsingHeader("Querying")) {
         static ImVector<ImPlotPoint> data;
-        static ImPlotLimits range, query;
+        static ImPlotLimits range, query, select;
 
         ImGui::BulletText("Ctrl + click in the plot area to draw points.");
         ImGui::BulletText("Middle click (or Ctrl + right click) and drag to create a query rect.");
@@ -993,12 +989,14 @@ void ShowDemoWindow(bool* p_open) {
                     ImPlot::PlotScatter("Average", &avg.x, &avg.y, 1);
                 }
             }
-            range = ImPlot::GetPlotLimits();
-            query = ImPlot::GetPlotQuery();
+            range  = ImPlot::GetPlotLimits();
+            query  = ImPlot::GetPlotQuery();
+            select = ImPlot::GetPlotSelection();
             ImPlot::EndPlot();
         }
-        ImGui::Text("The current plot limits are:  [%g,%g,%g,%g]", range.X.Min, range.X.Max, range.Y.Min, range.Y.Max);
-        ImGui::Text("The current query limits are: [%g,%g,%g,%g]", query.X.Min, query.X.Max, query.Y.Min, query.Y.Max);
+        ImGui::Text("Limits: [%g,%g,%g,%g]", range.X.Min, range.X.Max, range.Y.Min, range.Y.Max);
+        ImGui::Text("Query: [%g,%g,%g,%g]", query.X.Min, query.X.Max, query.Y.Min, query.Y.Max);
+        ImGui::Text("Selection: [%g,%g,%g,%g]", select.X.Min, select.X.Max, select.Y.Min, select.Y.Max);
 
         ImGui::Separator();
 

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1586,7 +1586,7 @@ void ShowDemoWindow(bool* p_open) {
         ImPlot::GetStyle().UseLocalTime = false;
         ImPlot::SetNextPlotFormatY("$%.0f");
         ImPlot::SetNextPlotLimits(1546300800, 1571961600, 1250, 1600);
-        if (ImPlot::BeginPlot("Candlestick Chart",NULL,NULL,ImVec2(-1,0),0,ImPlotAxisFlags_Time)) {
+        if (ImPlot::BeginPlot("Candlestick Chart",NULL,NULL,ImVec2(-1,0),0,ImPlotAxisFlags_Time,ImPlotAxisFlags_AutoFit|ImPlotAxisFlags_RangeFit)) {
             MyImPlot::PlotCandlestick("GOOGL",dates, opens, closes, lows, highs, 218, tooltip, 0.25f, bullCol, bearCol);
             ImPlot::EndPlot();
         }

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -654,8 +654,9 @@ void ShowDemoWindow(bool* p_open) {
         static NormalDistribution<500000> dist1(1, 2);
         static NormalDistribution<500000> dist2(1, 1);
         double max_count = 0;
-        ImPlot::PushColormap("Twilight");
-        if (ImPlot::BeginPlot("##Hist2D",0,0,ImVec2(ImGui::GetContentRegionAvail().x-100-ImGui::GetStyle().ItemSpacing.x,0),0,ImPlotAxisFlags_AutoFit,ImPlotAxisFlags_AutoFit)) {
+        ImPlotAxisFlags flags = ImPlotAxisFlags_AutoFit|ImPlotAxisFlags_Foreground;
+        ImPlot::PushColormap("Hot");
+        if (ImPlot::BeginPlot("##Hist2D",0,0,ImVec2(ImGui::GetContentRegionAvail().x-100-ImGui::GetStyle().ItemSpacing.x,0),0,flags,flags)) {
             max_count = ImPlot::PlotHistogram2D("Hist2D",dist1.Data,dist2.Data,count,xybins[0],xybins[1],density2,ImPlotLimits(-6,6,-6,6));
             ImPlot::EndPlot();
         }
@@ -950,6 +951,35 @@ void ShowDemoWindow(bool* p_open) {
             ImPlot::PlotLine("Circle",xs,ys,1000);
             ImPlot::EndPlot();
         }
+    }
+    //-------------------------------------------------------------------------
+    if (ImGui::CollapsingHeader("Auto-Fitting Data")) {
+
+        ImGui::BulletText("The Y-axis has been configured to auto-fit to only the data visible in X-axis range.");
+        ImGui::BulletText("Zoom and pan the X-axis. Disable Stems to see a difference in fit.");
+        ImGui::BulletText("If ImPlotAxisFlags_RangeFit is disabled, the axis will fit ALL data.");
+
+        static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
+        static ImPlotAxisFlags yflags = ImPlotAxisFlags_AutoFit|ImPlotAxisFlags_RangeFit;
+
+        ImGui::TextUnformatted("X: "); ImGui::SameLine();
+        ImGui::CheckboxFlags("ImPlotAxisFlags_AutoFit##X", (unsigned int*)&xflags, ImPlotAxisFlags_AutoFit); ImGui::SameLine();
+        ImGui::CheckboxFlags("ImPlotAxisFlags_RangeFit##X", (unsigned int*)&xflags, ImPlotAxisFlags_RangeFit);
+
+        ImGui::TextUnformatted("Y: "); ImGui::SameLine();
+        ImGui::CheckboxFlags("ImPlotAxisFlags_AutoFit##Y", (unsigned int*)&yflags, ImPlotAxisFlags_AutoFit); ImGui::SameLine();
+        ImGui::CheckboxFlags("ImPlotAxisFlags_RangeFit##Y", (unsigned int*)&yflags, ImPlotAxisFlags_RangeFit);
+
+        static double data[101];
+        srand(0);
+        for (int i = 0; i < 101; ++i)
+            data[i] = 1 + sin(i/10.0f);
+
+        if (ImPlot::BeginPlot("##DataFitting","X","Y",ImVec2(-1,0),0,xflags,yflags)) {
+            ImPlot::PlotLine("Line",data,101);
+            ImPlot::PlotStems("Stems",data,101);
+            ImPlot::EndPlot();
+        };
     }
     //-------------------------------------------------------------------------
     if (ImGui::CollapsingHeader("Querying")) {

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -552,7 +552,7 @@ void ShowDemo_Heatmaps() {
 
 }
 
-void ShowDemo_Histograms() {
+void ShowDemo_Histogram() {
     static int  bins       = 50;
     static bool cumulative = false;
     static bool density    = true;
@@ -612,7 +612,9 @@ void ShowDemo_Histograms() {
             ImPlot::PlotLine("Theoretical",x,y,100);
         ImPlot::EndPlot();
     }
+}
 
+void ShowDemo_Histogram2D() {
     static int count     = 500000;
     static int xybins[2] = {200,200};
     static bool density2 = false;
@@ -625,6 +627,7 @@ void ShowDemo_Histograms() {
     double max_count = 0;
     ImPlotAxisFlags flags = ImPlotAxisFlags_AutoFit|ImPlotAxisFlags_Foreground;
     ImPlot::PushColormap("Hot");
+    ImPlot::SetNextPlotLimits(-6,6,-6,6);
     if (ImPlot::BeginPlot("##Hist2D",0,0,ImVec2(ImGui::GetContentRegionAvail().x-100-ImGui::GetStyle().ItemSpacing.x,0),0,flags,flags)) {
         max_count = ImPlot::PlotHistogram2D("Hist2D",dist1.Data,dist2.Data,count,xybins[0],xybins[1],density2,ImPlotLimits(-6,6,-6,6));
         ImPlot::EndPlot();
@@ -1036,16 +1039,27 @@ void ShowDemo_SubplotAxisLinking() {
 void ShowDemo_Querying() {
     static ImVector<ImPlotPoint> data;
     static ImPlotLimits range, query, select;
+    static bool init = true;
+    if (init) {
+        for (int i = 0; i < 50; ++i)
+        {
+            double x = RandomRange(0.0, 1.0);
+            double y = RandomRange(0.0, 1.0);
+            data.push_back(ImPlotPoint(x,y));
+        }
+        init = false;
+    }
 
-    ImGui::BulletText("Ctrl + click in the plot area to draw points.");
     ImGui::BulletText("Middle click (or Ctrl + right click) and drag to create a query rect.");
     ImGui::Indent();
         ImGui::BulletText("Hold Alt to expand query horizontally.");
         ImGui::BulletText("Hold Shift to expand query vertically.");
         ImGui::BulletText("The query rect can be dragged after it's created.");
     ImGui::Unindent();
+    ImGui::BulletText("Ctrl + click in the plot area to draw points.");
 
-    if (ImPlot::BeginPlot("##Drawing", NULL, NULL, ImVec2(-1,0), ImPlotFlags_Query, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations)) {
+    ImPlot::SetNextPlotLimits(0,1,0,1);
+    if (ImPlot::BeginPlot("##Centroid", NULL, NULL, ImVec2(-1,0), ImPlotFlags_Query)) {
         if (ImPlot::IsPlotHovered() && ImGui::IsMouseClicked(0) && ImGui::GetIO().KeyCtrl) {
             ImPlotPoint pt = ImPlot::GetPlotMousePos();
             data.push_back(pt);
@@ -1067,7 +1081,7 @@ void ShowDemo_Querying() {
                 avg.x = avg.x / cnt;
                 avg.y = avg.y / cnt;
                 ImPlot::SetNextMarkerStyle(ImPlotMarker_Square);
-                ImPlot::PlotScatter("Average", &avg.x, &avg.y, 1);
+                ImPlot::PlotScatter("Centroid", &avg.x, &avg.y, 1);
             }
         }
         range  = ImPlot::GetPlotLimits();
@@ -1078,10 +1092,9 @@ void ShowDemo_Querying() {
     ImGui::Text("Limits: [%g,%g,%g,%g]", range.X.Min, range.X.Max, range.Y.Min, range.Y.Max);
     ImGui::Text("Query: [%g,%g,%g,%g]", query.X.Min, query.X.Max, query.Y.Min, query.Y.Max);
     ImGui::Text("Selection: [%g,%g,%g,%g]", select.X.Min, select.X.Max, select.Y.Min, select.Y.Max);
+}
 
-    ImGui::Separator();
-
-    // mimic's soulthread's imgui_plot demo
+void ShowDemo_Views() {
     static float x_data[512];
     static float y_data1[512];
     static float y_data2[512];
@@ -1734,8 +1747,10 @@ void ShowDemoWindow(bool* p_open) {
                 ShowDemo_PieCharts();
             if (ImGui::CollapsingHeader("Heatmaps"))
                 ShowDemo_Heatmaps();
-            if (ImGui::CollapsingHeader("Histograms"))
-                ShowDemo_Histograms();
+            if (ImGui::CollapsingHeader("Histogram"))
+                ShowDemo_Histogram();
+            if (ImGui::CollapsingHeader("Histogram 2D"))
+                ShowDemo_Histogram2D();
             if (ImGui::CollapsingHeader("Digital Plots"))
                 ShowDemo_DigitalPlots();
             if (ImGui::CollapsingHeader("Images"))
@@ -1777,10 +1792,12 @@ void ShowDemoWindow(bool* p_open) {
                 ShowDemo_OffsetAndStride();
             if (ImGui::CollapsingHeader("Querying"))
                 ShowDemo_Querying();
+            if (ImGui::CollapsingHeader("Views"))
+                ShowDemo_Views();
             if (ImGui::CollapsingHeader("Drag Lines"))
                 ShowDemo_DragLines();
             if (ImGui::CollapsingHeader("Drag Points"))
-                ShowDemo_DragLines();
+                ShowDemo_DragPoints();
             if (ImGui::CollapsingHeader("Annotations"))
                 ShowDemo_Annotations();
             if (ImGui::CollapsingHeader("Drag and Drop"))

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -174,8 +174,1485 @@ struct HugeTimeData {
     static const int Size = 60*60*24*366;
 };
 
+//-----------------------------------------------------------------------------
+// DEMOS
+//-----------------------------------------------------------------------------
+
+void ShowDemo_Help() {
+    ImGui::Text("ABOUT THIS DEMO:");
+    ImGui::BulletText("Sections below are demonstrating many aspects of the library.");
+    ImGui::BulletText("The \"Tools\" menu above gives access to: Style Editors (ImPlot/ImGui)\n"
+                        "and Metrics (general purpose Dear ImGui debugging tool).");
+    ImGui::Separator();
+    ImGui::Text("PROGRAMMER GUIDE:");
+    ImGui::BulletText("See the ShowDemoWindow() code in implot_demo.cpp. <- you are here!");
+    ImGui::BulletText("By default, anti-aliased lines are turned OFF.");
+    ImGui::Indent();
+        ImGui::BulletText("Software AA can be enabled globally with ImPlotStyle.AntiAliasedLines.");
+        ImGui::BulletText("Software AA can be enabled per plot with ImPlotFlags_AntiAliased.");
+        ImGui::BulletText("AA for plots can be toggled from the plot's context menu.");
+        ImGui::BulletText("If permitable, you are better off using hardware AA (e.g. MSAA).");
+    ImGui::Unindent();
+    ImGui::BulletText("If you see visual artifacts, do one of the following:");
+    ImGui::Indent();
+    ImGui::BulletText("Handle ImGuiBackendFlags_RendererHasVtxOffset for 16-bit indices in your backend.");
+    ImGui::BulletText("Or, enable 32-bit indices in imconfig.h.");
+    ImGui::BulletText("Your current configuration is:");
+    ImGui::Indent();
+    ImGui::BulletText("ImDrawIdx: %d-bit", (int)(sizeof(ImDrawIdx) * 8));
+    ImGui::BulletText("ImGuiBackendFlags_RendererHasVtxOffset: %s", (ImGui::GetIO().BackendFlags & ImGuiBackendFlags_RendererHasVtxOffset) ? "True" : "False");
+    ImGui::Unindent();
+    ImGui::Unindent();
+    ImGui::Separator();
+    ImGui::Text("USER GUIDE:");
+    ShowUserGuide();
+}
+
+//-----------------------------------------------------------------------------
+
+void ShowDemo_Configuration() {
+    ImGui::ShowFontSelector("Font");
+    ImGui::ShowStyleSelector("ImGui Style");
+    ImPlot::ShowStyleSelector("ImPlot Style");
+    ImPlot::ShowColormapSelector("ImPlot Colormap");
+    float indent = ImGui::CalcItemWidth() - ImGui::GetFrameHeight();
+    ImGui::Indent(ImGui::CalcItemWidth() - ImGui::GetFrameHeight());
+    ImGui::Checkbox("Anti-Aliased Lines", &ImPlot::GetStyle().AntiAliasedLines);
+    ImGui::Unindent(indent);
+}
+
+//-----------------------------------------------------------------------------
+
+void ShowDemo_LinePlots() {
+    static float xs1[1001], ys1[1001];
+    for (int i = 0; i < 1001; ++i) {
+        xs1[i] = i * 0.001f;
+        ys1[i] = 0.5f + 0.5f * sinf(50 * (xs1[i] + (float)ImGui::GetTime() / 10));
+    }
+    static double xs2[11], ys2[11];
+    for (int i = 0; i < 11; ++i) {
+        xs2[i] = i * 0.1f;
+        ys2[i] = xs2[i] * xs2[i];
+    }
+    ImGui::BulletText("Anti-aliasing can be enabled from the plot's context menu (see Help).");
+    if (ImPlot::BeginPlot("Line Plot", "x", "f(x)")) {
+        ImPlot::PlotLine("sin(x)", xs1, ys1, 1001);
+        ImPlot::SetNextMarkerStyle(ImPlotMarker_Circle);
+        ImPlot::PlotLine("x^2", xs2, ys2, 11);
+        ImPlot::EndPlot();
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+void ShowDemo_FilledLinePlots() {
+    static double xs1[101], ys1[101], ys2[101], ys3[101];
+    srand(0);
+    for (int i = 0; i < 101; ++i) {
+        xs1[i] = (float)i;
+        ys1[i] = RandomRange(400.0,450.0);
+        ys2[i] = RandomRange(275.0,350.0);
+        ys3[i] = RandomRange(150.0,225.0);
+    }
+    static bool show_lines = true;
+    static bool show_fills = true;
+    static float fill_ref = 0;
+    static int shade_mode = 0;
+    ImGui::Checkbox("Lines",&show_lines); ImGui::SameLine();
+    ImGui::Checkbox("Fills",&show_fills);
+    if (show_fills) {
+        ImGui::SameLine();
+        if (ImGui::RadioButton("To -INF",shade_mode == 0))
+            shade_mode = 0;
+        ImGui::SameLine();
+        if (ImGui::RadioButton("To +INF",shade_mode == 1))
+            shade_mode = 1;
+        ImGui::SameLine();
+        if (ImGui::RadioButton("To Ref",shade_mode == 2))
+            shade_mode = 2;
+        if (shade_mode == 2) {
+            ImGui::SameLine();
+            ImGui::SetNextItemWidth(100);
+            ImGui::DragFloat("##Ref",&fill_ref, 1, -100, 500);
+        }
+    }
+
+    ImPlot::SetNextPlotLimits(0,100,0,500);
+    if (ImPlot::BeginPlot("Stock Prices", "Days", "Price")) {
+        if (show_fills) {
+            ImPlot::PushStyleVar(ImPlotStyleVar_FillAlpha, 0.25f);
+            ImPlot::PlotShaded("Stock 1", xs1, ys1, 101, shade_mode == 0 ? -INFINITY : shade_mode == 1 ? INFINITY : fill_ref);
+            ImPlot::PlotShaded("Stock 2", xs1, ys2, 101, shade_mode == 0 ? -INFINITY : shade_mode == 1 ? INFINITY : fill_ref);
+            ImPlot::PlotShaded("Stock 3", xs1, ys3, 101, shade_mode == 0 ? -INFINITY : shade_mode == 1 ? INFINITY : fill_ref);
+            ImPlot::PopStyleVar();
+        }
+        if (show_lines) {
+            ImPlot::PlotLine("Stock 1", xs1, ys1, 101);
+            ImPlot::PlotLine("Stock 2", xs1, ys2, 101);
+            ImPlot::PlotLine("Stock 3", xs1, ys3, 101);
+        }
+        ImPlot::EndPlot();
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+void ShowDemo_ShadedPlots() {
+    static float xs[1001], ys[1001], ys1[1001], ys2[1001], ys3[1001], ys4[1001];
+    srand(0);
+    for (int i = 0; i < 1001; ++i) {
+        xs[i]  = i * 0.001f;
+        ys[i]  = 0.25f + 0.25f * sinf(25 * xs[i]) * sinf(5 * xs[i]) + RandomRange(-0.01f, 0.01f);
+        ys1[i] = ys[i] + RandomRange(0.1f, 0.12f);
+        ys2[i] = ys[i] - RandomRange(0.1f, 0.12f);
+        ys3[i] = 0.75f + 0.2f * sinf(25 * xs[i]);
+        ys4[i] = 0.75f + 0.1f * cosf(25 * xs[i]);
+    }
+    static float alpha = 0.25f;
+    ImGui::DragFloat("Alpha",&alpha,0.01f,0,1);
+
+    if (ImPlot::BeginPlot("Shaded Plots", "X-Axis", "Y-Axis")) {
+        ImPlot::PushStyleVar(ImPlotStyleVar_FillAlpha, alpha);
+        ImPlot::PlotShaded("Uncertain Data",xs,ys1,ys2,1001);
+        ImPlot::PlotLine("Uncertain Data", xs, ys, 1001);
+        ImPlot::PlotShaded("Overlapping",xs,ys3,ys4,1001);
+        ImPlot::PlotLine("Overlapping",xs,ys3,1001);
+        ImPlot::PlotLine("Overlapping",xs,ys4,1001);
+        ImPlot::PopStyleVar();
+        ImPlot::EndPlot();
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+void ShowDemo_ScatterPlots() {
+    srand(0);
+    static float xs1[100], ys1[100];
+    for (int i = 0; i < 100; ++i) {
+        xs1[i] = i * 0.01f;
+        ys1[i] = xs1[i] + 0.1f * ((float)rand() / (float)RAND_MAX);
+    }
+    static float xs2[50], ys2[50];
+    for (int i = 0; i < 50; i++) {
+        xs2[i] = 0.25f + 0.2f * ((float)rand() / (float)RAND_MAX);
+        ys2[i] = 0.75f + 0.2f * ((float)rand() / (float)RAND_MAX);
+    }
+
+    if (ImPlot::BeginPlot("Scatter Plot", NULL, NULL)) {
+        ImPlot::PlotScatter("Data 1", xs1, ys1, 100);
+        ImPlot::PushStyleVar(ImPlotStyleVar_FillAlpha, 0.25f);
+        ImPlot::SetNextMarkerStyle(ImPlotMarker_Square, 6, ImVec4(0,1,0,0.5f), IMPLOT_AUTO, ImVec4(0,1,0,1));
+        ImPlot::PlotScatter("Data 2", xs2, ys2, 50);
+        ImPlot::PopStyleVar();
+        ImPlot::EndPlot();
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+void ShowDemo_StairstepPlots() {
+    static float ys1[101], ys2[101];
+    for (int i = 0; i < 101; ++i) {
+        ys1[i] = 0.5f + 0.4f * sinf(50 * i * 0.01f);
+        ys2[i] = 0.5f + 0.2f * sinf(25 * i * 0.01f);
+    }
+    if (ImPlot::BeginPlot("Stairstep Plot", "x", "f(x)")) {
+        ImPlot::PlotStairs("Signal 1", ys1, 101, 0.01f);
+        ImPlot::SetNextMarkerStyle(ImPlotMarker_Square, 2.0f);
+        ImPlot::PlotStairs("Signal 2", ys2, 101, 0.01f);
+        ImPlot::EndPlot();
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+void ShowDemo_BarPlots() {
+    static bool horz                = false;
+    static ImS8  midtm[10]          = {83, 67, 23, 89, 83, 78, 91, 82, 85, 90};
+    static ImS16 final[10]          = {80, 62, 56, 99, 55, 78, 88, 78, 90, 100};
+    static ImS32 grade[10]          = {80, 69, 52, 92, 72, 78, 75, 76, 89, 95};
+
+    static const char*  labels[]    = {"S1","S2","S3","S4","S5","S6","S7","S8","S9","S10"};
+    static const double positions[] = {0,1,2,3,4,5,6,7,8,9};
+
+    ImGui::Checkbox("Horizontal",&horz);
+
+    if (horz) {
+        ImPlot::SetNextPlotLimits(0, 110, -0.5, 9.5, ImGuiCond_Always);
+        ImPlot::SetNextPlotTicksY(positions, 10, labels);
+    }
+    else {
+        ImPlot::SetNextPlotLimits(-0.5, 9.5, 0, 110, ImGuiCond_Always);
+        ImPlot::SetNextPlotTicksX(positions, 10, labels);
+    }
+    if (ImPlot::BeginPlot("Bar Plot", horz ? "Score" :  "Student", horz ? "Student" : "Score",
+                            ImVec2(-1,0), 0, 0, horz ? ImPlotAxisFlags_Invert : 0))
+    {
+        if (horz) {
+            ImPlot::SetLegendLocation(ImPlotLocation_West, ImPlotOrientation_Vertical);
+            ImPlot::PlotBarsH("Midterm Exam", midtm, 10, 0.2, -0.2);
+            ImPlot::PlotBarsH("Final Exam",   final, 10, 0.2,    0);
+            ImPlot::PlotBarsH("Course Grade", grade, 10, 0.2,  0.2);
+        }
+        else {
+            ImPlot::SetLegendLocation(ImPlotLocation_South, ImPlotOrientation_Horizontal);
+            ImPlot::PlotBars("Midterm Exam", midtm, 10, 0.2, -0.2);
+            ImPlot::PlotBars("Final Exam",   final, 10, 0.2,    0);
+            ImPlot::PlotBars("Course Grade", grade, 10, 0.2,  0.2);
+        }
+        ImPlot::EndPlot();
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+void ShowDemo_ErrorBars() {
+    static float xs[5]    = {1,2,3,4,5};
+    static float bar[5]   = {1,2,5,3,4};
+    static float lin1[5]  = {8,8,9,7,8};
+    static float lin2[5]  = {6,7,6,9,6};
+    static float err1[5]  = {0.2f, 0.4f, 0.2f, 0.6f, 0.4f};
+    static float err2[5]  = {0.4f, 0.2f, 0.4f, 0.8f, 0.6f};
+    static float err3[5]  = {0.09f, 0.14f, 0.09f, 0.12f, 0.16f};
+    static float err4[5]  = {0.02f, 0.08f, 0.15f, 0.05f, 0.2f};
+
+
+    ImPlot::SetNextPlotLimits(0, 6, 0, 10);
+    if (ImPlot::BeginPlot("##ErrorBars",NULL,NULL)) {
+
+        ImPlot::PlotBars("Bar", xs, bar, 5, 0.5f);
+        ImPlot::PlotErrorBars("Bar", xs, bar, err1, 5);
+
+        ImPlot::SetNextErrorBarStyle(ImPlot::GetColormapColor(1), 0);
+        ImPlot::PlotErrorBars("Line", xs, lin1, err1, err2, 5);
+        ImPlot::SetNextMarkerStyle(ImPlotMarker_Circle);
+        ImPlot::PlotLine("Line", xs, lin1, 5);
+
+        ImPlot::PushStyleColor(ImPlotCol_ErrorBar, ImPlot::GetColormapColor(2));
+        ImPlot::PlotErrorBars("Scatter", xs, lin2, err2, 5);
+        ImPlot::PlotErrorBarsH("Scatter", xs, lin2,  err3, err4, 5);
+        ImPlot::PopStyleColor();
+        ImPlot::PlotScatter("Scatter", xs, lin2, 5);
+
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_StemPlots() {
+    static double xs[51], ys1[51], ys2[51];
+    for (int i = 0; i < 51; ++i) {
+        xs[i] = i * 0.02;
+        ys1[i] = 1.0 + 0.5 * sin(25*xs[i])*cos(2*xs[i]);
+        ys2[i] = 0.5 + 0.25  * sin(10*xs[i]) * sin(xs[i]);
+    }
+    ImPlot::SetNextPlotLimits(0,1,0,1.6);
+    if (ImPlot::BeginPlot("Stem Plots")) {
+        ImPlot::PlotStems("Stems 1",xs,ys1,51);
+        ImPlot::SetNextLineStyle(ImVec4(1,0.5f,0,0.75f));
+        ImPlot::SetNextMarkerStyle(ImPlotMarker_Square,5,ImVec4(1,0.5f,0,0.25f));
+        ImPlot::PlotStems("Stems 2", xs, ys2,51);
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_InfiniteLines() {
+    static double vals[] = {0.25, 0.5, 0.75};
+    if (ImPlot::BeginPlot("##Infinite",0,0,ImVec2(-1,0),0,ImPlotAxisFlags_NoInitialFit,ImPlotAxisFlags_NoInitialFit)) {
+        ImPlot::PlotVLines("VLines",vals,3);
+        ImPlot::PlotHLines("HLines",vals,3);
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_PieCharts() {
+    static const char* labels1[]   = {"Frogs","Hogs","Dogs","Logs"};
+    static float data1[]           = {0.15f,  0.30f,  0.2f, 0.05f};
+    static bool normalize          = false;
+    ImGui::SetNextItemWidth(250);
+    ImGui::DragFloat4("Values", data1, 0.01f, 0, 1);
+    if ((data1[0] + data1[1] + data1[2] + data1[3]) < 1) {
+        ImGui::SameLine();
+        ImGui::Checkbox("Normalize", &normalize);
+    }
+
+    ImPlot::SetNextPlotLimits(0,1,0,1,ImGuiCond_Always);
+    if (ImPlot::BeginPlot("##Pie1", NULL, NULL, ImVec2(250,250), ImPlotFlags_Equal | ImPlotFlags_NoMousePos, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations)) {
+        ImPlot::PlotPieChart(labels1, data1, 4, 0.5, 0.5, 0.4, normalize, "%.2f");
+        ImPlot::EndPlot();
+    }
+
+    ImGui::SameLine();
+
+    static const char* labels2[]   = {"A","B","C","D","E"};
+    static int data2[]             = {1,1,2,3,5};
+
+    ImPlot::PushColormap(ImPlotColormap_Pastel);
+    ImPlot::SetNextPlotLimits(0,1,0,1,ImGuiCond_Always);
+    if (ImPlot::BeginPlot("##Pie2", NULL, NULL, ImVec2(250,250), ImPlotFlags_Equal | ImPlotFlags_NoMousePos, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations)) {
+        ImPlot::PlotPieChart(labels2, data2, 5, 0.5, 0.5, 0.4, true, "%.0f", 180);
+        ImPlot::EndPlot();
+    }
+    ImPlot::PopColormap();
+}
+
+void ShowDemo_Heatmaps() {
+    static float values1[7][7]  = {{0.8f, 2.4f, 2.5f, 3.9f, 0.0f, 4.0f, 0.0f},
+                                    {2.4f, 0.0f, 4.0f, 1.0f, 2.7f, 0.0f, 0.0f},
+                                    {1.1f, 2.4f, 0.8f, 4.3f, 1.9f, 4.4f, 0.0f},
+                                    {0.6f, 0.0f, 0.3f, 0.0f, 3.1f, 0.0f, 0.0f},
+                                    {0.7f, 1.7f, 0.6f, 2.6f, 2.2f, 6.2f, 0.0f},
+                                    {1.3f, 1.2f, 0.0f, 0.0f, 0.0f, 3.2f, 5.1f},
+                                    {0.1f, 2.0f, 0.0f, 1.4f, 0.0f, 1.9f, 6.3f}};
+    static float scale_min       = 0;
+    static float scale_max       = 6.3f;
+    static const char* xlabels[] = {"C1","C2","C3","C4","C5","C6","C7"};
+    static const char* ylabels[] = {"R1","R2","R3","R4","R5","R6","R7"};
+
+    static ImPlotColormap map = ImPlotColormap_Viridis;
+    if (ImPlot::ColormapButton(ImPlot::GetColormapName(map),ImVec2(225,0),map)) {
+        map = (map + 1) % ImPlot::GetColormapCount();
+        // We bust the color cache of our plots so that item colors will
+        // resample the new colormap in the event that they have already
+        // been created. See documentation in implot.h.
+        BustColorCache("##Heatmap1");
+        BustColorCache("##Heatmap2");
+    }
+
+    ImGui::SameLine();
+    ImGui::LabelText("##Colormap Index", "%s", "Change Colormap");
+    ImGui::SetNextItemWidth(225);
+    ImGui::DragFloatRange2("Min / Max",&scale_min, &scale_max, 0.01f, -20, 20);
+    static ImPlotAxisFlags axes_flags = ImPlotAxisFlags_Lock | ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_NoTickMarks;
+
+    ImPlot::PushColormap(map);
+    SetNextPlotTicksX(0 + 1.0/14.0, 1 - 1.0/14.0, 7, xlabels);
+    SetNextPlotTicksY(1 - 1.0/14.0, 0 + 1.0/14.0, 7, ylabels);
+    if (ImPlot::BeginPlot("##Heatmap1",NULL,NULL,ImVec2(225,225),ImPlotFlags_NoLegend|ImPlotFlags_NoMousePos,axes_flags,axes_flags)) {
+        ImPlot::PlotHeatmap("heat",values1[0],7,7,scale_min,scale_max);
+        ImPlot::EndPlot();
+    }
+    ImGui::SameLine();
+    ImPlot::ColormapScale("##HeatScale",scale_min, scale_max, ImVec2(60,225));
+
+    ImGui::SameLine();
+
+    const int size = 200;
+    static double values2[size*size];
+    srand((unsigned int)(ImGui::GetTime()*1000000));
+    for (int i = 0; i < size*size; ++i)
+        values2[i] = RandomRange(0.0,1.0);
+
+    ImPlot::SetNextPlotLimits(-1,1,-1,1);
+    if (ImPlot::BeginPlot("##Heatmap2",NULL,NULL,ImVec2(225,225),0,ImPlotAxisFlags_NoDecorations,ImPlotAxisFlags_NoDecorations)) {
+        ImPlot::PlotHeatmap("heat1",values2,size,size,0,1,NULL);
+        ImPlot::PlotHeatmap("heat2",values2,size,size,0,1,NULL, ImPlotPoint(-1,-1), ImPlotPoint(0,0));
+        ImPlot::EndPlot();
+    }
+    ImPlot::PopColormap();
+
+}
+
+void ShowDemo_Histograms() {
+    static int  bins       = 50;
+    static bool cumulative = false;
+    static bool density    = true;
+    static bool outliers   = true;
+    static double mu       = 5;
+    static double sigma    = 2;
+
+    ImGui::SetNextItemWidth(200);
+    if (ImGui::RadioButton("Sqrt",bins==ImPlotBin_Sqrt))       { bins = ImPlotBin_Sqrt;    } ImGui::SameLine();
+    if (ImGui::RadioButton("Sturges",bins==ImPlotBin_Sturges)) { bins = ImPlotBin_Sturges; } ImGui::SameLine();
+    if (ImGui::RadioButton("Rice",bins==ImPlotBin_Rice))       { bins = ImPlotBin_Rice;    } ImGui::SameLine();
+    if (ImGui::RadioButton("Scott",bins==ImPlotBin_Scott))     { bins = ImPlotBin_Scott;   } ImGui::SameLine();
+    if (ImGui::RadioButton("N Bins",bins>=0))                       bins = 50;
+    if (bins>=0) {
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(200);
+        ImGui::SliderInt("##Bins", &bins, 1, 100);
+    }
+    if (ImGui::Checkbox("Density", &density))
+        ImPlot::FitNextPlotAxes();
+    ImGui::SameLine();
+    if (ImGui::Checkbox("Cumulative", &cumulative))
+        ImPlot::FitNextPlotAxes();
+    ImGui::SameLine();
+    static bool range = false;
+    ImGui::Checkbox("Range", &range);
+    static float rmin = -3;
+    static float rmax = 13;
+    if (range) {
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(200);
+        ImGui::DragFloat2("##Range",&rmin,0.1f,-3,13);
+        ImGui::SameLine();
+        ImGui::Checkbox("Outliers",&outliers);
+    }
+
+    static NormalDistribution<10000> dist(mu, sigma);
+    static double x[100];
+    static double y[100];
+    if (density) {
+        for (int i = 0; i < 100; ++i) {
+            x[i] = -3 + 16 * (double)i/99.0;
+            y[i] = exp( - (x[i]-mu)*(x[i]-mu) / (2*sigma*sigma)) / (sigma * sqrt(2*3.141592653589793238));
+        }
+        if (cumulative) {
+            for (int i = 1; i < 100; ++i)
+                y[i] += y[i-1];
+            for (int i = 0; i < 100; ++i)
+                y[i] /= y[99];
+        }
+    }
+
+    if (ImPlot::BeginPlot("##Histograms")) {
+        ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
+        ImPlot::PlotHistogram("Empirical", dist.Data, 10000, bins, cumulative, density, range ? ImPlotRange(rmin,rmax) : ImPlotRange(), outliers);
+        if (density && outliers)
+            ImPlot::PlotLine("Theoretical",x,y,100);
+        ImPlot::EndPlot();
+    }
+
+    static int count     = 500000;
+    static int xybins[2] = {200,200};
+    static bool density2 = false;
+    ImGui::SliderInt("Count",&count,100,500000);
+    ImGui::SliderInt2("Bins",xybins,1,500);
+    ImGui::SameLine();
+    ImGui::Checkbox("Density##2",&density2);
+    static NormalDistribution<500000> dist1(1, 2);
+    static NormalDistribution<500000> dist2(1, 1);
+    double max_count = 0;
+    ImPlotAxisFlags flags = ImPlotAxisFlags_AutoFit|ImPlotAxisFlags_Foreground;
+    ImPlot::PushColormap("Hot");
+    if (ImPlot::BeginPlot("##Hist2D",0,0,ImVec2(ImGui::GetContentRegionAvail().x-100-ImGui::GetStyle().ItemSpacing.x,0),0,flags,flags)) {
+        max_count = ImPlot::PlotHistogram2D("Hist2D",dist1.Data,dist2.Data,count,xybins[0],xybins[1],density2,ImPlotLimits(-6,6,-6,6));
+        ImPlot::EndPlot();
+    }
+    ImGui::SameLine();
+    ImPlot::ColormapScale(density2 ? "Density" : "Count",0,max_count,ImVec2(100,0));
+    ImPlot::PopColormap();
+}
+
+void ShowDemo_DigitalPlots() {
+    ImGui::BulletText("Digital plots do not respond to Y drag and zoom, so that");
+    ImGui::Indent();
+    ImGui::Text("you can drag analog plots over the rising/falling digital edge.");
+    ImGui::Unindent();
+
+    static bool paused = false;
+    static ScrollingBuffer dataDigital[2];
+    static ScrollingBuffer dataAnalog[2];
+    static bool showDigital[2] = {true, false};
+    static bool showAnalog[2] = {true, false};
+
+    char label[32];
+    ImGui::Checkbox("digital_0", &showDigital[0]); ImGui::SameLine();
+    ImGui::Checkbox("digital_1", &showDigital[1]); ImGui::SameLine();
+    ImGui::Checkbox("analog_0",  &showAnalog[0]);  ImGui::SameLine();
+    ImGui::Checkbox("analog_1",  &showAnalog[1]);
+
+    static float t = 0;
+    if (!paused) {
+        t += ImGui::GetIO().DeltaTime;
+        //digital signal values
+        if (showDigital[0])
+            dataDigital[0].AddPoint(t, sinf(2*t) > 0.45);
+        if (showDigital[1])
+            dataDigital[1].AddPoint(t, sinf(2*t) < 0.45);
+        //Analog signal values
+        if (showAnalog[0])
+            dataAnalog[0].AddPoint(t, sinf(2*t));
+        if (showAnalog[1])
+            dataAnalog[1].AddPoint(t, cosf(2*t));
+    }
+    ImPlot::SetNextPlotLimitsY(-1, 1);
+    ImPlot::SetNextPlotLimitsX(t - 10.0, t, paused ? ImGuiCond_Once : ImGuiCond_Always);
+    if (ImPlot::BeginPlot("##Digital")) {
+        for (int i = 0; i < 2; ++i) {
+            if (showDigital[i] && dataDigital[i].Data.size() > 0) {
+                sprintf(label, "digital_%d", i);
+                ImPlot::PlotDigital(label, &dataDigital[i].Data[0].x, &dataDigital[i].Data[0].y, dataDigital[i].Data.size(), dataDigital[i].Offset, 2 * sizeof(float));
+            }
+        }
+        for (int i = 0; i < 2; ++i) {
+            if (showAnalog[i]) {
+                sprintf(label, "analog_%d", i);
+                if (dataAnalog[i].Data.size() > 0)
+                    ImPlot::PlotLine(label, &dataAnalog[i].Data[0].x, &dataAnalog[i].Data[0].y, dataAnalog[i].Data.size(), dataAnalog[i].Offset, 2 * sizeof(float));
+            }
+        }
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_Images() {
+    ImGui::BulletText("Below we are displaying the font texture, which is the only texture we have\naccess to in this demo.");
+    ImGui::BulletText("Use the 'ImTextureID' type as storage to pass pointers or identifiers to your\nown texture data.");
+    ImGui::BulletText("See ImGui Wiki page 'Image Loading and Displaying Examples'.");
+    static ImVec2 bmin(0,0);
+    static ImVec2 bmax(1,1);
+    static ImVec2 uv0(0,0);
+    static ImVec2 uv1(1,1);
+    static ImVec4 tint(1,1,1,1);
+    ImGui::SliderFloat2("Min", &bmin.x, -2, 2, "%.1f");
+    ImGui::SliderFloat2("Max", &bmax.x, -2, 2, "%.1f");
+    ImGui::SliderFloat2("UV0", &uv0.x, -2, 2, "%.1f");
+    ImGui::SliderFloat2("UV1", &uv1.x, -2, 2, "%.1f");
+    ImGui::ColorEdit4("Tint",&tint.x);
+    if (ImPlot::BeginPlot("##image")) {
+        ImPlot::PlotImage("my image",ImGui::GetIO().Fonts->TexID, bmin, bmax, uv0, uv1, tint);
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_RealtimePlots() {
+    ImGui::BulletText("Move your mouse to change the data!");
+    ImGui::BulletText("This example assumes 60 FPS. Higher FPS requires larger buffer size.");
+    static ScrollingBuffer sdata1, sdata2;
+    static RollingBuffer   rdata1, rdata2;
+    ImVec2 mouse = ImGui::GetMousePos();
+    static float t = 0;
+    t += ImGui::GetIO().DeltaTime;
+    sdata1.AddPoint(t, mouse.x * 0.0005f);
+    rdata1.AddPoint(t, mouse.x * 0.0005f);
+    sdata2.AddPoint(t, mouse.y * 0.0005f);
+    rdata2.AddPoint(t, mouse.y * 0.0005f);
+
+    static float history = 10.0f;
+    ImGui::SliderFloat("History",&history,1,30,"%.1f s");
+    rdata1.Span = history;
+    rdata2.Span = history;
+
+    static ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
+    ImPlot::SetNextPlotLimitsX(t - history, t, ImGuiCond_Always);
+    ImPlot::SetNextPlotLimitsY(0,1);
+    if (ImPlot::BeginPlot("##Scrolling", NULL, NULL, ImVec2(-1,150), 0, flags, flags)) {
+        ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL,0.5f);
+        ImPlot::PlotShaded("Mouse X", &sdata1.Data[0].x, &sdata1.Data[0].y, sdata1.Data.size(), -INFINITY, sdata1.Offset, 2 * sizeof(float));
+        ImPlot::PlotLine("Mouse Y", &sdata2.Data[0].x, &sdata2.Data[0].y, sdata2.Data.size(), sdata2.Offset, 2*sizeof(float));
+        ImPlot::EndPlot();
+    }
+    ImPlot::SetNextPlotLimitsX(0, history, ImGuiCond_Always);
+    ImPlot::SetNextPlotLimitsY(0,1);
+    if (ImPlot::BeginPlot("##Rolling", NULL, NULL, ImVec2(-1,150), 0, flags, flags)) {
+        ImPlot::PlotLine("Mouse X", &rdata1.Data[0].x, &rdata1.Data[0].y, rdata1.Data.size(), 0, 2 * sizeof(float));
+        ImPlot::PlotLine("Mouse Y", &rdata2.Data[0].x, &rdata2.Data[0].y, rdata2.Data.size(), 0, 2 * sizeof(float));
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_MarkersAndText() {
+    static float mk_size = ImPlot::GetStyle().MarkerSize;
+    static float mk_weight = ImPlot::GetStyle().MarkerWeight;
+    ImGui::DragFloat("Marker Size",&mk_size,0.1f,2.0f,10.0f,"%.2f px");
+    ImGui::DragFloat("Marker Weight", &mk_weight,0.05f,0.5f,3.0f,"%.2f px");
+
+    ImPlot::SetNextPlotLimits(0, 10, 0, 12);
+    if (ImPlot::BeginPlot("##MarkerStyles", NULL, NULL, ImVec2(-1,0), ImPlotFlags_CanvasOnly, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations)) {
+        ImS8 xs[2] = {1,4};
+        ImS8 ys[2] = {10,11};
+
+        // filled markers
+        for (int m = 0; m < ImPlotMarker_COUNT; ++m) {
+            ImGui::PushID(m);
+            ImPlot::SetNextMarkerStyle(m, mk_size, IMPLOT_AUTO_COL, mk_weight);
+            ImPlot::PlotLine("##Filled", xs, ys, 2);
+            ImGui::PopID();
+            ys[0]--; ys[1]--;
+        }
+        xs[0] = 6; xs[1] = 9; ys[0] = 10; ys[1] = 11;
+        // open markers
+        for (int m = 0; m < ImPlotMarker_COUNT; ++m) {
+            ImGui::PushID(m);
+            ImPlot::SetNextMarkerStyle(m, mk_size, ImVec4(0,0,0,0), mk_weight);
+            ImPlot::PlotLine("##Open", xs, ys, 2);
+            ImGui::PopID();
+            ys[0]--; ys[1]--;
+        }
+
+        ImPlot::PlotText("Filled Markers", 2.5f, 6.0f);
+        ImPlot::PlotText("Open Markers",   7.5f, 6.0f);
+
+        ImPlot::PushStyleColor(ImPlotCol_InlayText, ImVec4(1,0,1,1));
+        ImPlot::PlotText("Vertical Text", 5.0f, 6.0f, true);
+        ImPlot::PopStyleColor();
+
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_LogAxes() {
+    static double xs[1001], ys1[1001], ys2[1001], ys3[1001];
+    for (int i = 0; i < 1001; ++i) {
+        xs[i]  = i*0.1f;
+        ys1[i] = sin(xs[i]) + 1;
+        ys2[i] = log(xs[i]);
+        ys3[i] = pow(10.0, xs[i]);
+    }
+    ImGui::BulletText("Open the plot context menu (right click) to change scales.");
+
+    ImPlot::SetNextPlotLimits(0.1, 100, 0, 10);
+    if (ImPlot::BeginPlot("Log Plot", NULL, NULL, ImVec2(-1,0), 0, ImPlotAxisFlags_LogScale )) {
+        ImPlot::PlotLine("f(x) = x",        xs, xs,  1001);
+        ImPlot::PlotLine("f(x) = sin(x)+1", xs, ys1, 1001);
+        ImPlot::PlotLine("f(x) = log(x)",   xs, ys2, 1001);
+        ImPlot::PlotLine("f(x) = 10^x",     xs, ys3, 21);
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_TimeAxes() {
+
+    static double t_min = 1609459200; // 01/01/2021 @ 12:00:00am (UTC)
+    static double t_max = 1640995200; // 01/01/2022 @ 12:00:00am (UTC)
+
+    ImGui::BulletText("When ImPlotAxisFlags_Time is enabled on the X-Axis, values are interpreted as\n"
+                        "UNIX timestamps in seconds and axis labels are formated as date/time.");
+    ImGui::BulletText("By default, labels are in UTC time but can be set to use local time instead.");
+
+    ImGui::Checkbox("Local Time",&ImPlot::GetStyle().UseLocalTime);
+    ImGui::SameLine();
+    ImGui::Checkbox("ISO 8601",&ImPlot::GetStyle().UseISO8601);
+    ImGui::SameLine();
+    ImGui::Checkbox("24 Hour Clock",&ImPlot::GetStyle().Use24HourClock);
+
+    static HugeTimeData* data = NULL;
+    if (data == NULL) {
+        ImGui::SameLine();
+        if (ImGui::Button("Generate Huge Data (~500MB!)")) {
+            static HugeTimeData sdata(t_min);
+            data = &sdata;
+        }
+    }
+
+    ImPlot::SetNextPlotLimits(t_min,t_max,0,1);
+    if (ImPlot::BeginPlot("##Time", NULL, NULL, ImVec2(-1,0), 0, ImPlotAxisFlags_Time)) {
+        if (data != NULL) {
+            // downsample our data
+            int downsample = (int)ImPlot::GetPlotLimits().X.Size() / 1000 + 1;
+            int start = (int)(ImPlot::GetPlotLimits().X.Min - t_min);
+            start = start < 0 ? 0 : start > HugeTimeData::Size - 1 ? HugeTimeData::Size - 1 : start;
+            int end = (int)(ImPlot::GetPlotLimits().X.Max - t_min) + 1000;
+            end = end < 0 ? 0 : end > HugeTimeData::Size - 1 ? HugeTimeData::Size - 1 : end;
+            int size = (end - start)/downsample;
+            // plot it
+            ImPlot::PlotLine("Time Series", &data->Ts[start], &data->Ys[start], size, 0, sizeof(double)*downsample);
+        }
+        // plot time now
+        double t_now = (double)time(0);
+        double y_now = HugeTimeData::GetY(t_now);
+        ImPlot::PlotScatter("Now",&t_now,&y_now,1);
+        ImPlot::Annotate(t_now,y_now,ImVec2(10,10),ImPlot::GetLastItemColor(),"Now");
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_MultipleYAxes() {
+    static float xs[1001], xs2[1001], ys1[1001], ys2[1001], ys3[1001];
+    for (int i = 0; i < 1001; ++i) {
+        xs[i]  = (i*0.1f);
+        ys1[i] = sinf(xs[i]) * 3 + 1;
+        ys2[i] = cosf(xs[i]) * 0.2f + 0.5f;
+        ys3[i] = sinf(xs[i]+0.5f) * 100 + 200;
+        xs2[i] = xs[i] + 10.0f;
+    }
+    static bool y2_axis = true;
+    static bool y3_axis = true;
+    ImGui::Checkbox("Y-Axis 2", &y2_axis);
+    ImGui::SameLine();
+    ImGui::Checkbox("Y-Axis 3", &y3_axis);
+    ImGui::SameLine();
+
+    // you can fit axes programatically
+    ImGui::SameLine(); if (ImGui::Button("Fit X"))  ImPlot::FitNextPlotAxes(true, false, false, false);
+    ImGui::SameLine(); if (ImGui::Button("Fit Y"))  ImPlot::FitNextPlotAxes(false, true, false, false);
+    ImGui::SameLine(); if (ImGui::Button("Fit Y2")) ImPlot::FitNextPlotAxes(false, false, true, false);
+    ImGui::SameLine(); if (ImGui::Button("Fit Y3")) ImPlot::FitNextPlotAxes(false, false, false, true);
+
+    ImPlot::SetNextPlotLimits(0.1, 100, 0, 10);
+    ImPlot::SetNextPlotLimitsY(0, 1, ImGuiCond_Once, 1);
+    ImPlot::SetNextPlotLimitsY(0, 300, ImGuiCond_Once, 2);
+    if (ImPlot::BeginPlot("Multi-Axis Plot", NULL, "Y-Axis 1", ImVec2(-1,0),
+                            (y2_axis ? ImPlotFlags_YAxis2 : 0) |
+                            (y3_axis ? ImPlotFlags_YAxis3 : 0),
+                            ImPlotAxisFlags_None, ImPlotAxisFlags_None, ImPlotAxisFlags_NoGridLines, ImPlotAxisFlags_NoGridLines,
+                            "Y-Axis 2", "Y-Axis 3")) {
+        ImPlot::PlotLine("f(x) = x", xs, xs, 1001);
+        ImPlot::PlotLine("f(x) = sin(x)*3+1", xs, ys1, 1001);
+        if (y2_axis) {
+            ImPlot::SetPlotYAxis(ImPlotYAxis_2);
+            ImPlot::PlotLine("f(x) = cos(x)*.2+.5 (Y2)", xs, ys2, 1001);
+        }
+        if (y3_axis) {
+            ImPlot::SetPlotYAxis(ImPlotYAxis_3);
+            ImPlot::PlotLine("f(x) = sin(x+.5)*100+200 (Y3)", xs2, ys3, 1001);
+        }
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_LinkedAxes() {
+    static double xmin = 0, xmax = 1, ymin = 0, ymax = 1;
+    static bool linkx = true, linky = true;
+    int data[2] = {0,1};
+    ImGui::Checkbox("Link X", &linkx);
+    ImGui::SameLine();
+    ImGui::Checkbox("Link Y", &linky);
+    if (BeginAlignedPlots("AlignedGroup")) {
+        ImPlot::LinkNextPlotLimits(linkx ? &xmin : NULL , linkx ? &xmax : NULL, linky ? &ymin : NULL, linky ? &ymax : NULL);
+        if (ImPlot::BeginPlot("Plot A")) {
+            ImPlot::PlotLine("Line",data,2);
+            ImPlot::EndPlot();
+        }
+        ImPlot::LinkNextPlotLimits(linkx ? &xmin : NULL , linkx ? &xmax : NULL, linky ? &ymin : NULL, linky ? &ymax : NULL);
+        if (ImPlot::BeginPlot("Plot B")) {
+            ImPlot::PlotLine("Line",data,2);
+            ImPlot::EndPlot();
+        }
+        ImPlot::EndAlignedPlots();
+    }
+}
+
+void ShowDemo_EqualAxes() {
+    static double xs[1000], ys[1000];
+    for (int i = 0; i < 1000; ++i) {
+        double angle = i * 2 * PI / 999.0;
+        xs[i] = cos(angle); ys[i] = sin(angle);
+    }
+    if (ImPlot::BeginPlot("",0,0,ImVec2(-1,0),ImPlotFlags_Equal)) {
+        ImPlot::PlotLine("Circle",xs,ys,1000);
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_AutoFittingData() {
+    ImGui::BulletText("The Y-axis has been configured to auto-fit to only the data visible in X-axis range.");
+    ImGui::BulletText("Zoom and pan the X-axis. Disable Stems to see a difference in fit.");
+    ImGui::BulletText("If ImPlotAxisFlags_RangeFit is disabled, the axis will fit ALL data.");
+
+    static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
+    static ImPlotAxisFlags yflags = ImPlotAxisFlags_AutoFit|ImPlotAxisFlags_RangeFit;
+
+    ImGui::TextUnformatted("X: "); ImGui::SameLine();
+    ImGui::CheckboxFlags("ImPlotAxisFlags_AutoFit##X", (unsigned int*)&xflags, ImPlotAxisFlags_AutoFit); ImGui::SameLine();
+    ImGui::CheckboxFlags("ImPlotAxisFlags_RangeFit##X", (unsigned int*)&xflags, ImPlotAxisFlags_RangeFit);
+
+    ImGui::TextUnformatted("Y: "); ImGui::SameLine();
+    ImGui::CheckboxFlags("ImPlotAxisFlags_AutoFit##Y", (unsigned int*)&yflags, ImPlotAxisFlags_AutoFit); ImGui::SameLine();
+    ImGui::CheckboxFlags("ImPlotAxisFlags_RangeFit##Y", (unsigned int*)&yflags, ImPlotAxisFlags_RangeFit);
+
+    static double data[101];
+    srand(0);
+    for (int i = 0; i < 101; ++i)
+        data[i] = 1 + sin(i/10.0f);
+
+    if (ImPlot::BeginPlot("##DataFitting","X","Y",ImVec2(-1,0),0,xflags,yflags)) {
+        ImPlot::PlotLine("Line",data,101);
+        ImPlot::PlotStems("Stems",data,101);
+        ImPlot::EndPlot();
+    };
+}
+
+ImPlotPoint SinewaveGetter(void* data, int i) {
+    float f = *(float*)data;
+    return ImPlotPoint(i,sinf(f*i));
+}
+
+void ShowDemo_SubplotsSizing() {
+
+    static ImPlotSubplotFlags flags = ImPlotSubplotFlags_None;
+    ImGui::CheckboxFlags("ImPlotSubplotFlags_NoSplitters", (unsigned int*)&flags, ImPlotSubplotFlags_NoSplitters); 
+    ImGui::CheckboxFlags("ImPlotSubplotFlags_NoTitle", (unsigned int*)&flags, ImPlotSubplotFlags_NoTitle);
+
+    static int rows = 3;
+    static int cols = 3;
+    ImGui::SliderInt("Rows",&rows,1,5);
+    ImGui::SliderInt("Cols",&cols,1,5);
+    static float rratios[] = {5,1,1,1,1,1};
+    static float cratios[] = {5,1,1,1,1,1};
+    ImGui::DragScalarN("Row Ratios",ImGuiDataType_Float,rratios,rows,0.01f,0);
+    ImGui::DragScalarN("Col Ratios",ImGuiDataType_Float,cratios,cols,0.01f,0);
+    if (ImPlot::BeginSubplots("My Subplots", rows, cols, ImVec2(-1,400), flags, rratios, cratios)) {
+        for (int i = 0; i < rows*cols; ++i) {
+            if (ImPlot::BeginPlot("",NULL,NULL,ImVec2(),ImPlotFlags_NoLegend,ImPlotAxisFlags_NoTickLabels,ImPlotAxisFlags_NoTickLabels)) {
+                char buffer[8];
+                float fi = 0.01f * (i+1);
+                sprintf(buffer, "data%d", i);
+                if (i == 0)
+                    ImPlot::SetNextLineStyle(ImVec4(0,1,0,1));
+                ImPlot::PlotLineG(buffer,SinewaveGetter,&fi,1000);
+                ImPlot::EndPlot();
+            }
+        }            
+        ImPlot::EndSubplots();
+    }
+}
+
+void ShowDemo_SubplotItemSharing() {
+
+    static ImPlotSubplotFlags flags = ImPlotSubplotFlags_ShareItems;
+    ImGui::CheckboxFlags("ImPlotSubplotFlags_ShareItems", (unsigned int*)&flags, ImPlotSubplotFlags_ShareItems);
+
+    static int rows = 2;
+    static int cols = 2;
+    if (ImPlot::BeginSubplots("##ItemSharing", rows, cols, ImVec2(-1,400), flags)) {
+        for (int i = 0; i < rows*cols; ++i) {
+            if (ImPlot::BeginPlot("")) {
+                char buffer[8];
+                float fc = 0.01f;
+                float fi = 0.01f * (i+1);
+                sprintf(buffer, "data%d", i);
+                ImPlot::PlotLineG("common",SinewaveGetter,&fc,1000);
+                ImPlot::PlotLineG(buffer,SinewaveGetter,&fi,1000);
+                ImPlot::EndPlot();
+            }
+        }            
+        ImPlot::EndSubplots();
+    }
+}
+
+void ShowDemo_SubplotAxisLinking() {
+    static ImPlotSubplotFlags flags = ImPlotSubplotFlags_LinkRows | ImPlotSubplotFlags_LinkCols;
+    ImGui::CheckboxFlags("ImPlotSubplotFlags_LinkRows", (unsigned int*)&flags, ImPlotSubplotFlags_LinkRows);
+    ImGui::CheckboxFlags("ImPlotSubplotFlags_LinkCols", (unsigned int*)&flags, ImPlotSubplotFlags_LinkCols);
+    ImGui::CheckboxFlags("ImPlotSubplotFlags_LinkAllX", (unsigned int*)&flags, ImPlotSubplotFlags_LinkAllX);
+    ImGui::CheckboxFlags("ImPlotSubplotFlags_LinkAllY", (unsigned int*)&flags, ImPlotSubplotFlags_LinkAllY);
+
+    static int rows = 2;
+    static int cols = 2;
+    if (ImPlot::BeginSubplots("##AxisLinking", rows, cols, ImVec2(-1,400), flags)) {
+        for (int i = 0; i < rows*cols; ++i) {
+            if (ImPlot::BeginPlot("")) {
+                float fc = 0.01f;
+                ImPlot::PlotLineG("common",SinewaveGetter,&fc,1000);
+                ImPlot::EndPlot();
+            }
+        }            
+        ImPlot::EndSubplots();
+    }
+}
+
+void ShowDemo_Querying() {
+    static ImVector<ImPlotPoint> data;
+    static ImPlotLimits range, query, select;
+
+    ImGui::BulletText("Ctrl + click in the plot area to draw points.");
+    ImGui::BulletText("Middle click (or Ctrl + right click) and drag to create a query rect.");
+    ImGui::Indent();
+        ImGui::BulletText("Hold Alt to expand query horizontally.");
+        ImGui::BulletText("Hold Shift to expand query vertically.");
+        ImGui::BulletText("The query rect can be dragged after it's created.");
+    ImGui::Unindent();
+
+    if (ImPlot::BeginPlot("##Drawing", NULL, NULL, ImVec2(-1,0), ImPlotFlags_Query, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations)) {
+        if (ImPlot::IsPlotHovered() && ImGui::IsMouseClicked(0) && ImGui::GetIO().KeyCtrl) {
+            ImPlotPoint pt = ImPlot::GetPlotMousePos();
+            data.push_back(pt);
+        }
+        if (data.size() > 0)
+            ImPlot::PlotScatter("Points", &data[0].x, &data[0].y, data.size(), 0, 2 * sizeof(double));
+        if (ImPlot::IsPlotQueried() && data.size() > 0) {
+            ImPlotLimits range2 = ImPlot::GetPlotQuery();
+            int cnt = 0;
+            ImPlotPoint avg;
+            for (int i = 0; i < data.size(); ++i) {
+                if (range2.Contains(data[i].x, data[i].y)) {
+                    avg.x += data[i].x;
+                    avg.y += data[i].y;
+                    cnt++;
+                }
+            }
+            if (cnt > 0) {
+                avg.x = avg.x / cnt;
+                avg.y = avg.y / cnt;
+                ImPlot::SetNextMarkerStyle(ImPlotMarker_Square);
+                ImPlot::PlotScatter("Average", &avg.x, &avg.y, 1);
+            }
+        }
+        range  = ImPlot::GetPlotLimits();
+        query  = ImPlot::GetPlotQuery();
+        select = ImPlot::GetPlotSelection();
+        ImPlot::EndPlot();
+    }
+    ImGui::Text("Limits: [%g,%g,%g,%g]", range.X.Min, range.X.Max, range.Y.Min, range.Y.Max);
+    ImGui::Text("Query: [%g,%g,%g,%g]", query.X.Min, query.X.Max, query.Y.Min, query.Y.Max);
+    ImGui::Text("Selection: [%g,%g,%g,%g]", select.X.Min, select.X.Max, select.Y.Min, select.Y.Max);
+
+    ImGui::Separator();
+
+    // mimic's soulthread's imgui_plot demo
+    static float x_data[512];
+    static float y_data1[512];
+    static float y_data2[512];
+    static float y_data3[512];
+    static float sampling_freq = 44100;
+    static float freq = 500;
+    for (size_t i = 0; i < 512; ++i) {
+        const float t = i / sampling_freq;
+        x_data[i] = t;
+        const float arg = 2 * 3.14f * freq * t;
+        y_data1[i] = sinf(arg);
+        y_data2[i] = y_data1[i] * -0.6f + sinf(2 * arg) * 0.4f;
+        y_data3[i] = y_data2[i] * -0.6f + sinf(3 * arg) * 0.4f;
+    }
+    ImGui::BulletText("Query the first plot to render a subview in the second plot (see above for controls).");
+    ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
+    static bool use_selection = false;
+    ImGui::Checkbox("Use Box Selection",&use_selection);
+    bool is_viewed = false;
+    ImPlotLimits view;
+    ImPlot::SetNextPlotLimits(0,0.01,-1,1);
+    if (ImPlot::BeginPlot("##View1",NULL,NULL,ImVec2(-1,150), ImPlotFlags_Query, flags, flags)) {
+        ImPlot::PlotLine("Signal 1", x_data, y_data1, 512);
+        ImPlot::PlotLine("Signal 2", x_data, y_data2, 512);
+        ImPlot::PlotLine("Signal 3", x_data, y_data3, 512);
+        is_viewed = use_selection ? ImPlot::IsPlotSelected()   : ImPlot::IsPlotQueried();
+        view      = use_selection ? ImPlot::GetPlotSelection() : ImPlot::GetPlotQuery();
+        ImPlot::EndPlot();
+    }
+    ImPlot::SetNextPlotLimits(view.X.Min, view.X.Max, view.Y.Min, view.Y.Max, ImGuiCond_Always);
+    if (ImPlot::BeginPlot("##View2",NULL,NULL,ImVec2(-1,150), ImPlotFlags_CanvasOnly, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations)) {
+        if (is_viewed) {
+            ImPlot::PlotLine("Signal 1", x_data, y_data1, 512);
+            ImPlot::PlotLine("Signal 2", x_data, y_data2, 512);
+            ImPlot::PlotLine("Signal 3", x_data, y_data3, 512);
+        }
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_LegendOptions() {
+    static ImPlotLocation loc = ImPlotLocation_East;
+    static bool h = false; static bool o = true;
+    ImGui::CheckboxFlags("North", (unsigned int*)&loc, ImPlotLocation_North); ImGui::SameLine();
+    ImGui::CheckboxFlags("South", (unsigned int*)&loc, ImPlotLocation_South); ImGui::SameLine();
+    ImGui::CheckboxFlags("West",  (unsigned int*)&loc, ImPlotLocation_West);  ImGui::SameLine();
+    ImGui::CheckboxFlags("East",  (unsigned int*)&loc, ImPlotLocation_East);  ImGui::SameLine();
+    ImGui::Checkbox("Horizontal##2", &h); ImGui::SameLine();
+    ImGui::Checkbox("Outside", &o);
+
+    ImGui::SliderFloat2("LegendPadding", (float*)&GetStyle().LegendPadding, 0.0f, 20.0f, "%.0f");
+    ImGui::SliderFloat2("LegendInnerPadding", (float*)&GetStyle().LegendInnerPadding, 0.0f, 10.0f, "%.0f");
+    ImGui::SliderFloat2("LegendSpacing", (float*)&GetStyle().LegendSpacing, 0.0f, 5.0f, "%.0f");
+
+    if (ImPlot::BeginPlot("##Legend","x","y",ImVec2(-1,0))) {
+        ImPlot::SetLegendLocation(loc, h ? ImPlotOrientation_Horizontal : ImPlotOrientation_Vertical, o);
+        static MyImPlot::WaveData data1(0.001, 0.2, 2, 0.75);
+        static MyImPlot::WaveData data2(0.001, 0.2, 4, 0.25);
+        static MyImPlot::WaveData data3(0.001, 0.2, 6, 0.5);
+        ImPlot::PlotLineG("Item 1", MyImPlot::SineWave, &data1, 1000);         // "Item 1" added to legend
+        ImPlot::PlotLineG("Item 2##IDText", MyImPlot::SawWave, &data2, 1000);  // "Item 2" added to legend, text after ## used for ID only
+        ImPlot::PlotLineG("##NotListed", MyImPlot::SawWave, &data3, 1000);     // plotted, but not added to legend
+        ImPlot::PlotLineG("Item 3", MyImPlot::SineWave, &data1, 1000);         // "Item 3" added to legend
+        ImPlot::PlotLineG("Item 3", MyImPlot::SawWave,  &data2, 1000);         // combined with previous "Item 3"
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_DragLines() {
+    ImGui::BulletText("Click and drag the horizontal and vertical lines.");
+    static double x1 = 0.2;
+    static double x2 = 0.8;
+    static double y1 = 0.25;
+    static double y2 = 0.75;
+    static double f = 0.1;
+    static bool show_labels = true;
+    ImGui::Checkbox("Show Labels##1",&show_labels);
+    ImPlot::SetNextPlotLimits(0,1,0,1);
+    if (ImPlot::BeginPlot("##guides",0,0,ImVec2(-1,0),ImPlotFlags_YAxis2)) {
+        ImPlot::DragLineX("x1",&x1,show_labels);
+        ImPlot::DragLineX("x2",&x2,show_labels);
+        ImPlot::DragLineY("y1",&y1,show_labels);
+        ImPlot::DragLineY("y2",&y2,show_labels);
+        double xs[1000], ys[1000];
+        for (int i = 0; i < 1000; ++i) {
+            xs[i] = (x2+x1)/2+fabs(x2-x1)*(i/1000.0f - 0.5f);
+            ys[i] = (y1+y2)/2+fabs(y2-y1)/2*sin(f*i/10);
+        }
+        ImPlot::PlotLine("Interactive Data", xs, ys, 1000);
+        ImPlot::SetPlotYAxis(ImPlotYAxis_2);
+        ImPlot::DragLineY("f",&f,show_labels,ImVec4(1,0.5f,1,1));
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_DragPoints() {
+    static bool show_labels = true;
+    ImGui::BulletText("Click and drag any point.");
+    ImGui::Checkbox("Show Labels##2",&show_labels);
+    ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels | ImPlotAxisFlags_NoTickMarks;
+    ImPlot::SetNextPlotLimits(0,1,0,1);
+    if (ImPlot::BeginPlot("##Bezier",0,0,ImVec2(-1,0),ImPlotFlags_CanvasOnly,flags,flags)) {
+        static ImPlotPoint P[] = {ImPlotPoint(.05f,.05f), ImPlotPoint(0.2,0.4),  ImPlotPoint(0.8,0.6),  ImPlotPoint(.95f,.95f)};
+        static ImPlotPoint B[100];
+        for (int i = 0; i < 100; ++i) {
+            double t  = i / 99.0;
+            double u  = 1 - t;
+            double w1 = u*u*u;
+            double w2 = 3*u*u*t;
+            double w3 = 3*u*t*t;
+            double w4 = t*t*t;
+            B[i] = ImPlotPoint(w1*P[0].x + w2*P[1].x + w3*P[2].x + w4*P[3].x, w1*P[0].y + w2*P[1].y + w3*P[2].y + w4*P[3].y);
+        }
+        ImPlot::SetNextLineStyle(ImVec4(0,0.9f,0,1), 2);
+        ImPlot::PlotLine("##bez",&B[0].x, &B[0].y, 100, 0, sizeof(ImPlotPoint));
+        ImPlot::SetNextLineStyle(ImVec4(1,0.5f,1,1));
+        ImPlot::PlotLine("##h1",&P[0].x, &P[0].y, 2, 0, sizeof(ImPlotPoint));
+        ImPlot::SetNextLineStyle(ImVec4(0,0.5f,1,1));
+        ImPlot::PlotLine("##h2",&P[2].x, &P[2].y, 2, 0, sizeof(ImPlotPoint));
+        ImPlot::DragPoint("P0",&P[0].x,&P[0].y, show_labels, ImVec4(0,0.9f,0,1));
+        ImPlot::DragPoint("P1",&P[1].x,&P[1].y, show_labels, ImVec4(1,0.5f,1,1));
+        ImPlot::DragPoint("P2",&P[2].x,&P[2].y, show_labels, ImVec4(0,0.5f,1,1));
+        ImPlot::DragPoint("P3",&P[3].x,&P[3].y, show_labels, ImVec4(0,0.9f,0,1));
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_Annotations() {
+    static bool clamp = false;
+    ImGui::Checkbox("Clamp",&clamp);
+    ImPlot::SetNextPlotLimits(0,2,0,1);
+    if (ImPlot::BeginPlot("##Annotations")) {
+
+        static float p[] = {0.25f, 0.25f, 0.75f, 0.75f, 0.25f};
+        ImPlot::PlotScatter("##Points",&p[0],&p[1],4);
+        ImVec4 col = GetLastItemColor();
+        clamp ? ImPlot::AnnotateClamped(0.25,0.25,ImVec2(-15,15),col,"BL") : ImPlot::Annotate(0.25,0.25,ImVec2(-15,15),col,"BL");
+        clamp ? ImPlot::AnnotateClamped(0.75,0.25,ImVec2(15,15),col,"BR") : ImPlot::Annotate(0.75,0.25,ImVec2(15,15),col,"BR");
+        clamp ? ImPlot::AnnotateClamped(0.75,0.75,ImVec2(15,-15),col,"TR") : ImPlot::Annotate(0.75,0.75,ImVec2(15,-15),col,"TR");
+        clamp ? ImPlot::AnnotateClamped(0.25,0.75,ImVec2(-15,-15),col,"TL") : ImPlot::Annotate(0.25,0.75,ImVec2(-15,-15),col,"TL");
+        clamp ? ImPlot::AnnotateClamped(0.5,0.5,ImVec2(0,0),col,"Center") : ImPlot::Annotate(0.5,0.5,ImVec2(0,0),col,"Center");
+
+        float bx[] = {1.2f,1.5f,1.8f};
+        float by[] = {0.25f, 0.5f, 0.75f};
+        ImPlot::PlotBars("##Bars",bx,by,3,0.2);
+        for (int i = 0; i < 3; ++i)
+            ImPlot::Annotate(bx[i],by[i],ImVec2(0,-5),"B[%d]=%.2f",i,by[i]);
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_DragAndDrop() {
+    ImGui::BulletText("Drag/drop items from the left column.");
+    ImGui::BulletText("Drag/drop items between plots.");
+    ImGui::Indent();
+    ImGui::BulletText("Plot 1 Targets: Plot, Y-Axes, Legend");
+    ImGui::BulletText("Plot 1 Sources: Legend Items");
+    ImGui::BulletText("Plot 2 Targets: Plot, X-Axis, Y-Axis");
+    ImGui::BulletText("Plot 2 Sources: Plot, X-Axis, Y-Axis (hold Ctrl)");
+    ImGui::Unindent();
+
+    // convenience struct to manage DND items; do this however you like
+    struct MyDndItem {
+        int              Idx;
+        int              Plt;
+        int              Yax;
+        char             Label[16];
+        ImVector<ImVec2> Data;
+        ImVec4           Color;
+        MyDndItem()        {
+            static int i = 0;
+            Idx = i++;
+            Plt = 0;
+            Yax = ImPlotYAxis_1;
+            sprintf(Label, "%02d Hz", Idx+1);
+            Color = RandomColor();
+            Data.reserve(1001);
+            for (int k = 0; k < 1001; ++k) {
+                float t = k * 1.0f / 999;
+                Data.push_back(ImVec2(t, 0.5f + 0.5f * sinf(2*3.14f*t*(Idx+1))));
+            }
+        }
+        void Reset() { Plt = 0; Yax = ImPlotYAxis_1; }
+    };
+
+    const int         k_dnd = 20;
+    static MyDndItem  dnd[k_dnd];
+    static MyDndItem* dndx = NULL; // for plot 2
+    static MyDndItem* dndy = NULL; // for plot 2
+
+    // child window to serve as initial source for our DND items
+    ImGui::BeginChild("DND_LEFT",ImVec2(100,400));
+    if (ImGui::Button("Reset Data", ImVec2(100, 0))) {
+        for (int k = 0; k < k_dnd; ++k)
+            dnd[k].Reset();
+        dndx = dndy = NULL;
+    }
+    for (int k = 0; k < k_dnd; ++k) {
+        if (dnd[k].Plt > 0)
+            continue;
+        ImPlot::ItemIcon(dnd[k].Color); ImGui::SameLine();
+        ImGui::Selectable(dnd[k].Label, false, 0, ImVec2(100, 0));
+        if (ImGui::BeginDragDropSource(ImGuiDragDropFlags_None)) {
+            ImGui::SetDragDropPayload("MY_DND", &k, sizeof(int));
+            ImPlot::ItemIcon(dnd[k].Color); ImGui::SameLine();
+            ImGui::TextUnformatted(dnd[k].Label);
+            ImGui::EndDragDropSource();
+        }
+    }
+    ImGui::EndChild();
+    if (ImGui::BeginDragDropTarget()) {
+        if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) {
+            int i = *(int*)payload->Data; dnd[i].Reset();
+        }
+        ImGui::EndDragDropTarget();
+    }
+
+    ImGui::SameLine();
+    ImGui::BeginChild("DND_RIGHT",ImVec2(-1,400));
+    // plot 1 (time series)
+    ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels | ImPlotAxisFlags_NoGridLines;
+    if (ImPlot::BeginPlot("##DND1", NULL, "[drop here]", ImVec2(-1,195), ImPlotFlags_YAxis2 | ImPlotFlags_YAxis3, flags | ImPlotAxisFlags_Lock, flags, flags, flags, "[drop here]", "[drop here]")) {
+        for (int k = 0; k < k_dnd; ++k) {
+            if (dnd[k].Plt == 1 && dnd[k].Data.size() > 0) {
+                ImPlot::SetPlotYAxis(dnd[k].Yax);
+                ImPlot::SetNextLineStyle(dnd[k].Color);
+                static char label[32];
+                sprintf(label,"%s (Y%d)", dnd[k].Label, dnd[k].Yax+1);
+                ImPlot::PlotLine(label, &dnd[k].Data[0].x, &dnd[k].Data[0].y, dnd[k].Data.size(), 0, 2 * sizeof(float));
+                // allow legend item labels to be DND sources
+                if (ImPlot::BeginDragDropSourceItem(label)) {
+                    ImGui::SetDragDropPayload("MY_DND", &k, sizeof(int));
+                    ImPlot::ItemIcon(dnd[k].Color); ImGui::SameLine();
+                    ImGui::TextUnformatted(dnd[k].Label);
+                    ImPlot::EndDragDropSource();
+                }
+            }
+        }
+        // allow the main plot area to be a DND target
+        if (ImPlot::BeginDragDropTarget()) {
+            if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) {
+                int i = *(int*)payload->Data; dnd[i].Plt = 1; dnd[i].Yax = 0;
+            }
+            ImPlot::EndDragDropTarget();
+        }
+        // allow each y-axis to be a DND target
+        for (int y = 0; y < 3; ++y) {
+            if (ImPlot::BeginDragDropTargetY(y)) {
+                if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) {
+                    int i = *(int*)payload->Data; dnd[i].Plt = 1; dnd[i].Yax = y;
+                }
+                ImPlot::EndDragDropTarget();
+            }
+        }
+        // allow the legend to be a DND target
+        if (ImPlot::BeginDragDropTargetLegend()) {
+            if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) {
+                int i = *(int*)payload->Data; dnd[i].Plt = 1; dnd[i].Yax = 0;
+            }
+            ImPlot::EndDragDropTarget();
+        }
+        ImPlot::EndPlot();
+    }
+    // plot 2 (Lissajous)
+    ImPlot::PushStyleColor(ImPlotCol_XAxis, dndx == NULL ? ImPlot::GetStyle().Colors[ImPlotCol_XAxis] : dndx->Color);
+    ImPlot::PushStyleColor(ImPlotCol_YAxis, dndy == NULL ? ImPlot::GetStyle().Colors[ImPlotCol_YAxis] : dndy->Color);
+    if (ImPlot::BeginPlot("##DND2", dndx == NULL ? "[drop here]" : dndx->Label, dndy == NULL ? "[drop here]" : dndy->Label, ImVec2(-1,195), 0, flags, flags )) {
+        if (dndx != NULL && dndy != NULL) {
+            ImVec4 mixed((dndx->Color.x + dndy->Color.x)/2,(dndx->Color.y + dndy->Color.y)/2,(dndx->Color.z + dndy->Color.z)/2,(dndx->Color.w + dndy->Color.w)/2);
+            ImPlot::SetNextLineStyle(mixed);
+            ImPlot::PlotLine("##dndxy", &dndx->Data[0].y, &dndy->Data[0].y, dndx->Data.size(), 0, 2 * sizeof(float));
+        }
+        // allow the x-axis to be a DND target
+        if (ImPlot::BeginDragDropTargetX()) {
+            if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) {
+                int i = *(int*)payload->Data; dndx = &dnd[i];
+            }
+            ImPlot::EndDragDropTarget();
+        }
+        // allow the x-axis to be a DND source
+        if (dndx != NULL && ImPlot::BeginDragDropSourceX()) {
+            ImGui::SetDragDropPayload("MY_DND", &dndx->Idx, sizeof(int));
+            ImPlot::ItemIcon(dndx->Color); ImGui::SameLine();
+            ImGui::TextUnformatted(dndx->Label);
+            ImPlot::EndDragDropSource();
+        }
+        // allow the y-axis to be a DND target
+        if (ImPlot::BeginDragDropTargetY()) {
+            if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) {
+                int i = *(int*)payload->Data; dndy = &dnd[i];
+            }
+            ImPlot::EndDragDropTarget();
+        }
+        // allow the y-axis to be a DND source
+        if (dndy != NULL && ImPlot::BeginDragDropSourceY()) {
+            ImGui::SetDragDropPayload("MY_DND", &dndy->Idx, sizeof(int));
+            ImPlot::ItemIcon(dndy->Color); ImGui::SameLine();
+            ImGui::TextUnformatted(dndy->Label);
+            ImPlot::EndDragDropSource();
+        }
+        // allow the plot area to be a DND target
+        if (ImPlot::BeginDragDropTarget()) {
+            if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) {
+                int i = *(int*)payload->Data; dndx = dndy = &dnd[i];
+            }
+        }
+        // allow the plot area to be a DND source
+        if (ImPlot::BeginDragDropSource()) {
+            ImGui::TextUnformatted("Yes, you can\ndrag this!");
+            ImPlot::EndDragDropSource();
+        }
+        ImPlot::EndPlot();
+    }
+    ImPlot::PopStyleColor(2);
+    ImGui::EndChild();
+}
+
+void ShowDemo_Tables() {
+#ifdef IMGUI_HAS_TABLE
+    static ImGuiTableFlags flags = ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_RowBg;
+    static bool anim = true;
+    static int offset = 0;
+    ImGui::BulletText("Plots can be used inside of ImGui tables as a means of creating subplots.");
+    ImGui::Checkbox("Animate",&anim);
+    if (anim)
+        offset = (offset + 1) % 100;
+    if (ImGui::BeginTable("##table", 3, flags, ImVec2(-1,0))) {
+        ImGui::TableSetupColumn("Electrode", ImGuiTableColumnFlags_WidthFixed, 75.0f);
+        ImGui::TableSetupColumn("Voltage", ImGuiTableColumnFlags_WidthFixed, 75.0f);
+        ImGui::TableSetupColumn("EMG Signal");
+        ImGui::TableHeadersRow();
+        ImPlot::PushColormap(ImPlotColormap_Cool);
+        for (int row = 0; row < 10; row++) {
+            ImGui::TableNextRow();
+            static float data[100];
+            srand(row);
+            for (int i = 0; i < 100; ++i)
+                data[i] = RandomRange(0.0f,10.0f);
+            ImGui::TableSetColumnIndex(0);
+            ImGui::Text("EMG %d", row);
+            ImGui::TableSetColumnIndex(1);
+            ImGui::Text("%.3f V", data[offset]);
+            ImGui::TableSetColumnIndex(2);
+            ImGui::PushID(row);
+            MyImPlot::Sparkline("##spark",data,100,0,11.0f,offset,ImPlot::GetColormapColor(row),ImVec2(-1, 35));
+            ImGui::PopID();
+        }
+        ImPlot::PopColormap();
+        ImGui::EndTable();
+    }
+#else
+    ImGui::BulletText("You need to merge the ImGui 'tables' branch for this section.");
+#endif
+}
+
+void ShowDemo_OffsetAndStride() {
+    static const int k_circles    = 11;
+    static const int k_points_per = 50;
+    static const int k_size       = 2 * k_points_per * k_circles;
+    static double interleaved_data[k_size];
+    for (int p = 0; p < k_points_per; ++p) {
+        for (int c = 0; c < k_circles; ++c) {
+            double r = (double)c / (k_circles - 1) * 0.2 + 0.2;
+            interleaved_data[p*2*k_circles + 2*c + 0] = 0.5 + r * cos((double)p/k_points_per * 6.28);
+            interleaved_data[p*2*k_circles + 2*c + 1] = 0.5 + r * sin((double)p/k_points_per * 6.28);
+        }
+    }
+    static int offset = 0;
+    ImGui::BulletText("Offsetting is useful for realtime plots (see above) and circular buffers.");
+    ImGui::BulletText("Striding is useful for interleaved data (e.g. audio) or plotting structs.");
+    ImGui::BulletText("Here, all circle data is stored in a single interleaved buffer:");
+    ImGui::BulletText("[c0.x0 c0.y0 ... cn.x0 cn.y0 c0.x1 c0.y1 ... cn.x1 cn.y1 ... cn.xm cn.ym]");
+    ImGui::BulletText("The offset value indicates which circle point index is considered the first.");
+    ImGui::BulletText("Offsets can be negative and/or larger than the actual data count.");
+    ImGui::SliderInt("Offset", &offset, -2*k_points_per, 2*k_points_per);
+    if (ImPlot::BeginPlot("##strideoffset",0,0,ImVec2(-1,0), ImPlotFlags_Equal)) {
+        ImPlot::PushColormap(ImPlotColormap_Jet);
+        char buff[16];
+        for (int c = 0; c < k_circles; ++c) {
+            sprintf(buff, "Circle %d", c);
+            ImPlot::PlotLine(buff, &interleaved_data[c*2 + 0], &interleaved_data[c*2 + 1], k_points_per, offset, 2*k_circles*sizeof(double));
+        }
+        ImPlot::EndPlot();
+        ImPlot::PopColormap();
+    }
+    // offset++; uncomment for animation!
+}
+
+void ShowDemo_CustomDataAndGetters() {
+    ImGui::BulletText("You can plot custom structs using the stride feature.");
+    ImGui::BulletText("Most plotters can also be passed a function pointer for getting data.");
+    ImGui::Indent();
+        ImGui::BulletText("You can optionally pass user data to be given to your getter function.");
+        ImGui::BulletText("C++ lambdas can be passed as function pointers as well!");
+    ImGui::Unindent();
+
+    MyImPlot::Vector2f vec2_data[2] = { MyImPlot::Vector2f(0,0), MyImPlot::Vector2f(1,1) };
+
+    if (ImPlot::BeginPlot("##Custom Data")) {
+
+        // custom structs using stride example:
+        ImPlot::PlotLine("Vector2f", &vec2_data[0].x, &vec2_data[0].y, 2, 0, sizeof(MyImPlot::Vector2f) /* or sizeof(float) * 2 */);
+
+        // custom getter example 1:
+        ImPlot::PlotLineG("Spiral", MyImPlot::Spiral, NULL, 1000);
+
+        // custom getter example 2:
+        static MyImPlot::WaveData data1(0.001, 0.2, 2, 0.75);
+        static MyImPlot::WaveData data2(0.001, 0.2, 4, 0.25);
+        ImPlot::PlotLineG("Waves", MyImPlot::SineWave, &data1, 1000);
+        ImPlot::PlotLineG("Waves", MyImPlot::SawWave, &data2, 1000);
+        ImPlot::PushStyleVar(ImPlotStyleVar_FillAlpha, 0.25f);
+        ImPlot::PlotShadedG("Waves", MyImPlot::SineWave, &data1, MyImPlot::SawWave, &data2, 1000);
+        ImPlot::PopStyleVar();
+
+        // you can also pass C++ lambdas:
+        // auto lamda = [](void* data, int idx) { ... return ImPlotPoint(x,y); };
+        // ImPlot::PlotLine("My Lambda", lambda, data, 1000);
+
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_TickLabels()  {
+    static bool custom_fmt    = true;
+    static bool custom_ticks  = false;
+    static bool custom_labels = true;
+    ImGui::Checkbox("Show Custom Format", &custom_fmt);
+    ImGui::SameLine();
+    ImGui::Checkbox("Show Custom Ticks", &custom_ticks);
+    if (custom_ticks) {
+        ImGui::SameLine();
+        ImGui::Checkbox("Show Custom Labels", &custom_labels);
+    }
+    double pi = 3.14;
+    const char* pi_str[] = {"PI"};
+    static double yticks[] = {1,3,7,9};
+    static const char*  ylabels[] = {"One","Three","Seven","Nine"};
+    static double yticks_aux[] = {0.2,0.4,0.6};
+    static const char* ylabels_aux[] = {"A","B","C","D","E","F"};
+    if (custom_fmt) {
+        ImPlot::SetNextPlotFormatX("%g ms");
+        ImPlot::SetNextPlotFormatY("%g Hz", ImPlotYAxis_1);
+        ImPlot::SetNextPlotFormatY("%g dB", ImPlotYAxis_2);
+        ImPlot::SetNextPlotFormatY("%g km", ImPlotYAxis_3);
+    }
+    if (custom_ticks) {
+        ImPlot::SetNextPlotTicksX(&pi,1,custom_labels ? pi_str : NULL, true);
+        ImPlot::SetNextPlotTicksY(yticks, 4, custom_labels ? ylabels : NULL, ImPlotYAxis_1);
+        ImPlot::SetNextPlotTicksY(yticks_aux, 3, custom_labels ? ylabels_aux : NULL, false, ImPlotYAxis_2);
+        ImPlot::SetNextPlotTicksY(0, 1, 6, custom_labels ? ylabels_aux : NULL, false, ImPlotYAxis_3);
+    }
+    ImPlot::SetNextPlotLimits(2.5,5,0,10);
+    if (ImPlot::BeginPlot("##Ticks", NULL, NULL, ImVec2(-1,0), ImPlotFlags_YAxis2 | ImPlotFlags_YAxis3)) {
+        // nothing to see here, just the ticks
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_CustomStyles() {
+    ImPlot::PushColormap(ImPlotColormap_Deep);
+    // normally you wouldn't change the entire style each frame
+    ImPlotStyle backup = ImPlot::GetStyle();
+    MyImPlot::StyleSeaborn();
+    ImPlot::SetNextPlotLimits(-0.5f, 9.5f, 0, 10);
+    if (ImPlot::BeginPlot("seaborn style", "x-axis", "y-axis")) {
+        unsigned int lin[10] = {8,8,9,7,8,8,8,9,7,8};
+        unsigned int bar[10] = {1,2,5,3,4,1,2,5,3,4};
+        unsigned int dot[10] = {7,6,6,7,8,5,6,5,8,7};
+        ImPlot::PlotBars("Bars", bar, 10, 0.5f);
+        ImPlot::PlotLine("Line", lin, 10);
+        ImPlot::NextColormapColor(); // skip green
+        ImPlot::PlotScatter("Scatter", dot, 10);
+        ImPlot::EndPlot();
+    }
+    ImPlot::GetStyle() = backup;
+    ImPlot::PopColormap();
+}
+
+void ShowDemo_CustomRendering() {
+    if (ImPlot::BeginPlot("##CustomRend")) {
+        ImVec2 cntr = ImPlot::PlotToPixels(ImPlotPoint(0.5f,  0.5f));
+        ImVec2 rmin = ImPlot::PlotToPixels(ImPlotPoint(0.25f, 0.75f));
+        ImVec2 rmax = ImPlot::PlotToPixels(ImPlotPoint(0.75f, 0.25f));
+        ImPlot::PushPlotClipRect();
+        ImPlot::GetPlotDrawList()->AddCircleFilled(cntr,20,IM_COL32(255,255,0,255),20);
+        ImPlot::GetPlotDrawList()->AddRect(rmin, rmax, IM_COL32(128,0,255,255));
+        ImPlot::PopPlotClipRect();
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_LegendPopups() {
+    ImGui::BulletText("You can implement legend context menus to inject per-item controls and widgets.");
+    ImGui::BulletText("Right click the legend label/icon to edit custom item attributes.");
+
+    static float  frequency = 0.1f;
+    static float  amplitude = 0.5f;
+    static ImVec4 color     = ImVec4(1,1,0,1);
+    static float  alpha     = 1.0f;
+    static bool   line      = false;
+    static float  thickness = 1;
+    static bool   markers   = false;
+    static bool   shaded    = false;
+
+    static float vals[101];
+    for (int i = 0; i < 101; ++i)
+        vals[i] = amplitude * sinf(frequency * i);
+
+    ImPlot::SetNextPlotLimits(0,100,-1,1);
+    if (ImPlot::BeginPlot("Right Click the Legend")) {
+        // rendering logic
+        ImPlot::PushStyleVar(ImPlotStyleVar_FillAlpha, alpha);
+        if (!line) {
+            ImPlot::SetNextFillStyle(color);
+            ImPlot::PlotBars("Right Click Me", vals, 101);
+        }
+        else {
+            if (markers) ImPlot::SetNextMarkerStyle(ImPlotMarker_Circle);
+            ImPlot::SetNextLineStyle(color, thickness);
+            ImPlot::PlotLine("Right Click Me", vals, 101);
+            if (shaded) ImPlot::PlotShaded("Right Click Me",vals,101);
+        }
+        ImPlot::PopStyleVar();
+        // custom legend context menu
+        if (ImPlot::BeginLegendPopup("Right Click Me")) {
+            ImGui::SliderFloat("Frequency",&frequency,0,1,"%0.2f");
+            ImGui::SliderFloat("Amplitude",&amplitude,0,1,"%0.2f");
+            ImGui::Separator();
+            ImGui::ColorEdit3("Color",&color.x);
+            ImGui::SliderFloat("Transparency",&alpha,0,1,"%.2f");
+            ImGui::Checkbox("Line Plot", &line);
+            if (line) {
+                ImGui::SliderFloat("Thickness", &thickness, 0, 5);
+                ImGui::Checkbox("Markers", &markers);
+                ImGui::Checkbox("Shaded",&shaded);
+            }
+            ImPlot::EndLegendPopup();
+        }
+        ImPlot::EndPlot();
+    }
+}
+
+void ShowDemo_CustomPlottersAndTooltips()  {
+    ImGui::BulletText("You can create custom plotters or extend ImPlot using implot_internal.h.");
+    double dates[]  = {1546300800,1546387200,1546473600,1546560000,1546819200,1546905600,1546992000,1547078400,1547164800,1547424000,1547510400,1547596800,1547683200,1547769600,1547942400,1548028800,1548115200,1548201600,1548288000,1548374400,1548633600,1548720000,1548806400,1548892800,1548979200,1549238400,1549324800,1549411200,1549497600,1549584000,1549843200,1549929600,1550016000,1550102400,1550188800,1550361600,1550448000,1550534400,1550620800,1550707200,1550793600,1551052800,1551139200,1551225600,1551312000,1551398400,1551657600,1551744000,1551830400,1551916800,1552003200,1552262400,1552348800,1552435200,1552521600,1552608000,1552867200,1552953600,1553040000,1553126400,1553212800,1553472000,1553558400,1553644800,1553731200,1553817600,1554076800,1554163200,1554249600,1554336000,1554422400,1554681600,1554768000,1554854400,1554940800,1555027200,1555286400,1555372800,1555459200,1555545600,1555632000,1555891200,1555977600,1556064000,1556150400,1556236800,1556496000,1556582400,1556668800,1556755200,1556841600,1557100800,1557187200,1557273600,1557360000,1557446400,1557705600,1557792000,1557878400,1557964800,1558051200,1558310400,1558396800,1558483200,1558569600,1558656000,1558828800,1558915200,1559001600,1559088000,1559174400,1559260800,1559520000,1559606400,1559692800,1559779200,1559865600,1560124800,1560211200,1560297600,1560384000,1560470400,1560729600,1560816000,1560902400,1560988800,1561075200,1561334400,1561420800,1561507200,1561593600,1561680000,1561939200,1562025600,1562112000,1562198400,1562284800,1562544000,1562630400,1562716800,1562803200,1562889600,1563148800,1563235200,1563321600,1563408000,1563494400,1563753600,1563840000,1563926400,1564012800,1564099200,1564358400,1564444800,1564531200,1564617600,1564704000,1564963200,1565049600,1565136000,1565222400,1565308800,1565568000,1565654400,1565740800,1565827200,1565913600,1566172800,1566259200,1566345600,1566432000,1566518400,1566777600,1566864000,1566950400,1567036800,1567123200,1567296000,1567382400,1567468800,1567555200,1567641600,1567728000,1567987200,1568073600,1568160000,1568246400,1568332800,1568592000,1568678400,1568764800,1568851200,1568937600,1569196800,1569283200,1569369600,1569456000,1569542400,1569801600,1569888000,1569974400,1570060800,1570147200,1570406400,1570492800,1570579200,1570665600,1570752000,1571011200,1571097600,1571184000,1571270400,1571356800,1571616000,1571702400,1571788800,1571875200,1571961600};
+    double opens[]  = {1284.7,1319.9,1318.7,1328,1317.6,1321.6,1314.3,1325,1319.3,1323.1,1324.7,1321.3,1323.5,1322,1281.3,1281.95,1311.1,1315,1314,1313.1,1331.9,1334.2,1341.3,1350.6,1349.8,1346.4,1343.4,1344.9,1335.6,1337.9,1342.5,1337,1338.6,1337,1340.4,1324.65,1324.35,1349.5,1371.3,1367.9,1351.3,1357.8,1356.1,1356,1347.6,1339.1,1320.6,1311.8,1314,1312.4,1312.3,1323.5,1319.1,1327.2,1332.1,1320.3,1323.1,1328,1330.9,1338,1333,1335.3,1345.2,1341.1,1332.5,1314,1314.4,1310.7,1314,1313.1,1315,1313.7,1320,1326.5,1329.2,1314.2,1312.3,1309.5,1297.4,1293.7,1277.9,1295.8,1295.2,1290.3,1294.2,1298,1306.4,1299.8,1302.3,1297,1289.6,1302,1300.7,1303.5,1300.5,1303.2,1306,1318.7,1315,1314.5,1304.1,1294.7,1293.7,1291.2,1290.2,1300.4,1284.2,1284.25,1301.8,1295.9,1296.2,1304.4,1323.1,1340.9,1341,1348,1351.4,1351.4,1343.5,1342.3,1349,1357.6,1357.1,1354.7,1361.4,1375.2,1403.5,1414.7,1433.2,1438,1423.6,1424.4,1418,1399.5,1435.5,1421.25,1434.1,1412.4,1409.8,1412.2,1433.4,1418.4,1429,1428.8,1420.6,1441,1460.4,1441.7,1438.4,1431,1439.3,1427.4,1431.9,1439.5,1443.7,1425.6,1457.5,1451.2,1481.1,1486.7,1512.1,1515.9,1509.2,1522.3,1513,1526.6,1533.9,1523,1506.3,1518.4,1512.4,1508.8,1545.4,1537.3,1551.8,1549.4,1536.9,1535.25,1537.95,1535.2,1556,1561.4,1525.6,1516.4,1507,1493.9,1504.9,1506.5,1513.1,1506.5,1509.7,1502,1506.8,1521.5,1529.8,1539.8,1510.9,1511.8,1501.7,1478,1485.4,1505.6,1511.6,1518.6,1498.7,1510.9,1510.8,1498.3,1492,1497.7,1484.8,1494.2,1495.6,1495.6,1487.5,1491.1,1495.1,1506.4};
+    double highs[]  = {1284.75,1320.6,1327,1330.8,1326.8,1321.6,1326,1328,1325.8,1327.1,1326,1326,1323.5,1322.1,1282.7,1282.95,1315.8,1316.3,1314,1333.2,1334.7,1341.7,1353.2,1354.6,1352.2,1346.4,1345.7,1344.9,1340.7,1344.2,1342.7,1342.1,1345.2,1342,1350,1324.95,1330.75,1369.6,1374.3,1368.4,1359.8,1359,1357,1356,1353.4,1340.6,1322.3,1314.1,1316.1,1312.9,1325.7,1323.5,1326.3,1336,1332.1,1330.1,1330.4,1334.7,1341.1,1344.2,1338.8,1348.4,1345.6,1342.8,1334.7,1322.3,1319.3,1314.7,1316.6,1316.4,1315,1325.4,1328.3,1332.2,1329.2,1316.9,1312.3,1309.5,1299.6,1296.9,1277.9,1299.5,1296.2,1298.4,1302.5,1308.7,1306.4,1305.9,1307,1297.2,1301.7,1305,1305.3,1310.2,1307,1308,1319.8,1321.7,1318.7,1316.2,1305.9,1295.8,1293.8,1293.7,1304.2,1302,1285.15,1286.85,1304,1302,1305.2,1323,1344.1,1345.2,1360.1,1355.3,1363.8,1353,1344.7,1353.6,1358,1373.6,1358.2,1369.6,1377.6,1408.9,1425.5,1435.9,1453.7,1438,1426,1439.1,1418,1435,1452.6,1426.65,1437.5,1421.5,1414.1,1433.3,1441.3,1431.4,1433.9,1432.4,1440.8,1462.3,1467,1443.5,1444,1442.9,1447,1437.6,1440.8,1445.7,1447.8,1458.2,1461.9,1481.8,1486.8,1522.7,1521.3,1521.1,1531.5,1546.1,1534.9,1537.7,1538.6,1523.6,1518.8,1518.4,1514.6,1540.3,1565,1554.5,1556.6,1559.8,1541.9,1542.9,1540.05,1558.9,1566.2,1561.9,1536.2,1523.8,1509.1,1506.2,1532.2,1516.6,1519.7,1515,1519.5,1512.1,1524.5,1534.4,1543.3,1543.3,1542.8,1519.5,1507.2,1493.5,1511.4,1525.8,1522.2,1518.8,1515.3,1518,1522.3,1508,1501.5,1503,1495.5,1501.1,1497.9,1498.7,1492.1,1499.4,1506.9,1520.9};
+    double lows[]   = {1282.85,1315,1318.7,1309.6,1317.6,1312.9,1312.4,1319.1,1319,1321,1318.1,1321.3,1319.9,1312,1280.5,1276.15,1308,1309.9,1308.5,1312.3,1329.3,1333.1,1340.2,1347,1345.9,1338,1340.8,1335,1332,1337.9,1333,1336.8,1333.2,1329.9,1340.4,1323.85,1324.05,1349,1366.3,1351.2,1349.1,1352.4,1350.7,1344.3,1338.9,1316.3,1308.4,1306.9,1309.6,1306.7,1312.3,1315.4,1319,1327.2,1317.2,1320,1323,1328,1323,1327.8,1331.7,1335.3,1336.6,1331.8,1311.4,1310,1309.5,1308,1310.6,1302.8,1306.6,1313.7,1320,1322.8,1311,1312.1,1303.6,1293.9,1293.5,1291,1277.9,1294.1,1286,1289.1,1293.5,1296.9,1298,1299.6,1292.9,1285.1,1288.5,1296.3,1297.2,1298.4,1298.6,1302,1300.3,1312,1310.8,1301.9,1292,1291.1,1286.3,1289.2,1289.9,1297.4,1283.65,1283.25,1292.9,1295.9,1290.8,1304.2,1322.7,1336.1,1341,1343.5,1345.8,1340.3,1335.1,1341.5,1347.6,1352.8,1348.2,1353.7,1356.5,1373.3,1398,1414.7,1427,1416.4,1412.7,1420.1,1396.4,1398.8,1426.6,1412.85,1400.7,1406,1399.8,1404.4,1415.5,1417.2,1421.9,1415,1413.7,1428.1,1434,1435.7,1427.5,1429.4,1423.9,1425.6,1427.5,1434.8,1422.3,1412.1,1442.5,1448.8,1468.2,1484.3,1501.6,1506.2,1498.6,1488.9,1504.5,1518.3,1513.9,1503.3,1503,1506.5,1502.1,1503,1534.8,1535.3,1541.4,1528.6,1525.6,1535.25,1528.15,1528,1542.6,1514.3,1510.7,1505.5,1492.1,1492.9,1496.8,1493.1,1503.4,1500.9,1490.7,1496.3,1505.3,1505.3,1517.9,1507.4,1507.1,1493.3,1470.5,1465,1480.5,1501.7,1501.4,1493.3,1492.1,1505.1,1495.7,1478,1487.1,1480.8,1480.6,1487,1488.3,1484.8,1484,1490.7,1490.4,1503.1};
+    double closes[] = {1283.35,1315.3,1326.1,1317.4,1321.5,1317.4,1323.5,1319.2,1321.3,1323.3,1319.7,1325.1,1323.6,1313.8,1282.05,1279.05,1314.2,1315.2,1310.8,1329.1,1334.5,1340.2,1340.5,1350,1347.1,1344.3,1344.6,1339.7,1339.4,1343.7,1337,1338.9,1340.1,1338.7,1346.8,1324.25,1329.55,1369.6,1372.5,1352.4,1357.6,1354.2,1353.4,1346,1341,1323.8,1311.9,1309.1,1312.2,1310.7,1324.3,1315.7,1322.4,1333.8,1319.4,1327.1,1325.8,1330.9,1325.8,1331.6,1336.5,1346.7,1339.2,1334.7,1313.3,1316.5,1312.4,1313.4,1313.3,1312.2,1313.7,1319.9,1326.3,1331.9,1311.3,1313.4,1309.4,1295.2,1294.7,1294.1,1277.9,1295.8,1291.2,1297.4,1297.7,1306.8,1299.4,1303.6,1302.2,1289.9,1299.2,1301.8,1303.6,1299.5,1303.2,1305.3,1319.5,1313.6,1315.1,1303.5,1293,1294.6,1290.4,1291.4,1302.7,1301,1284.15,1284.95,1294.3,1297.9,1304.1,1322.6,1339.3,1340.1,1344.9,1354,1357.4,1340.7,1342.7,1348.2,1355.1,1355.9,1354.2,1362.1,1360.1,1408.3,1411.2,1429.5,1430.1,1426.8,1423.4,1425.1,1400.8,1419.8,1432.9,1423.55,1412.1,1412.2,1412.8,1424.9,1419.3,1424.8,1426.1,1423.6,1435.9,1440.8,1439.4,1439.7,1434.5,1436.5,1427.5,1432.2,1433.3,1441.8,1437.8,1432.4,1457.5,1476.5,1484.2,1519.6,1509.5,1508.5,1517.2,1514.1,1527.8,1531.2,1523.6,1511.6,1515.7,1515.7,1508.5,1537.6,1537.2,1551.8,1549.1,1536.9,1529.4,1538.05,1535.15,1555.9,1560.4,1525.5,1515.5,1511.1,1499.2,1503.2,1507.4,1499.5,1511.5,1513.4,1515.8,1506.2,1515.1,1531.5,1540.2,1512.3,1515.2,1506.4,1472.9,1489,1507.9,1513.8,1512.9,1504.4,1503.9,1512.8,1500.9,1488.7,1497.6,1483.5,1494,1498.3,1494.1,1488.1,1487.5,1495.7,1504.7,1505.3};
+    static bool tooltip = true;
+    ImGui::Checkbox("Show Tooltip", &tooltip);
+    ImGui::SameLine();
+    static ImVec4 bullCol = ImVec4(0.000f, 1.000f, 0.441f, 1.000f);
+    static ImVec4 bearCol = ImVec4(0.853f, 0.050f, 0.310f, 1.000f);
+    ImGui::SameLine(); ImGui::ColorEdit4("##Bull", &bullCol.x, ImGuiColorEditFlags_NoInputs);
+    ImGui::SameLine(); ImGui::ColorEdit4("##Bear", &bearCol.x, ImGuiColorEditFlags_NoInputs);
+    ImPlot::GetStyle().UseLocalTime = false;
+    ImPlot::SetNextPlotFormatY("$%.0f");
+    ImPlot::SetNextPlotLimits(1546300800, 1571961600, 1250, 1600);
+    if (ImPlot::BeginPlot("Candlestick Chart",NULL,NULL,ImVec2(-1,0),0,ImPlotAxisFlags_Time,ImPlotAxisFlags_AutoFit|ImPlotAxisFlags_RangeFit)) {
+        MyImPlot::PlotCandlestick("GOOGL",dates, opens, closes, lows, highs, 218, tooltip, 0.25f, bullCol, bearCol);
+        ImPlot::EndPlot();
+    }
+    }
+
+//-----------------------------------------------------------------------------
+// DEMO WINDOW
+//-----------------------------------------------------------------------------
+
 void ShowDemoWindow(bool* p_open) {
-    double DEMO_TIME = ImGui::GetTime();
     static bool show_imgui_metrics       = false;
     static bool show_implot_metrics      = false;
     static bool show_imgui_style_editor  = false;
@@ -231,1447 +1708,109 @@ void ShowDemoWindow(bool* p_open) {
 
     ImGui::Spacing();
 
-    if (ImGui::CollapsingHeader("Help")) {
-        ImGui::Text("ABOUT THIS DEMO:");
-        ImGui::BulletText("Sections below are demonstrating many aspects of the library.");
-        ImGui::BulletText("The \"Tools\" menu above gives access to: Style Editors (ImPlot/ImGui)\n"
-                          "and Metrics (general purpose Dear ImGui debugging tool).");
-        ImGui::Separator();
-        ImGui::Text("PROGRAMMER GUIDE:");
-        ImGui::BulletText("See the ShowDemoWindow() code in implot_demo.cpp. <- you are here!");
-        ImGui::BulletText("By default, anti-aliased lines are turned OFF.");
-        ImGui::Indent();
-            ImGui::BulletText("Software AA can be enabled globally with ImPlotStyle.AntiAliasedLines.");
-            ImGui::BulletText("Software AA can be enabled per plot with ImPlotFlags_AntiAliased.");
-            ImGui::BulletText("AA for plots can be toggled from the plot's context menu.");
-            ImGui::BulletText("If permitable, you are better off using hardware AA (e.g. MSAA).");
-        ImGui::Unindent();
-        ImGui::BulletText("If you see visual artifacts, do one of the following:");
-        ImGui::Indent();
-        ImGui::BulletText("Handle ImGuiBackendFlags_RendererHasVtxOffset for 16-bit indices in your backend.");
-        ImGui::BulletText("Or, enable 32-bit indices in imconfig.h.");
-        ImGui::BulletText("Your current configuration is:");
-        ImGui::Indent();
-        ImGui::BulletText("ImDrawIdx: %d-bit", (int)(sizeof(ImDrawIdx) * 8));
-        ImGui::BulletText("ImGuiBackendFlags_RendererHasVtxOffset: %s", (ImGui::GetIO().BackendFlags & ImGuiBackendFlags_RendererHasVtxOffset) ? "True" : "False");
-        ImGui::Unindent();
-        ImGui::Unindent();
-        ImGui::Separator();
-        ImGui::Text("USER GUIDE:");
-        ShowUserGuide();
+    if (ImGui::BeginTabBar("ImPlotDemoTabs")) {
+        if (ImGui::BeginTabItem("Plots")) {
+            if (ImGui::CollapsingHeader("Line Plots"))
+                ShowDemo_LinePlots();
+            if (ImGui::CollapsingHeader("Filled Line Plots"))
+                ShowDemo_FilledLinePlots();
+            if (ImGui::CollapsingHeader("Shaded Plots##"))
+                ShowDemo_ShadedPlots();
+            if (ImGui::CollapsingHeader("Scatter Plots"))
+                ShowDemo_ScatterPlots();
+            if (ImGui::CollapsingHeader("Realtime Plots"))
+                ShowDemo_RealtimePlots();
+            if (ImGui::CollapsingHeader("Stairstep Plots"))
+                ShowDemo_StairstepPlots();
+            if (ImGui::CollapsingHeader("Bar Plots"))
+                ShowDemo_BarPlots();
+            if (ImGui::CollapsingHeader("Error Bars"))
+                ShowDemo_ErrorBars();
+            if (ImGui::CollapsingHeader("Stem Plots##"))
+                ShowDemo_StemPlots();
+            if (ImGui::CollapsingHeader("Infinite Lines"))
+                ShowDemo_InfiniteLines();
+            if (ImGui::CollapsingHeader("Pie Charts"))
+                ShowDemo_PieCharts();
+            if (ImGui::CollapsingHeader("Heatmaps"))
+                ShowDemo_Heatmaps();
+            if (ImGui::CollapsingHeader("Histograms"))
+                ShowDemo_Histograms();
+            if (ImGui::CollapsingHeader("Digital Plots"))
+                ShowDemo_DigitalPlots();
+            if (ImGui::CollapsingHeader("Images"))
+                ShowDemo_Images();
+            if (ImGui::CollapsingHeader("Markers and Text"))
+                ShowDemo_MarkersAndText();
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Subplots")) {
+            if (ImGui::CollapsingHeader("Grid Sizing"))
+                ShowDemo_SubplotsSizing();
+            if (ImGui::CollapsingHeader("Item Sharing"))
+                ShowDemo_SubplotItemSharing();
+            if (ImGui::CollapsingHeader("Axis Linking"))
+                ShowDemo_SubplotAxisLinking();
+            if (ImGui::CollapsingHeader("Tables"))
+                ShowDemo_Tables();
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Axes")) {
+            if (ImGui::CollapsingHeader("Log Axes"))
+                ShowDemo_LogAxes();
+            if (ImGui::CollapsingHeader("Time Axes"))
+                ShowDemo_TimeAxes();
+            if (ImGui::CollapsingHeader("Multiple Y-Axes"))
+                ShowDemo_MultipleYAxes();
+            if (ImGui::CollapsingHeader("Tick Labels"))
+                ShowDemo_TickLabels();
+            if (ImGui::CollapsingHeader("Linked Axes"))
+                ShowDemo_LinkedAxes();
+            if (ImGui::CollapsingHeader("Equal Axes"))
+                ShowDemo_EqualAxes();
+            if (ImGui::CollapsingHeader("Auto-Fitting Data"))
+                ShowDemo_AutoFittingData();
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Tools")) {
+            if (ImGui::CollapsingHeader("Offset and Stride"))
+                ShowDemo_OffsetAndStride();
+            if (ImGui::CollapsingHeader("Querying"))
+                ShowDemo_Querying();
+            if (ImGui::CollapsingHeader("Drag Lines"))
+                ShowDemo_DragLines();
+            if (ImGui::CollapsingHeader("Drag Points"))
+                ShowDemo_DragLines();
+            if (ImGui::CollapsingHeader("Annotations"))
+                ShowDemo_Annotations();
+            if (ImGui::CollapsingHeader("Drag and Drop"))
+                ShowDemo_DragAndDrop();
+            if (ImGui::CollapsingHeader("Legend Options"))
+                ShowDemo_LegendOptions();
+            if (ImGui::CollapsingHeader("Legend Popups"))
+                ShowDemo_LegendPopups();
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Custom")) {
+            if (ImGui::CollapsingHeader("Custom Styles"))
+                ShowDemo_CustomStyles();
+            if (ImGui::CollapsingHeader("Custom Data and Getters"))
+                ShowDemo_CustomDataAndGetters();
+            if (ImGui::CollapsingHeader("Custom Rendering"))
+                ShowDemo_CustomRendering();
+            if (ImGui::CollapsingHeader("Custom Plotters and Tooltips"))
+                ShowDemo_CustomPlottersAndTooltips();
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Help")) {
+            if (ImGui::CollapsingHeader("Help"))
+                ShowDemo_Help();
+            if (ImGui::CollapsingHeader("Configuration"))
+                ShowDemo_Configuration();
+            ImGui::EndTabItem();
+        }
+        ImGui::EndTabBar();
     }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Configuration")) {
-        ImGui::ShowFontSelector("Font");
-        ImGui::ShowStyleSelector("ImGui Style");
-        ImPlot::ShowStyleSelector("ImPlot Style");
-        ImPlot::ShowColormapSelector("ImPlot Colormap");
-        float indent = ImGui::CalcItemWidth() - ImGui::GetFrameHeight();
-        ImGui::Indent(ImGui::CalcItemWidth() - ImGui::GetFrameHeight());
-        ImGui::Checkbox("Anti-Aliased Lines", &ImPlot::GetStyle().AntiAliasedLines);
-        ImGui::Unindent(indent);
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Line Plots")) {
-        static float xs1[1001], ys1[1001];
-        for (int i = 0; i < 1001; ++i) {
-            xs1[i] = i * 0.001f;
-            ys1[i] = 0.5f + 0.5f * sinf(50 * (xs1[i] + (float)DEMO_TIME / 10));
-        }
-        static double xs2[11], ys2[11];
-        for (int i = 0; i < 11; ++i) {
-            xs2[i] = i * 0.1f;
-            ys2[i] = xs2[i] * xs2[i];
-        }
-        ImGui::BulletText("Anti-aliasing can be enabled from the plot's context menu (see Help).");
-        if (ImPlot::BeginPlot("Line Plot", "x", "f(x)")) {
-            ImPlot::PlotLine("sin(x)", xs1, ys1, 1001);
-            ImPlot::SetNextMarkerStyle(ImPlotMarker_Circle);
-            ImPlot::PlotLine("x^2", xs2, ys2, 11);
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Filled Line Plots")) {
-        static double xs1[101], ys1[101], ys2[101], ys3[101];
-        srand(0);
-        for (int i = 0; i < 101; ++i) {
-            xs1[i] = (float)i;
-            ys1[i] = RandomRange(400.0,450.0);
-            ys2[i] = RandomRange(275.0,350.0);
-            ys3[i] = RandomRange(150.0,225.0);
-        }
-        static bool show_lines = true;
-        static bool show_fills = true;
-        static float fill_ref = 0;
-        static int shade_mode = 0;
-        ImGui::Checkbox("Lines",&show_lines); ImGui::SameLine();
-        ImGui::Checkbox("Fills",&show_fills);
-        if (show_fills) {
-            ImGui::SameLine();
-            if (ImGui::RadioButton("To -INF",shade_mode == 0))
-                shade_mode = 0;
-            ImGui::SameLine();
-            if (ImGui::RadioButton("To +INF",shade_mode == 1))
-                shade_mode = 1;
-            ImGui::SameLine();
-            if (ImGui::RadioButton("To Ref",shade_mode == 2))
-                shade_mode = 2;
-            if (shade_mode == 2) {
-                ImGui::SameLine();
-                ImGui::SetNextItemWidth(100);
-                ImGui::DragFloat("##Ref",&fill_ref, 1, -100, 500);
-            }
-        }
-
-
-        ImPlot::SetNextPlotLimits(0,100,0,500);
-        if (ImPlot::BeginPlot("Stock Prices", "Days", "Price")) {
-            if (show_fills) {
-                ImPlot::PushStyleVar(ImPlotStyleVar_FillAlpha, 0.25f);
-                ImPlot::PlotShaded("Stock 1", xs1, ys1, 101, shade_mode == 0 ? -INFINITY : shade_mode == 1 ? INFINITY : fill_ref);
-                ImPlot::PlotShaded("Stock 2", xs1, ys2, 101, shade_mode == 0 ? -INFINITY : shade_mode == 1 ? INFINITY : fill_ref);
-                ImPlot::PlotShaded("Stock 3", xs1, ys3, 101, shade_mode == 0 ? -INFINITY : shade_mode == 1 ? INFINITY : fill_ref);
-                ImPlot::PopStyleVar();
-            }
-            if (show_lines) {
-                ImPlot::PlotLine("Stock 1", xs1, ys1, 101);
-                ImPlot::PlotLine("Stock 2", xs1, ys2, 101);
-                ImPlot::PlotLine("Stock 3", xs1, ys3, 101);
-            }
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Shaded Plots##")) {
-        static float xs[1001], ys[1001], ys1[1001], ys2[1001], ys3[1001], ys4[1001];
-        srand(0);
-        for (int i = 0; i < 1001; ++i) {
-            xs[i]  = i * 0.001f;
-            ys[i]  = 0.25f + 0.25f * sinf(25 * xs[i]) * sinf(5 * xs[i]) + RandomRange(-0.01f, 0.01f);
-            ys1[i] = ys[i] + RandomRange(0.1f, 0.12f);
-            ys2[i] = ys[i] - RandomRange(0.1f, 0.12f);
-            ys3[i] = 0.75f + 0.2f * sinf(25 * xs[i]);
-            ys4[i] = 0.75f + 0.1f * cosf(25 * xs[i]);
-        }
-        static float alpha = 0.25f;
-        ImGui::DragFloat("Alpha",&alpha,0.01f,0,1);
-
-        if (ImPlot::BeginPlot("Shaded Plots", "X-Axis", "Y-Axis")) {
-            ImPlot::PushStyleVar(ImPlotStyleVar_FillAlpha, alpha);
-            ImPlot::PlotShaded("Uncertain Data",xs,ys1,ys2,1001);
-            ImPlot::PlotLine("Uncertain Data", xs, ys, 1001);
-            ImPlot::PlotShaded("Overlapping",xs,ys3,ys4,1001);
-            ImPlot::PlotLine("Overlapping",xs,ys3,1001);
-            ImPlot::PlotLine("Overlapping",xs,ys4,1001);
-            ImPlot::PopStyleVar();
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Scatter Plots")) {
-        srand(0);
-        static float xs1[100], ys1[100];
-        for (int i = 0; i < 100; ++i) {
-            xs1[i] = i * 0.01f;
-            ys1[i] = xs1[i] + 0.1f * ((float)rand() / (float)RAND_MAX);
-        }
-        static float xs2[50], ys2[50];
-        for (int i = 0; i < 50; i++) {
-            xs2[i] = 0.25f + 0.2f * ((float)rand() / (float)RAND_MAX);
-            ys2[i] = 0.75f + 0.2f * ((float)rand() / (float)RAND_MAX);
-        }
-
-        if (ImPlot::BeginPlot("Scatter Plot", NULL, NULL)) {
-            ImPlot::PlotScatter("Data 1", xs1, ys1, 100);
-            ImPlot::PushStyleVar(ImPlotStyleVar_FillAlpha, 0.25f);
-            ImPlot::SetNextMarkerStyle(ImPlotMarker_Square, 6, ImVec4(0,1,0,0.5f), IMPLOT_AUTO, ImVec4(0,1,0,1));
-            ImPlot::PlotScatter("Data 2", xs2, ys2, 50);
-            ImPlot::PopStyleVar();
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Stairstep Plots")) {
-        static float ys1[101], ys2[101];
-        for (int i = 0; i < 101; ++i) {
-            ys1[i] = 0.5f + 0.4f * sinf(50 * i * 0.01f);
-            ys2[i] = 0.5f + 0.2f * sinf(25 * i * 0.01f);
-        }
-        if (ImPlot::BeginPlot("Stairstep Plot", "x", "f(x)")) {
-            ImPlot::PlotStairs("Signal 1", ys1, 101, 0.01f);
-            ImPlot::SetNextMarkerStyle(ImPlotMarker_Square, 2.0f);
-            ImPlot::PlotStairs("Signal 2", ys2, 101, 0.01f);
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Bar Plots")) {
-
-        static bool horz                = false;
-        static ImS8  midtm[10]          = {83, 67, 23, 89, 83, 78, 91, 82, 85, 90};
-        static ImS16 final[10]          = {80, 62, 56, 99, 55, 78, 88, 78, 90, 100};
-        static ImS32 grade[10]          = {80, 69, 52, 92, 72, 78, 75, 76, 89, 95};
-
-        static const char*  labels[]    = {"S1","S2","S3","S4","S5","S6","S7","S8","S9","S10"};
-        static const double positions[] = {0,1,2,3,4,5,6,7,8,9};
-
-        ImGui::Checkbox("Horizontal",&horz);
-
-        if (horz) {
-            ImPlot::SetNextPlotLimits(0, 110, -0.5, 9.5, ImGuiCond_Always);
-            ImPlot::SetNextPlotTicksY(positions, 10, labels);
-        }
-        else {
-            ImPlot::SetNextPlotLimits(-0.5, 9.5, 0, 110, ImGuiCond_Always);
-            ImPlot::SetNextPlotTicksX(positions, 10, labels);
-        }
-        if (ImPlot::BeginPlot("Bar Plot", horz ? "Score" :  "Student", horz ? "Student" : "Score",
-                              ImVec2(-1,0), 0, 0, horz ? ImPlotAxisFlags_Invert : 0))
-        {
-            if (horz) {
-                ImPlot::SetLegendLocation(ImPlotLocation_West, ImPlotOrientation_Vertical);
-                ImPlot::PlotBarsH("Midterm Exam", midtm, 10, 0.2, -0.2);
-                ImPlot::PlotBarsH("Final Exam",   final, 10, 0.2,    0);
-                ImPlot::PlotBarsH("Course Grade", grade, 10, 0.2,  0.2);
-            }
-            else {
-                ImPlot::SetLegendLocation(ImPlotLocation_South, ImPlotOrientation_Horizontal);
-                ImPlot::PlotBars("Midterm Exam", midtm, 10, 0.2, -0.2);
-                ImPlot::PlotBars("Final Exam",   final, 10, 0.2,    0);
-                ImPlot::PlotBars("Course Grade", grade, 10, 0.2,  0.2);
-            }
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Error Bars")) {
-        static float xs[5]    = {1,2,3,4,5};
-        static float bar[5]   = {1,2,5,3,4};
-        static float lin1[5]  = {8,8,9,7,8};
-        static float lin2[5]  = {6,7,6,9,6};
-        static float err1[5]  = {0.2f, 0.4f, 0.2f, 0.6f, 0.4f};
-        static float err2[5]  = {0.4f, 0.2f, 0.4f, 0.8f, 0.6f};
-        static float err3[5]  = {0.09f, 0.14f, 0.09f, 0.12f, 0.16f};
-        static float err4[5]  = {0.02f, 0.08f, 0.15f, 0.05f, 0.2f};
-
-
-        ImPlot::SetNextPlotLimits(0, 6, 0, 10);
-        if (ImPlot::BeginPlot("##ErrorBars",NULL,NULL)) {
-
-            ImPlot::PlotBars("Bar", xs, bar, 5, 0.5f);
-            ImPlot::PlotErrorBars("Bar", xs, bar, err1, 5);
-
-            ImPlot::SetNextErrorBarStyle(ImPlot::GetColormapColor(1), 0);
-            ImPlot::PlotErrorBars("Line", xs, lin1, err1, err2, 5);
-            ImPlot::SetNextMarkerStyle(ImPlotMarker_Circle);
-            ImPlot::PlotLine("Line", xs, lin1, 5);
-
-            ImPlot::PushStyleColor(ImPlotCol_ErrorBar, ImPlot::GetColormapColor(2));
-            ImPlot::PlotErrorBars("Scatter", xs, lin2, err2, 5);
-            ImPlot::PlotErrorBarsH("Scatter", xs, lin2,  err3, err4, 5);
-            ImPlot::PopStyleColor();
-            ImPlot::PlotScatter("Scatter", xs, lin2, 5);
-
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Stem Plots##")) {
-        static double xs[51], ys1[51], ys2[51];
-        for (int i = 0; i < 51; ++i) {
-            xs[i] = i * 0.02;
-            ys1[i] = 1.0 + 0.5 * sin(25*xs[i])*cos(2*xs[i]);
-            ys2[i] = 0.5 + 0.25  * sin(10*xs[i]) * sin(xs[i]);
-        }
-        ImPlot::SetNextPlotLimits(0,1,0,1.6);
-        if (ImPlot::BeginPlot("Stem Plots")) {
-            ImPlot::PlotStems("Stems 1",xs,ys1,51);
-            ImPlot::SetNextLineStyle(ImVec4(1,0.5f,0,0.75f));
-            ImPlot::SetNextMarkerStyle(ImPlotMarker_Square,5,ImVec4(1,0.5f,0,0.25f));
-            ImPlot::PlotStems("Stems 2", xs, ys2,51);
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Infinite Lines")) {
-        static double vals[] = {0.25, 0.5, 0.75};
-        if (ImPlot::BeginPlot("##Infinite",0,0,ImVec2(-1,0),0,ImPlotAxisFlags_NoInitialFit,ImPlotAxisFlags_NoInitialFit)) {
-            ImPlot::PlotVLines("VLines",vals,3);
-            ImPlot::PlotHLines("HLines",vals,3);
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Pie Charts")) {
-        static const char* labels1[]   = {"Frogs","Hogs","Dogs","Logs"};
-        static float data1[]           = {0.15f,  0.30f,  0.2f, 0.05f};
-        static bool normalize          = false;
-        ImGui::SetNextItemWidth(250);
-        ImGui::DragFloat4("Values", data1, 0.01f, 0, 1);
-        if ((data1[0] + data1[1] + data1[2] + data1[3]) < 1) {
-            ImGui::SameLine();
-            ImGui::Checkbox("Normalize", &normalize);
-        }
-
-        ImPlot::SetNextPlotLimits(0,1,0,1,ImGuiCond_Always);
-        if (ImPlot::BeginPlot("##Pie1", NULL, NULL, ImVec2(250,250), ImPlotFlags_Equal | ImPlotFlags_NoMousePos, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations)) {
-            ImPlot::PlotPieChart(labels1, data1, 4, 0.5, 0.5, 0.4, normalize, "%.2f");
-            ImPlot::EndPlot();
-        }
-
-        ImGui::SameLine();
-
-        static const char* labels2[]   = {"A","B","C","D","E"};
-        static int data2[]             = {1,1,2,3,5};
-
-        ImPlot::PushColormap(ImPlotColormap_Pastel);
-        ImPlot::SetNextPlotLimits(0,1,0,1,ImGuiCond_Always);
-        if (ImPlot::BeginPlot("##Pie2", NULL, NULL, ImVec2(250,250), ImPlotFlags_Equal | ImPlotFlags_NoMousePos, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations)) {
-            ImPlot::PlotPieChart(labels2, data2, 5, 0.5, 0.5, 0.4, true, "%.0f", 180);
-            ImPlot::EndPlot();
-        }
-        ImPlot::PopColormap();
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Heatmaps")) {
-        static float values1[7][7]  = {{0.8f, 2.4f, 2.5f, 3.9f, 0.0f, 4.0f, 0.0f},
-                                       {2.4f, 0.0f, 4.0f, 1.0f, 2.7f, 0.0f, 0.0f},
-                                       {1.1f, 2.4f, 0.8f, 4.3f, 1.9f, 4.4f, 0.0f},
-                                       {0.6f, 0.0f, 0.3f, 0.0f, 3.1f, 0.0f, 0.0f},
-                                       {0.7f, 1.7f, 0.6f, 2.6f, 2.2f, 6.2f, 0.0f},
-                                       {1.3f, 1.2f, 0.0f, 0.0f, 0.0f, 3.2f, 5.1f},
-                                       {0.1f, 2.0f, 0.0f, 1.4f, 0.0f, 1.9f, 6.3f}};
-        static float scale_min       = 0;
-        static float scale_max       = 6.3f;
-        static const char* xlabels[] = {"C1","C2","C3","C4","C5","C6","C7"};
-        static const char* ylabels[] = {"R1","R2","R3","R4","R5","R6","R7"};
-
-        static ImPlotColormap map = ImPlotColormap_Viridis;
-        if (ImPlot::ColormapButton(ImPlot::GetColormapName(map),ImVec2(225,0),map)) {
-            map = (map + 1) % ImPlot::GetColormapCount();
-            // We bust the color cache of our plots so that item colors will
-            // resample the new colormap in the event that they have already
-            // been created. See documentation in implot.h.
-            BustColorCache("##Heatmap1");
-            BustColorCache("##Heatmap2");
-        }
-
-        ImGui::SameLine();
-        ImGui::LabelText("##Colormap Index", "%s", "Change Colormap");
-        ImGui::SetNextItemWidth(225);
-        ImGui::DragFloatRange2("Min / Max",&scale_min, &scale_max, 0.01f, -20, 20);
-        static ImPlotAxisFlags axes_flags = ImPlotAxisFlags_Lock | ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_NoTickMarks;
-
-        ImPlot::PushColormap(map);
-        SetNextPlotTicksX(0 + 1.0/14.0, 1 - 1.0/14.0, 7, xlabels);
-        SetNextPlotTicksY(1 - 1.0/14.0, 0 + 1.0/14.0, 7, ylabels);
-        if (ImPlot::BeginPlot("##Heatmap1",NULL,NULL,ImVec2(225,225),ImPlotFlags_NoLegend|ImPlotFlags_NoMousePos,axes_flags,axes_flags)) {
-            ImPlot::PlotHeatmap("heat",values1[0],7,7,scale_min,scale_max);
-            ImPlot::EndPlot();
-        }
-        ImGui::SameLine();
-        ImPlot::ColormapScale("##HeatScale",scale_min, scale_max, ImVec2(60,225));
-
-        ImGui::SameLine();
-
-        const int size = 200;
-        static double values2[size*size];
-        srand((unsigned int)(DEMO_TIME*1000000));
-        for (int i = 0; i < size*size; ++i)
-            values2[i] = RandomRange(0.0,1.0);
-
-        ImPlot::SetNextPlotLimits(-1,1,-1,1);
-        if (ImPlot::BeginPlot("##Heatmap2",NULL,NULL,ImVec2(225,225),0,ImPlotAxisFlags_NoDecorations,ImPlotAxisFlags_NoDecorations)) {
-            ImPlot::PlotHeatmap("heat1",values2,size,size,0,1,NULL);
-            ImPlot::PlotHeatmap("heat2",values2,size,size,0,1,NULL, ImPlotPoint(-1,-1), ImPlotPoint(0,0));
-            ImPlot::EndPlot();
-        }
-        ImPlot::PopColormap();
-
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Histograms")) {
-        static int  bins       = 50;
-        static bool cumulative = false;
-        static bool density    = true;
-        static bool outliers   = true;
-        static double mu       = 5;
-        static double sigma    = 2;
-
-        ImGui::SetNextItemWidth(200);
-        if (ImGui::RadioButton("Sqrt",bins==ImPlotBin_Sqrt))       { bins = ImPlotBin_Sqrt;    } ImGui::SameLine();
-        if (ImGui::RadioButton("Sturges",bins==ImPlotBin_Sturges)) { bins = ImPlotBin_Sturges; } ImGui::SameLine();
-        if (ImGui::RadioButton("Rice",bins==ImPlotBin_Rice))       { bins = ImPlotBin_Rice;    } ImGui::SameLine();
-        if (ImGui::RadioButton("Scott",bins==ImPlotBin_Scott))     { bins = ImPlotBin_Scott;   } ImGui::SameLine();
-        if (ImGui::RadioButton("N Bins",bins>=0))                       bins = 50;
-        if (bins>=0) {
-            ImGui::SameLine();
-            ImGui::SetNextItemWidth(200);
-            ImGui::SliderInt("##Bins", &bins, 1, 100);
-        }
-        if (ImGui::Checkbox("Density", &density))
-            ImPlot::FitNextPlotAxes();
-        ImGui::SameLine();
-        if (ImGui::Checkbox("Cumulative", &cumulative))
-            ImPlot::FitNextPlotAxes();
-        ImGui::SameLine();
-        static bool range = false;
-        ImGui::Checkbox("Range", &range);
-        static float rmin = -3;
-        static float rmax = 13;
-        if (range) {
-            ImGui::SameLine();
-            ImGui::SetNextItemWidth(200);
-            ImGui::DragFloat2("##Range",&rmin,0.1f,-3,13);
-            ImGui::SameLine();
-            ImGui::Checkbox("Outliers",&outliers);
-        }
-
-        static NormalDistribution<10000> dist(mu, sigma);
-        static double x[100];
-        static double y[100];
-        if (density) {
-            for (int i = 0; i < 100; ++i) {
-                x[i] = -3 + 16 * (double)i/99.0;
-                y[i] = exp( - (x[i]-mu)*(x[i]-mu) / (2*sigma*sigma)) / (sigma * sqrt(2*3.141592653589793238));
-            }
-            if (cumulative) {
-                for (int i = 1; i < 100; ++i)
-                    y[i] += y[i-1];
-                for (int i = 0; i < 100; ++i)
-                    y[i] /= y[99];
-            }
-        }
-
-        if (ImPlot::BeginPlot("##Histograms")) {
-            ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, 0.5f);
-            ImPlot::PlotHistogram("Empirical", dist.Data, 10000, bins, cumulative, density, range ? ImPlotRange(rmin,rmax) : ImPlotRange(), outliers);
-            if (density && outliers)
-                ImPlot::PlotLine("Theoretical",x,y,100);
-            ImPlot::EndPlot();
-        }
-
-        static int count     = 500000;
-        static int xybins[2] = {200,200};
-        static bool density2 = false;
-        ImGui::SliderInt("Count",&count,100,500000);
-        ImGui::SliderInt2("Bins",xybins,1,500);
-        ImGui::SameLine();
-        ImGui::Checkbox("Density##2",&density2);
-        static NormalDistribution<500000> dist1(1, 2);
-        static NormalDistribution<500000> dist2(1, 1);
-        double max_count = 0;
-        ImPlotAxisFlags flags = ImPlotAxisFlags_AutoFit|ImPlotAxisFlags_Foreground;
-        ImPlot::PushColormap("Hot");
-        if (ImPlot::BeginPlot("##Hist2D",0,0,ImVec2(ImGui::GetContentRegionAvail().x-100-ImGui::GetStyle().ItemSpacing.x,0),0,flags,flags)) {
-            max_count = ImPlot::PlotHistogram2D("Hist2D",dist1.Data,dist2.Data,count,xybins[0],xybins[1],density2,ImPlotLimits(-6,6,-6,6));
-            ImPlot::EndPlot();
-        }
-        ImGui::SameLine();
-        ImPlot::ColormapScale(density2 ? "Density" : "Count",0,max_count,ImVec2(100,0));
-        ImPlot::PopColormap();
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Digital Plots")) {
-        ImGui::BulletText("Digital plots do not respond to Y drag and zoom, so that");
-        ImGui::Indent();
-        ImGui::Text("you can drag analog plots over the rising/falling digital edge.");
-        ImGui::Unindent();
-
-        static bool paused = false;
-        static ScrollingBuffer dataDigital[2];
-        static ScrollingBuffer dataAnalog[2];
-        static bool showDigital[2] = {true, false};
-        static bool showAnalog[2] = {true, false};
-
-        char label[32];
-        ImGui::Checkbox("digital_0", &showDigital[0]); ImGui::SameLine();
-        ImGui::Checkbox("digital_1", &showDigital[1]); ImGui::SameLine();
-        ImGui::Checkbox("analog_0",  &showAnalog[0]);  ImGui::SameLine();
-        ImGui::Checkbox("analog_1",  &showAnalog[1]);
-
-        static float t = 0;
-        if (!paused) {
-            t += ImGui::GetIO().DeltaTime;
-            //digital signal values
-            if (showDigital[0])
-                dataDigital[0].AddPoint(t, sinf(2*t) > 0.45);
-            if (showDigital[1])
-                dataDigital[1].AddPoint(t, sinf(2*t) < 0.45);
-            //Analog signal values
-            if (showAnalog[0])
-                dataAnalog[0].AddPoint(t, sinf(2*t));
-            if (showAnalog[1])
-                dataAnalog[1].AddPoint(t, cosf(2*t));
-        }
-        ImPlot::SetNextPlotLimitsY(-1, 1);
-        ImPlot::SetNextPlotLimitsX(t - 10.0, t, paused ? ImGuiCond_Once : ImGuiCond_Always);
-        if (ImPlot::BeginPlot("##Digital")) {
-            for (int i = 0; i < 2; ++i) {
-                if (showDigital[i] && dataDigital[i].Data.size() > 0) {
-                    sprintf(label, "digital_%d", i);
-                    ImPlot::PlotDigital(label, &dataDigital[i].Data[0].x, &dataDigital[i].Data[0].y, dataDigital[i].Data.size(), dataDigital[i].Offset, 2 * sizeof(float));
-                }
-            }
-            for (int i = 0; i < 2; ++i) {
-                if (showAnalog[i]) {
-                    sprintf(label, "analog_%d", i);
-                    if (dataAnalog[i].Data.size() > 0)
-                        ImPlot::PlotLine(label, &dataAnalog[i].Data[0].x, &dataAnalog[i].Data[0].y, dataAnalog[i].Data.size(), dataAnalog[i].Offset, 2 * sizeof(float));
-                }
-            }
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Images")) {
-        ImGui::BulletText("Below we are displaying the font texture, which is the only texture we have\naccess to in this demo.");
-        ImGui::BulletText("Use the 'ImTextureID' type as storage to pass pointers or identifiers to your\nown texture data.");
-        ImGui::BulletText("See ImGui Wiki page 'Image Loading and Displaying Examples'.");
-        static ImVec2 bmin(0,0);
-        static ImVec2 bmax(1,1);
-        static ImVec2 uv0(0,0);
-        static ImVec2 uv1(1,1);
-        static ImVec4 tint(1,1,1,1);
-        ImGui::SliderFloat2("Min", &bmin.x, -2, 2, "%.1f");
-        ImGui::SliderFloat2("Max", &bmax.x, -2, 2, "%.1f");
-        ImGui::SliderFloat2("UV0", &uv0.x, -2, 2, "%.1f");
-        ImGui::SliderFloat2("UV1", &uv1.x, -2, 2, "%.1f");
-        ImGui::ColorEdit4("Tint",&tint.x);
-        if (ImPlot::BeginPlot("##image")) {
-            ImPlot::PlotImage("my image",ImGui::GetIO().Fonts->TexID, bmin, bmax, uv0, uv1, tint);
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Realtime Plots")) {
-        ImGui::BulletText("Move your mouse to change the data!");
-        ImGui::BulletText("This example assumes 60 FPS. Higher FPS requires larger buffer size.");
-        static ScrollingBuffer sdata1, sdata2;
-        static RollingBuffer   rdata1, rdata2;
-        ImVec2 mouse = ImGui::GetMousePos();
-        static float t = 0;
-        t += ImGui::GetIO().DeltaTime;
-        sdata1.AddPoint(t, mouse.x * 0.0005f);
-        rdata1.AddPoint(t, mouse.x * 0.0005f);
-        sdata2.AddPoint(t, mouse.y * 0.0005f);
-        rdata2.AddPoint(t, mouse.y * 0.0005f);
-
-        static float history = 10.0f;
-        ImGui::SliderFloat("History",&history,1,30,"%.1f s");
-        rdata1.Span = history;
-        rdata2.Span = history;
-
-        static ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
-        ImPlot::SetNextPlotLimitsX(t - history, t, ImGuiCond_Always);
-        ImPlot::SetNextPlotLimitsY(0,1);
-        if (ImPlot::BeginPlot("##Scrolling", NULL, NULL, ImVec2(-1,150), 0, flags, flags)) {
-            ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL,0.5f);
-            ImPlot::PlotShaded("Mouse X", &sdata1.Data[0].x, &sdata1.Data[0].y, sdata1.Data.size(), -INFINITY, sdata1.Offset, 2 * sizeof(float));
-            ImPlot::PlotLine("Mouse Y", &sdata2.Data[0].x, &sdata2.Data[0].y, sdata2.Data.size(), sdata2.Offset, 2*sizeof(float));
-            ImPlot::EndPlot();
-        }
-        ImPlot::SetNextPlotLimitsX(0, history, ImGuiCond_Always);
-        ImPlot::SetNextPlotLimitsY(0,1);
-        if (ImPlot::BeginPlot("##Rolling", NULL, NULL, ImVec2(-1,150), 0, flags, flags)) {
-            ImPlot::PlotLine("Mouse X", &rdata1.Data[0].x, &rdata1.Data[0].y, rdata1.Data.size(), 0, 2 * sizeof(float));
-            ImPlot::PlotLine("Mouse Y", &rdata2.Data[0].x, &rdata2.Data[0].y, rdata2.Data.size(), 0, 2 * sizeof(float));
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Markers and Text")) {
-        static float mk_size = ImPlot::GetStyle().MarkerSize;
-        static float mk_weight = ImPlot::GetStyle().MarkerWeight;
-        ImGui::DragFloat("Marker Size",&mk_size,0.1f,2.0f,10.0f,"%.2f px");
-        ImGui::DragFloat("Marker Weight", &mk_weight,0.05f,0.5f,3.0f,"%.2f px");
-
-        ImPlot::SetNextPlotLimits(0, 10, 0, 12);
-        if (ImPlot::BeginPlot("##MarkerStyles", NULL, NULL, ImVec2(-1,0), ImPlotFlags_CanvasOnly, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations)) {
-            ImS8 xs[2] = {1,4};
-            ImS8 ys[2] = {10,11};
-
-            // filled markers
-            for (int m = 0; m < ImPlotMarker_COUNT; ++m) {
-                ImGui::PushID(m);
-                ImPlot::SetNextMarkerStyle(m, mk_size, IMPLOT_AUTO_COL, mk_weight);
-                ImPlot::PlotLine("##Filled", xs, ys, 2);
-                ImGui::PopID();
-                ys[0]--; ys[1]--;
-            }
-            xs[0] = 6; xs[1] = 9; ys[0] = 10; ys[1] = 11;
-            // open markers
-            for (int m = 0; m < ImPlotMarker_COUNT; ++m) {
-                ImGui::PushID(m);
-                ImPlot::SetNextMarkerStyle(m, mk_size, ImVec4(0,0,0,0), mk_weight);
-                ImPlot::PlotLine("##Open", xs, ys, 2);
-                ImGui::PopID();
-                ys[0]--; ys[1]--;
-            }
-
-            ImPlot::PlotText("Filled Markers", 2.5f, 6.0f);
-            ImPlot::PlotText("Open Markers",   7.5f, 6.0f);
-
-            ImPlot::PushStyleColor(ImPlotCol_InlayText, ImVec4(1,0,1,1));
-            ImPlot::PlotText("Vertical Text", 5.0f, 6.0f, true);
-            ImPlot::PopStyleColor();
-
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Log Scale")) {
-        static double xs[1001], ys1[1001], ys2[1001], ys3[1001];
-        for (int i = 0; i < 1001; ++i) {
-            xs[i]  = i*0.1f;
-            ys1[i] = sin(xs[i]) + 1;
-            ys2[i] = log(xs[i]);
-            ys3[i] = pow(10.0, xs[i]);
-        }
-        ImGui::BulletText("Open the plot context menu (right click) to change scales.");
-
-        ImPlot::SetNextPlotLimits(0.1, 100, 0, 10);
-        if (ImPlot::BeginPlot("Log Plot", NULL, NULL, ImVec2(-1,0), 0, ImPlotAxisFlags_LogScale )) {
-            ImPlot::PlotLine("f(x) = x",        xs, xs,  1001);
-            ImPlot::PlotLine("f(x) = sin(x)+1", xs, ys1, 1001);
-            ImPlot::PlotLine("f(x) = log(x)",   xs, ys2, 1001);
-            ImPlot::PlotLine("f(x) = 10^x",     xs, ys3, 21);
-            ImPlot::EndPlot();
-        }
-    }
-    if (ImGui::CollapsingHeader("Time Formatted Axes")) {
-
-        static double t_min = 1609459200; // 01/01/2021 @ 12:00:00am (UTC)
-        static double t_max = 1640995200; // 01/01/2022 @ 12:00:00am (UTC)
-
-        ImGui::BulletText("When ImPlotAxisFlags_Time is enabled on the X-Axis, values are interpreted as\n"
-                          "UNIX timestamps in seconds and axis labels are formated as date/time.");
-        ImGui::BulletText("By default, labels are in UTC time but can be set to use local time instead.");
-
-        ImGui::Checkbox("Local Time",&ImPlot::GetStyle().UseLocalTime);
-        ImGui::SameLine();
-        ImGui::Checkbox("ISO 8601",&ImPlot::GetStyle().UseISO8601);
-        ImGui::SameLine();
-        ImGui::Checkbox("24 Hour Clock",&ImPlot::GetStyle().Use24HourClock);
-
-        static HugeTimeData* data = NULL;
-        if (data == NULL) {
-            ImGui::SameLine();
-            if (ImGui::Button("Generate Huge Data (~500MB!)")) {
-                static HugeTimeData sdata(t_min);
-                data = &sdata;
-            }
-        }
-
-        ImPlot::SetNextPlotLimits(t_min,t_max,0,1);
-        if (ImPlot::BeginPlot("##Time", NULL, NULL, ImVec2(-1,0), 0, ImPlotAxisFlags_Time)) {
-            if (data != NULL) {
-                // downsample our data
-                int downsample = (int)ImPlot::GetPlotLimits().X.Size() / 1000 + 1;
-                int start = (int)(ImPlot::GetPlotLimits().X.Min - t_min);
-                start = start < 0 ? 0 : start > HugeTimeData::Size - 1 ? HugeTimeData::Size - 1 : start;
-                int end = (int)(ImPlot::GetPlotLimits().X.Max - t_min) + 1000;
-                end = end < 0 ? 0 : end > HugeTimeData::Size - 1 ? HugeTimeData::Size - 1 : end;
-                int size = (end - start)/downsample;
-                // plot it
-                ImPlot::PlotLine("Time Series", &data->Ts[start], &data->Ys[start], size, 0, sizeof(double)*downsample);
-            }
-            // plot time now
-            double t_now = (double)time(0);
-            double y_now = HugeTimeData::GetY(t_now);
-            ImPlot::PlotScatter("Now",&t_now,&y_now,1);
-            ImPlot::Annotate(t_now,y_now,ImVec2(10,10),ImPlot::GetLastItemColor(),"Now");
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Multiple Y-Axes")) {
-        static float xs[1001], xs2[1001], ys1[1001], ys2[1001], ys3[1001];
-        for (int i = 0; i < 1001; ++i) {
-            xs[i]  = (i*0.1f);
-            ys1[i] = sinf(xs[i]) * 3 + 1;
-            ys2[i] = cosf(xs[i]) * 0.2f + 0.5f;
-            ys3[i] = sinf(xs[i]+0.5f) * 100 + 200;
-            xs2[i] = xs[i] + 10.0f;
-        }
-        static bool y2_axis = true;
-        static bool y3_axis = true;
-        ImGui::Checkbox("Y-Axis 2", &y2_axis);
-        ImGui::SameLine();
-        ImGui::Checkbox("Y-Axis 3", &y3_axis);
-        ImGui::SameLine();
-
-        // you can fit axes programatically
-        ImGui::SameLine(); if (ImGui::Button("Fit X"))  ImPlot::FitNextPlotAxes(true, false, false, false);
-        ImGui::SameLine(); if (ImGui::Button("Fit Y"))  ImPlot::FitNextPlotAxes(false, true, false, false);
-        ImGui::SameLine(); if (ImGui::Button("Fit Y2")) ImPlot::FitNextPlotAxes(false, false, true, false);
-        ImGui::SameLine(); if (ImGui::Button("Fit Y3")) ImPlot::FitNextPlotAxes(false, false, false, true);
-
-        ImPlot::SetNextPlotLimits(0.1, 100, 0, 10);
-        ImPlot::SetNextPlotLimitsY(0, 1, ImGuiCond_Once, 1);
-        ImPlot::SetNextPlotLimitsY(0, 300, ImGuiCond_Once, 2);
-        if (ImPlot::BeginPlot("Multi-Axis Plot", NULL, "Y-Axis 1", ImVec2(-1,0),
-                             (y2_axis ? ImPlotFlags_YAxis2 : 0) |
-                             (y3_axis ? ImPlotFlags_YAxis3 : 0),
-                              ImPlotAxisFlags_None, ImPlotAxisFlags_None, ImPlotAxisFlags_NoGridLines, ImPlotAxisFlags_NoGridLines,
-                              "Y-Axis 2", "Y-Axis 3")) {
-            ImPlot::PlotLine("f(x) = x", xs, xs, 1001);
-            ImPlot::PlotLine("f(x) = sin(x)*3+1", xs, ys1, 1001);
-            if (y2_axis) {
-                ImPlot::SetPlotYAxis(ImPlotYAxis_2);
-                ImPlot::PlotLine("f(x) = cos(x)*.2+.5 (Y2)", xs, ys2, 1001);
-            }
-            if (y3_axis) {
-                ImPlot::SetPlotYAxis(ImPlotYAxis_3);
-                ImPlot::PlotLine("f(x) = sin(x+.5)*100+200 (Y3)", xs2, ys3, 1001);
-            }
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Linked Axes")) {
-        static double xmin = 0, xmax = 1, ymin = 0, ymax = 1;
-        static bool linkx = true, linky = true;
-        int data[2] = {0,1};
-        ImGui::Checkbox("Link X", &linkx);
-        ImGui::SameLine();
-        ImGui::Checkbox("Link Y", &linky);
-        ImPlot::LinkNextPlotLimits(linkx ? &xmin : NULL , linkx ? &xmax : NULL, linky ? &ymin : NULL, linky ? &ymax : NULL);
-        if (ImPlot::BeginPlot("Plot A")) {
-            ImPlot::PlotLine("Line",data,2);
-            ImPlot::EndPlot();
-        }
-        ImPlot::LinkNextPlotLimits(linkx ? &xmin : NULL , linkx ? &xmax : NULL, linky ? &ymin : NULL, linky ? &ymax : NULL);
-        if (ImPlot::BeginPlot("Plot B")) {
-            ImPlot::PlotLine("Line",data,2);
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Equal Axes")) {
-        static double xs[1000], ys[1000];
-        for (int i = 0; i < 1000; ++i) {
-            double angle = i * 2 * PI / 999.0;
-            xs[i] = cos(angle); ys[i] = sin(angle);
-        }
-        if (ImPlot::BeginPlot("",0,0,ImVec2(-1,0),ImPlotFlags_Equal)) {
-            ImPlot::PlotLine("Circle",xs,ys,1000);
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Subplots")) {
-        static ImPlotSubplotFlags flags = ImPlotSubplotFlags_None;
-        ImGui::CheckboxFlags("ImPlotSubplotFlags_LinkRows", (unsigned int*)&flags, ImPlotSubplotFlags_LinkRows);
-        ImGui::CheckboxFlags("ImPlotSubplotFlags_LinkCols", (unsigned int*)&flags, ImPlotSubplotFlags_LinkCols);
-        ImGui::CheckboxFlags("ImPlotSubplotFlags_LinkAllX", (unsigned int*)&flags, ImPlotSubplotFlags_LinkAllX);
-        ImGui::CheckboxFlags("ImPlotSubplotFlags_LinkAllY", (unsigned int*)&flags, ImPlotSubplotFlags_LinkAllY);
-        ImGui::CheckboxFlags("ImPlotSubplotFlags_NoAlign", (unsigned int*)&flags, ImPlotSubplotFlags_NoAlign);
-        ImGui::CheckboxFlags("ImPlotSubplotFlags_NoTitle", (unsigned int*)&flags, ImPlotSubplotFlags_NoTitle);
-
-        static int rows = 2;
-        static int cols = 2;
-        ImGui::SliderInt("Rows",&rows,1,5);
-        ImGui::SliderInt("Cols",&cols,1,5);
-        static MyImPlot::WaveData wd(1,1,10,0);
-        if (ImPlot::BeginSubplots("Subplots", rows, cols, ImVec2(-1,450), flags)) {
-            for (int i = 0; i < rows*cols; ++i) {
-                if (ImPlot::BeginPlot("title","x-axis","y-axis",ImVec2(0,0),0)) {
-                    ImPlot::PlotLineG("data",MyImPlot::SineWave,&wd,1000);
-                    ImPlot::EndPlot();
-                }
-            }
-            ImPlot::EndSubplots();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Auto-Fitting Data")) {
-
-        ImGui::BulletText("The Y-axis has been configured to auto-fit to only the data visible in X-axis range.");
-        ImGui::BulletText("Zoom and pan the X-axis. Disable Stems to see a difference in fit.");
-        ImGui::BulletText("If ImPlotAxisFlags_RangeFit is disabled, the axis will fit ALL data.");
-
-        static ImPlotAxisFlags xflags = ImPlotAxisFlags_None;
-        static ImPlotAxisFlags yflags = ImPlotAxisFlags_AutoFit|ImPlotAxisFlags_RangeFit;
-
-        ImGui::TextUnformatted("X: "); ImGui::SameLine();
-        ImGui::CheckboxFlags("ImPlotAxisFlags_AutoFit##X", (unsigned int*)&xflags, ImPlotAxisFlags_AutoFit); ImGui::SameLine();
-        ImGui::CheckboxFlags("ImPlotAxisFlags_RangeFit##X", (unsigned int*)&xflags, ImPlotAxisFlags_RangeFit);
-
-        ImGui::TextUnformatted("Y: "); ImGui::SameLine();
-        ImGui::CheckboxFlags("ImPlotAxisFlags_AutoFit##Y", (unsigned int*)&yflags, ImPlotAxisFlags_AutoFit); ImGui::SameLine();
-        ImGui::CheckboxFlags("ImPlotAxisFlags_RangeFit##Y", (unsigned int*)&yflags, ImPlotAxisFlags_RangeFit);
-
-        static double data[101];
-        srand(0);
-        for (int i = 0; i < 101; ++i)
-            data[i] = 1 + sin(i/10.0f);
-
-        if (ImPlot::BeginPlot("##DataFitting","X","Y",ImVec2(-1,0),0,xflags,yflags)) {
-            ImPlot::PlotLine("Line",data,101);
-            ImPlot::PlotStems("Stems",data,101);
-            ImPlot::EndPlot();
-        };
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Align plot group")) {
-        static double xmin = 0, xmax = 1;
-        int data[2] = {0,1};
-        static int orientation = 0;
-        static float hzWidth = (ImGui::GetWindowSize().x / 3) - 20;
-        ImGui::Combo("Orientation", &orientation, "Vertical\0Horizontal\0");
-        if (ImPlot::BeginAlignedPlots("Align_Demo", (orientation == 0) ? ImPlotOrientation_Vertical : ImPlotOrientation_Horizontal)) {
-            static bool showA = true;
-            ImGui::Checkbox("A", &showA); ImGui::SameLine();
-            static bool showB = true;
-            ImGui::Checkbox("B", &showB); ImGui::SameLine();
-            static bool showC = false;
-            ImGui::Checkbox("C", &showC);
-            if (showA) {
-                ImPlot::SetNextPlotLimitsY(-1000, 1000, ImGuiCond_Once, 0);
-                ImPlot::LinkNextPlotLimits(&xmin, &xmax, NULL, NULL);
-                if (ImPlot::BeginPlot("Plot A", NULL, NULL, ImVec2((orientation == 0) ? -1 : hzWidth, 200))) {
-                    ImPlot::PlotLine("Line",data,2);
-                    ImPlot::EndPlot();
-                }
-            }
-            if (showB) {
-                if (orientation != 0) ImGui::SameLine();
-                ImPlot::LinkNextPlotLimits(&xmin, &xmax, NULL, NULL);
-                if (ImPlot::BeginPlot((orientation == 0) ? "Plot B" : "##Plot B", NULL, NULL, ImVec2((orientation == 0) ? -1 : hzWidth, 200), ImPlotFlags_YAxis2)) {
-                    ImPlot::PlotLine("Line",data,2);
-                    ImPlot::EndPlot();
-                }
-            }
-            if (showC) {
-                if (orientation != 0) ImGui::SameLine();
-                static int yAxis = 0;
-                ImPlot::LinkNextPlotLimits(&xmin, &xmax, NULL, NULL);
-                ImPlot::SetNextPlotLimitsY(-100000, 100000, ImGuiCond_Once, 0);
-                ImPlot::SetNextPlotLimitsY(-100000, 100000, ImGuiCond_Once, 1);
-                ImPlot::SetNextPlotLimitsY(-100000, 100000, ImGuiCond_Once, 2);
-                if (ImPlot::BeginPlot("Plot C", (orientation == 0) ? NULL : "X axis label", "Y axis label", ImVec2((orientation == 0) ? -1 : hzWidth, 200), ((yAxis > 0 ) ? ImPlotFlags_YAxis2 : 0) | ((yAxis > 1 ) ? ImPlotFlags_YAxis3 : 0))) {
-                    ImPlot::PlotLine("Line",data,2);
-                    ImPlot::EndPlot();
-                }
-                ImGui::SetNextItemWidth(150);
-                ImGui::Combo("Y axis", &yAxis, "Y1\0Y1, Y2\0Y1, Y2, Y3\0");
-            }
-            ImPlot::EndAlignedPlots();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Querying")) {
-        static ImVector<ImPlotPoint> data;
-        static ImPlotLimits range, query, select;
-
-        ImGui::BulletText("Ctrl + click in the plot area to draw points.");
-        ImGui::BulletText("Middle click (or Ctrl + right click) and drag to create a query rect.");
-        ImGui::Indent();
-            ImGui::BulletText("Hold Alt to expand query horizontally.");
-            ImGui::BulletText("Hold Shift to expand query vertically.");
-            ImGui::BulletText("The query rect can be dragged after it's created.");
-        ImGui::Unindent();
-
-        if (ImPlot::BeginPlot("##Drawing", NULL, NULL, ImVec2(-1,0), ImPlotFlags_Query, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations)) {
-            if (ImPlot::IsPlotHovered() && ImGui::IsMouseClicked(0) && ImGui::GetIO().KeyCtrl) {
-                ImPlotPoint pt = ImPlot::GetPlotMousePos();
-                data.push_back(pt);
-            }
-            if (data.size() > 0)
-                ImPlot::PlotScatter("Points", &data[0].x, &data[0].y, data.size(), 0, 2 * sizeof(double));
-            if (ImPlot::IsPlotQueried() && data.size() > 0) {
-                ImPlotLimits range2 = ImPlot::GetPlotQuery();
-                int cnt = 0;
-                ImPlotPoint avg;
-                for (int i = 0; i < data.size(); ++i) {
-                    if (range2.Contains(data[i].x, data[i].y)) {
-                        avg.x += data[i].x;
-                        avg.y += data[i].y;
-                        cnt++;
-                    }
-                }
-                if (cnt > 0) {
-                    avg.x = avg.x / cnt;
-                    avg.y = avg.y / cnt;
-                    ImPlot::SetNextMarkerStyle(ImPlotMarker_Square);
-                    ImPlot::PlotScatter("Average", &avg.x, &avg.y, 1);
-                }
-            }
-            range  = ImPlot::GetPlotLimits();
-            query  = ImPlot::GetPlotQuery();
-            select = ImPlot::GetPlotSelection();
-            ImPlot::EndPlot();
-        }
-        ImGui::Text("Limits: [%g,%g,%g,%g]", range.X.Min, range.X.Max, range.Y.Min, range.Y.Max);
-        ImGui::Text("Query: [%g,%g,%g,%g]", query.X.Min, query.X.Max, query.Y.Min, query.Y.Max);
-        ImGui::Text("Selection: [%g,%g,%g,%g]", select.X.Min, select.X.Max, select.Y.Min, select.Y.Max);
-
-        ImGui::Separator();
-
-        // mimic's soulthread's imgui_plot demo
-        static float x_data[512];
-        static float y_data1[512];
-        static float y_data2[512];
-        static float y_data3[512];
-        static float sampling_freq = 44100;
-        static float freq = 500;
-        for (size_t i = 0; i < 512; ++i) {
-            const float t = i / sampling_freq;
-            x_data[i] = t;
-            const float arg = 2 * 3.14f * freq * t;
-            y_data1[i] = sinf(arg);
-            y_data2[i] = y_data1[i] * -0.6f + sinf(2 * arg) * 0.4f;
-            y_data3[i] = y_data2[i] * -0.6f + sinf(3 * arg) * 0.4f;
-        }
-        ImGui::BulletText("Query the first plot to render a subview in the second plot (see above for controls).");
-        ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
-        static bool use_selection = false;
-        ImGui::Checkbox("Use Box Selection",&use_selection);
-        bool is_viewed = false;
-        ImPlotLimits view;
-        ImPlot::SetNextPlotLimits(0,0.01,-1,1);
-        if (ImPlot::BeginPlot("##View1",NULL,NULL,ImVec2(-1,150), ImPlotFlags_Query, flags, flags)) {
-            ImPlot::PlotLine("Signal 1", x_data, y_data1, 512);
-            ImPlot::PlotLine("Signal 2", x_data, y_data2, 512);
-            ImPlot::PlotLine("Signal 3", x_data, y_data3, 512);
-            is_viewed = use_selection ? ImPlot::IsPlotSelected()   : ImPlot::IsPlotQueried();
-            view      = use_selection ? ImPlot::GetPlotSelection() : ImPlot::GetPlotQuery();
-            ImPlot::EndPlot();
-        }
-        ImPlot::SetNextPlotLimits(view.X.Min, view.X.Max, view.Y.Min, view.Y.Max, ImGuiCond_Always);
-        if (ImPlot::BeginPlot("##View2",NULL,NULL,ImVec2(-1,150), ImPlotFlags_CanvasOnly, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations)) {
-            if (is_viewed) {
-                ImPlot::PlotLine("Signal 1", x_data, y_data1, 512);
-                ImPlot::PlotLine("Signal 2", x_data, y_data2, 512);
-                ImPlot::PlotLine("Signal 3", x_data, y_data3, 512);
-            }
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Legend")) {
-        static ImPlotLocation loc = ImPlotLocation_East;
-        static bool h = false; static bool o = true;
-        ImGui::CheckboxFlags("North", (unsigned int*)&loc, ImPlotLocation_North); ImGui::SameLine();
-        ImGui::CheckboxFlags("South", (unsigned int*)&loc, ImPlotLocation_South); ImGui::SameLine();
-        ImGui::CheckboxFlags("West",  (unsigned int*)&loc, ImPlotLocation_West);  ImGui::SameLine();
-        ImGui::CheckboxFlags("East",  (unsigned int*)&loc, ImPlotLocation_East);  ImGui::SameLine();
-        ImGui::Checkbox("Horizontal##2", &h); ImGui::SameLine();
-        ImGui::Checkbox("Outside", &o);
-
-        ImGui::SliderFloat2("LegendPadding", (float*)&GetStyle().LegendPadding, 0.0f, 20.0f, "%.0f");
-        ImGui::SliderFloat2("LegendInnerPadding", (float*)&GetStyle().LegendInnerPadding, 0.0f, 10.0f, "%.0f");
-        ImGui::SliderFloat2("LegendSpacing", (float*)&GetStyle().LegendSpacing, 0.0f, 5.0f, "%.0f");
-
-        if (ImPlot::BeginPlot("##Legend","x","y",ImVec2(-1,0))) {
-            ImPlot::SetLegendLocation(loc, h ? ImPlotOrientation_Horizontal : ImPlotOrientation_Vertical, o);
-            static MyImPlot::WaveData data1(0.001, 0.2, 2, 0.75);
-            static MyImPlot::WaveData data2(0.001, 0.2, 4, 0.25);
-            static MyImPlot::WaveData data3(0.001, 0.2, 6, 0.5);
-            ImPlot::PlotLineG("Item 1", MyImPlot::SineWave, &data1, 1000);         // "Item 1" added to legend
-            ImPlot::PlotLineG("Item 2##IDText", MyImPlot::SawWave, &data2, 1000);  // "Item 2" added to legend, text after ## used for ID only
-            ImPlot::PlotLineG("##NotListed", MyImPlot::SawWave, &data3, 1000);     // plotted, but not added to legend
-            ImPlot::PlotLineG("Item 3", MyImPlot::SineWave, &data1, 1000);         // "Item 3" added to legend
-            ImPlot::PlotLineG("Item 3", MyImPlot::SawWave,  &data2, 1000);         // combined with previous "Item 3"
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Drag Lines and Points")) {
-        ImGui::BulletText("Click and drag the horizontal and vertical lines.");
-        static double x1 = 0.2;
-        static double x2 = 0.8;
-        static double y1 = 0.25;
-        static double y2 = 0.75;
-        static double f = 0.1;
-        static bool show_labels = true;
-        ImGui::Checkbox("Show Labels##1",&show_labels);
-        ImPlot::SetNextPlotLimits(0,1,0,1);
-        if (ImPlot::BeginPlot("##guides",0,0,ImVec2(-1,0),ImPlotFlags_YAxis2)) {
-            ImPlot::DragLineX("x1",&x1,show_labels);
-            ImPlot::DragLineX("x2",&x2,show_labels);
-            ImPlot::DragLineY("y1",&y1,show_labels);
-            ImPlot::DragLineY("y2",&y2,show_labels);
-            double xs[1000], ys[1000];
-            for (int i = 0; i < 1000; ++i) {
-                xs[i] = (x2+x1)/2+fabs(x2-x1)*(i/1000.0f - 0.5f);
-                ys[i] = (y1+y2)/2+fabs(y2-y1)/2*sin(f*i/10);
-            }
-            ImPlot::PlotLine("Interactive Data", xs, ys, 1000);
-            ImPlot::SetPlotYAxis(ImPlotYAxis_2);
-            ImPlot::DragLineY("f",&f,show_labels,ImVec4(1,0.5f,1,1));
-            ImPlot::EndPlot();
-        }
-        ImGui::BulletText("Click and drag any point.");
-        ImGui::Checkbox("Show Labels##2",&show_labels);
-        ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels | ImPlotAxisFlags_NoTickMarks;
-        ImPlot::SetNextPlotLimits(0,1,0,1);
-        if (ImPlot::BeginPlot("##Bezier",0,0,ImVec2(-1,0),ImPlotFlags_CanvasOnly,flags,flags)) {
-            static ImPlotPoint P[] = {ImPlotPoint(.05f,.05f), ImPlotPoint(0.2,0.4),  ImPlotPoint(0.8,0.6),  ImPlotPoint(.95f,.95f)};
-            static ImPlotPoint B[100];
-            for (int i = 0; i < 100; ++i) {
-                double t  = i / 99.0;
-                double u  = 1 - t;
-                double w1 = u*u*u;
-                double w2 = 3*u*u*t;
-                double w3 = 3*u*t*t;
-                double w4 = t*t*t;
-                B[i] = ImPlotPoint(w1*P[0].x + w2*P[1].x + w3*P[2].x + w4*P[3].x, w1*P[0].y + w2*P[1].y + w3*P[2].y + w4*P[3].y);
-            }
-            ImPlot::SetNextLineStyle(ImVec4(0,0.9f,0,1), 2);
-            ImPlot::PlotLine("##bez",&B[0].x, &B[0].y, 100, 0, sizeof(ImPlotPoint));
-            ImPlot::SetNextLineStyle(ImVec4(1,0.5f,1,1));
-            ImPlot::PlotLine("##h1",&P[0].x, &P[0].y, 2, 0, sizeof(ImPlotPoint));
-            ImPlot::SetNextLineStyle(ImVec4(0,0.5f,1,1));
-            ImPlot::PlotLine("##h2",&P[2].x, &P[2].y, 2, 0, sizeof(ImPlotPoint));
-            ImPlot::DragPoint("P0",&P[0].x,&P[0].y, show_labels, ImVec4(0,0.9f,0,1));
-            ImPlot::DragPoint("P1",&P[1].x,&P[1].y, show_labels, ImVec4(1,0.5f,1,1));
-            ImPlot::DragPoint("P2",&P[2].x,&P[2].y, show_labels, ImVec4(0,0.5f,1,1));
-            ImPlot::DragPoint("P3",&P[3].x,&P[3].y, show_labels, ImVec4(0,0.9f,0,1));
-            ImPlot::EndPlot();
-        }
-    }
-    if (ImGui::CollapsingHeader("Annotations")) {
-        static bool clamp = false;
-        ImGui::Checkbox("Clamp",&clamp);
-        ImPlot::SetNextPlotLimits(0,2,0,1);
-        if (ImPlot::BeginPlot("##Annotations")) {
-
-            static float p[] = {0.25f, 0.25f, 0.75f, 0.75f, 0.25f};
-            ImPlot::PlotScatter("##Points",&p[0],&p[1],4);
-            ImVec4 col = GetLastItemColor();
-            clamp ? ImPlot::AnnotateClamped(0.25,0.25,ImVec2(-15,15),col,"BL") : ImPlot::Annotate(0.25,0.25,ImVec2(-15,15),col,"BL");
-            clamp ? ImPlot::AnnotateClamped(0.75,0.25,ImVec2(15,15),col,"BR") : ImPlot::Annotate(0.75,0.25,ImVec2(15,15),col,"BR");
-            clamp ? ImPlot::AnnotateClamped(0.75,0.75,ImVec2(15,-15),col,"TR") : ImPlot::Annotate(0.75,0.75,ImVec2(15,-15),col,"TR");
-            clamp ? ImPlot::AnnotateClamped(0.25,0.75,ImVec2(-15,-15),col,"TL") : ImPlot::Annotate(0.25,0.75,ImVec2(-15,-15),col,"TL");
-            clamp ? ImPlot::AnnotateClamped(0.5,0.5,ImVec2(0,0),col,"Center") : ImPlot::Annotate(0.5,0.5,ImVec2(0,0),col,"Center");
-
-            float bx[] = {1.2f,1.5f,1.8f};
-            float by[] = {0.25f, 0.5f, 0.75f};
-            ImPlot::PlotBars("##Bars",bx,by,3,0.2);
-            for (int i = 0; i < 3; ++i)
-                ImPlot::Annotate(bx[i],by[i],ImVec2(0,-5),"B[%d]=%.2f",i,by[i]);
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Drag and Drop")) {
-        ImGui::BulletText("Drag/drop items from the left column.");
-        ImGui::BulletText("Drag/drop items between plots.");
-        ImGui::Indent();
-        ImGui::BulletText("Plot 1 Targets: Plot, Y-Axes, Legend");
-        ImGui::BulletText("Plot 1 Sources: Legend Items");
-        ImGui::BulletText("Plot 2 Targets: Plot, X-Axis, Y-Axis");
-        ImGui::BulletText("Plot 2 Sources: Plot, X-Axis, Y-Axis (hold Ctrl)");
-        ImGui::Unindent();
-
-        // convenience struct to manage DND items; do this however you like
-        struct MyDndItem {
-            int              Idx;
-            int              Plt;
-            int              Yax;
-            char             Label[16];
-            ImVector<ImVec2> Data;
-            ImVec4           Color;
-            MyDndItem()        {
-                static int i = 0;
-                Idx = i++;
-                Plt = 0;
-                Yax = ImPlotYAxis_1;
-                sprintf(Label, "%02d Hz", Idx+1);
-                Color = RandomColor();
-                Data.reserve(1001);
-                for (int k = 0; k < 1001; ++k) {
-                    float t = k * 1.0f / 999;
-                    Data.push_back(ImVec2(t, 0.5f + 0.5f * sinf(2*3.14f*t*(Idx+1))));
-                }
-            }
-            void Reset() { Plt = 0; Yax = ImPlotYAxis_1; }
-        };
-
-        const int         k_dnd = 20;
-        static MyDndItem  dnd[k_dnd];
-        static MyDndItem* dndx = NULL; // for plot 2
-        static MyDndItem* dndy = NULL; // for plot 2
-
-        // child window to serve as initial source for our DND items
-        ImGui::BeginChild("DND_LEFT",ImVec2(100,400));
-        if (ImGui::Button("Reset Data", ImVec2(100, 0))) {
-            for (int k = 0; k < k_dnd; ++k)
-                dnd[k].Reset();
-            dndx = dndy = NULL;
-        }
-        for (int k = 0; k < k_dnd; ++k) {
-            if (dnd[k].Plt > 0)
-                continue;
-            ImPlot::ItemIcon(dnd[k].Color); ImGui::SameLine();
-            ImGui::Selectable(dnd[k].Label, false, 0, ImVec2(100, 0));
-            if (ImGui::BeginDragDropSource(ImGuiDragDropFlags_None)) {
-                ImGui::SetDragDropPayload("MY_DND", &k, sizeof(int));
-                ImPlot::ItemIcon(dnd[k].Color); ImGui::SameLine();
-                ImGui::TextUnformatted(dnd[k].Label);
-                ImGui::EndDragDropSource();
-            }
-        }
-        ImGui::EndChild();
-        if (ImGui::BeginDragDropTarget()) {
-            if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) {
-                int i = *(int*)payload->Data; dnd[i].Reset();
-            }
-            ImGui::EndDragDropTarget();
-        }
-
-        ImGui::SameLine();
-        ImGui::BeginChild("DND_RIGHT",ImVec2(-1,400));
-        // plot 1 (time series)
-        ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels | ImPlotAxisFlags_NoGridLines;
-        if (ImPlot::BeginPlot("##DND1", NULL, "[drop here]", ImVec2(-1,195), ImPlotFlags_YAxis2 | ImPlotFlags_YAxis3, flags | ImPlotAxisFlags_Lock, flags, flags, flags, "[drop here]", "[drop here]")) {
-            for (int k = 0; k < k_dnd; ++k) {
-                if (dnd[k].Plt == 1 && dnd[k].Data.size() > 0) {
-                    ImPlot::SetPlotYAxis(dnd[k].Yax);
-                    ImPlot::SetNextLineStyle(dnd[k].Color);
-                    static char label[32];
-                    sprintf(label,"%s (Y%d)", dnd[k].Label, dnd[k].Yax+1);
-                    ImPlot::PlotLine(label, &dnd[k].Data[0].x, &dnd[k].Data[0].y, dnd[k].Data.size(), 0, 2 * sizeof(float));
-                    // allow legend item labels to be DND sources
-                    if (ImPlot::BeginDragDropSourceItem(label)) {
-                        ImGui::SetDragDropPayload("MY_DND", &k, sizeof(int));
-                        ImPlot::ItemIcon(dnd[k].Color); ImGui::SameLine();
-                        ImGui::TextUnformatted(dnd[k].Label);
-                        ImPlot::EndDragDropSource();
-                    }
-                }
-            }
-            // allow the main plot area to be a DND target
-            if (ImPlot::BeginDragDropTarget()) {
-                if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) {
-                    int i = *(int*)payload->Data; dnd[i].Plt = 1; dnd[i].Yax = 0;
-                }
-                ImPlot::EndDragDropTarget();
-            }
-            // allow each y-axis to be a DND target
-            for (int y = 0; y < 3; ++y) {
-                if (ImPlot::BeginDragDropTargetY(y)) {
-                    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) {
-                        int i = *(int*)payload->Data; dnd[i].Plt = 1; dnd[i].Yax = y;
-                    }
-                    ImPlot::EndDragDropTarget();
-                }
-            }
-            // allow the legend to be a DND target
-            if (ImPlot::BeginDragDropTargetLegend()) {
-                if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) {
-                    int i = *(int*)payload->Data; dnd[i].Plt = 1; dnd[i].Yax = 0;
-                }
-                ImPlot::EndDragDropTarget();
-            }
-            ImPlot::EndPlot();
-        }
-        // plot 2 (Lissajous)
-        ImPlot::PushStyleColor(ImPlotCol_XAxis, dndx == NULL ? ImPlot::GetStyle().Colors[ImPlotCol_XAxis] : dndx->Color);
-        ImPlot::PushStyleColor(ImPlotCol_YAxis, dndy == NULL ? ImPlot::GetStyle().Colors[ImPlotCol_YAxis] : dndy->Color);
-        if (ImPlot::BeginPlot("##DND2", dndx == NULL ? "[drop here]" : dndx->Label, dndy == NULL ? "[drop here]" : dndy->Label, ImVec2(-1,195), 0, flags, flags )) {
-            if (dndx != NULL && dndy != NULL) {
-                ImVec4 mixed((dndx->Color.x + dndy->Color.x)/2,(dndx->Color.y + dndy->Color.y)/2,(dndx->Color.z + dndy->Color.z)/2,(dndx->Color.w + dndy->Color.w)/2);
-                ImPlot::SetNextLineStyle(mixed);
-                ImPlot::PlotLine("##dndxy", &dndx->Data[0].y, &dndy->Data[0].y, dndx->Data.size(), 0, 2 * sizeof(float));
-            }
-            // allow the x-axis to be a DND target
-            if (ImPlot::BeginDragDropTargetX()) {
-                if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) {
-                    int i = *(int*)payload->Data; dndx = &dnd[i];
-                }
-                ImPlot::EndDragDropTarget();
-            }
-            // allow the x-axis to be a DND source
-            if (dndx != NULL && ImPlot::BeginDragDropSourceX()) {
-                ImGui::SetDragDropPayload("MY_DND", &dndx->Idx, sizeof(int));
-                ImPlot::ItemIcon(dndx->Color); ImGui::SameLine();
-                ImGui::TextUnformatted(dndx->Label);
-                ImPlot::EndDragDropSource();
-            }
-            // allow the y-axis to be a DND target
-            if (ImPlot::BeginDragDropTargetY()) {
-                if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) {
-                    int i = *(int*)payload->Data; dndy = &dnd[i];
-                }
-                ImPlot::EndDragDropTarget();
-            }
-            // allow the y-axis to be a DND source
-            if (dndy != NULL && ImPlot::BeginDragDropSourceY()) {
-                ImGui::SetDragDropPayload("MY_DND", &dndy->Idx, sizeof(int));
-                ImPlot::ItemIcon(dndy->Color); ImGui::SameLine();
-                ImGui::TextUnformatted(dndy->Label);
-                ImPlot::EndDragDropSource();
-            }
-            // allow the plot area to be a DND target
-            if (ImPlot::BeginDragDropTarget()) {
-                if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) {
-                    int i = *(int*)payload->Data; dndx = dndy = &dnd[i];
-                }
-            }
-            // allow the plot area to be a DND source
-            if (ImPlot::BeginDragDropSource()) {
-                ImGui::TextUnformatted("Yes, you can\ndrag this!");
-                ImPlot::EndDragDropSource();
-            }
-            ImPlot::EndPlot();
-        }
-        ImPlot::PopStyleColor(2);
-        ImGui::EndChild();
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Tables")) {
-#ifdef IMGUI_HAS_TABLE
-        static ImGuiTableFlags flags = ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_RowBg;
-        static bool anim = true;
-        static int offset = 0;
-        ImGui::BulletText("Plots can be used inside of ImGui tables.");
-        ImGui::Checkbox("Animate",&anim);
-        if (anim)
-            offset = (offset + 1) % 100;
-        if (ImGui::BeginTable("##table", 3, flags, ImVec2(-1,0))) {
-            ImGui::TableSetupColumn("Electrode", ImGuiTableColumnFlags_WidthFixed, 75.0f);
-            ImGui::TableSetupColumn("Voltage", ImGuiTableColumnFlags_WidthFixed, 75.0f);
-            ImGui::TableSetupColumn("EMG Signal");
-            ImGui::TableHeadersRow();
-            ImPlot::PushColormap(ImPlotColormap_Cool);
-            for (int row = 0; row < 10; row++) {
-                ImGui::TableNextRow();
-                static float data[100];
-                srand(row);
-                for (int i = 0; i < 100; ++i)
-                    data[i] = RandomRange(0.0f,10.0f);
-                ImGui::TableSetColumnIndex(0);
-                ImGui::Text("EMG %d", row);
-                ImGui::TableSetColumnIndex(1);
-                ImGui::Text("%.3f V", data[offset]);
-                ImGui::TableSetColumnIndex(2);
-                ImGui::PushID(row);
-                MyImPlot::Sparkline("##spark",data,100,0,11.0f,offset,ImPlot::GetColormapColor(row),ImVec2(-1, 35));
-                ImGui::PopID();
-            }
-            ImPlot::PopColormap();
-            ImGui::EndTable();
-        }
-#else
-    ImGui::BulletText("You need to merge the ImGui 'tables' branch for this section.");
-#endif
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Offset and Stride")) {
-        static const int k_circles    = 11;
-        static const int k_points_per = 50;
-        static const int k_size       = 2 * k_points_per * k_circles;
-        static double interleaved_data[k_size];
-        for (int p = 0; p < k_points_per; ++p) {
-            for (int c = 0; c < k_circles; ++c) {
-                double r = (double)c / (k_circles - 1) * 0.2 + 0.2;
-                interleaved_data[p*2*k_circles + 2*c + 0] = 0.5 + r * cos((double)p/k_points_per * 6.28);
-                interleaved_data[p*2*k_circles + 2*c + 1] = 0.5 + r * sin((double)p/k_points_per * 6.28);
-            }
-        }
-        static int offset = 0;
-        ImGui::BulletText("Offsetting is useful for realtime plots (see above) and circular buffers.");
-        ImGui::BulletText("Striding is useful for interleaved data (e.g. audio) or plotting structs.");
-        ImGui::BulletText("Here, all circle data is stored in a single interleaved buffer:");
-        ImGui::BulletText("[c0.x0 c0.y0 ... cn.x0 cn.y0 c0.x1 c0.y1 ... cn.x1 cn.y1 ... cn.xm cn.ym]");
-        ImGui::BulletText("The offset value indicates which circle point index is considered the first.");
-        ImGui::BulletText("Offsets can be negative and/or larger than the actual data count.");
-        ImGui::SliderInt("Offset", &offset, -2*k_points_per, 2*k_points_per);
-        if (ImPlot::BeginPlot("##strideoffset",0,0,ImVec2(-1,0), ImPlotFlags_Equal)) {
-            ImPlot::PushColormap(ImPlotColormap_Jet);
-            char buff[16];
-            for (int c = 0; c < k_circles; ++c) {
-                sprintf(buff, "Circle %d", c);
-                ImPlot::PlotLine(buff, &interleaved_data[c*2 + 0], &interleaved_data[c*2 + 1], k_points_per, offset, 2*k_circles*sizeof(double));
-            }
-            ImPlot::EndPlot();
-            ImPlot::PopColormap();
-        }
-        // offset++; uncomment for animation!
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Custom Data and Getters")) {
-        ImGui::BulletText("You can plot custom structs using the stride feature.");
-        ImGui::BulletText("Most plotters can also be passed a function pointer for getting data.");
-        ImGui::Indent();
-            ImGui::BulletText("You can optionally pass user data to be given to your getter function.");
-            ImGui::BulletText("C++ lambdas can be passed as function pointers as well!");
-        ImGui::Unindent();
-
-        MyImPlot::Vector2f vec2_data[2] = { MyImPlot::Vector2f(0,0), MyImPlot::Vector2f(1,1) };
-
-        if (ImPlot::BeginPlot("##Custom Data")) {
-
-            // custom structs using stride example:
-            ImPlot::PlotLine("Vector2f", &vec2_data[0].x, &vec2_data[0].y, 2, 0, sizeof(MyImPlot::Vector2f) /* or sizeof(float) * 2 */);
-
-            // custom getter example 1:
-            ImPlot::PlotLineG("Spiral", MyImPlot::Spiral, NULL, 1000);
-
-            // custom getter example 2:
-            static MyImPlot::WaveData data1(0.001, 0.2, 2, 0.75);
-            static MyImPlot::WaveData data2(0.001, 0.2, 4, 0.25);
-            ImPlot::PlotLineG("Waves", MyImPlot::SineWave, &data1, 1000);
-            ImPlot::PlotLineG("Waves", MyImPlot::SawWave, &data2, 1000);
-            ImPlot::PushStyleVar(ImPlotStyleVar_FillAlpha, 0.25f);
-            ImPlot::PlotShadedG("Waves", MyImPlot::SineWave, &data1, MyImPlot::SawWave, &data2, 1000);
-            ImPlot::PopStyleVar();
-
-            // you can also pass C++ lambdas:
-            // auto lamda = [](void* data, int idx) { ... return ImPlotPoint(x,y); };
-            // ImPlot::PlotLine("My Lambda", lambda, data, 1000);
-
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Custom Ticks##")) {
-        static bool custom_fmt    = true;
-        static bool custom_ticks  = false;
-        static bool custom_labels = true;
-        ImGui::Checkbox("Show Custom Format", &custom_fmt);
-        ImGui::SameLine();
-        ImGui::Checkbox("Show Custom Ticks", &custom_ticks);
-        if (custom_ticks) {
-            ImGui::SameLine();
-            ImGui::Checkbox("Show Custom Labels", &custom_labels);
-        }
-        double pi = 3.14;
-        const char* pi_str[] = {"PI"};
-        static double yticks[] = {1,3,7,9};
-        static const char*  ylabels[] = {"One","Three","Seven","Nine"};
-        static double yticks_aux[] = {0.2,0.4,0.6};
-        static const char* ylabels_aux[] = {"A","B","C","D","E","F"};
-        if (custom_fmt) {
-            ImPlot::SetNextPlotFormatX("%g ms");
-            ImPlot::SetNextPlotFormatY("%g Hz", ImPlotYAxis_1);
-            ImPlot::SetNextPlotFormatY("%g dB", ImPlotYAxis_2);
-            ImPlot::SetNextPlotFormatY("%g km", ImPlotYAxis_3);
-        }
-        if (custom_ticks) {
-            ImPlot::SetNextPlotTicksX(&pi,1,custom_labels ? pi_str : NULL, true);
-            ImPlot::SetNextPlotTicksY(yticks, 4, custom_labels ? ylabels : NULL, ImPlotYAxis_1);
-            ImPlot::SetNextPlotTicksY(yticks_aux, 3, custom_labels ? ylabels_aux : NULL, false, ImPlotYAxis_2);
-            ImPlot::SetNextPlotTicksY(0, 1, 6, custom_labels ? ylabels_aux : NULL, false, ImPlotYAxis_3);
-        }
-        ImPlot::SetNextPlotLimits(2.5,5,0,10);
-        if (ImPlot::BeginPlot("Custom Ticks", NULL, NULL, ImVec2(-1,0), ImPlotFlags_YAxis2 | ImPlotFlags_YAxis3)) {
-            // nothing to see here, just the ticks
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Custom Styles")) {
-        ImPlot::PushColormap(ImPlotColormap_Deep);
-        // normally you wouldn't change the entire style each frame
-        ImPlotStyle backup = ImPlot::GetStyle();
-        MyImPlot::StyleSeaborn();
-        ImPlot::SetNextPlotLimits(-0.5f, 9.5f, 0, 10);
-        if (ImPlot::BeginPlot("seaborn style", "x-axis", "y-axis")) {
-            unsigned int lin[10] = {8,8,9,7,8,8,8,9,7,8};
-            unsigned int bar[10] = {1,2,5,3,4,1,2,5,3,4};
-            unsigned int dot[10] = {7,6,6,7,8,5,6,5,8,7};
-            ImPlot::PlotBars("Bars", bar, 10, 0.5f);
-            ImPlot::PlotLine("Line", lin, 10);
-            ImPlot::NextColormapColor(); // skip green
-            ImPlot::PlotScatter("Scatter", dot, 10);
-            ImPlot::EndPlot();
-        }
-        ImPlot::GetStyle() = backup;
-        ImPlot::PopColormap();
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Custom Rendering")) {
-        if (ImPlot::BeginPlot("##CustomRend")) {
-            ImVec2 cntr = ImPlot::PlotToPixels(ImPlotPoint(0.5f,  0.5f));
-            ImVec2 rmin = ImPlot::PlotToPixels(ImPlotPoint(0.25f, 0.75f));
-            ImVec2 rmax = ImPlot::PlotToPixels(ImPlotPoint(0.75f, 0.25f));
-            ImPlot::PushPlotClipRect();
-            ImPlot::GetPlotDrawList()->AddCircleFilled(cntr,20,IM_COL32(255,255,0,255),20);
-            ImPlot::GetPlotDrawList()->AddRect(rmin, rmax, IM_COL32(128,0,255,255));
-            ImPlot::PopPlotClipRect();
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Custom Context Menus")) {
-        ImGui::BulletText("You can implement legend context menus to inject per-item controls and widgets.");
-        ImGui::BulletText("Right click the legend label/icon to edit custom item attributes.");
-
-        static float  frequency = 0.1f;
-        static float  amplitude = 0.5f;
-        static ImVec4 color     = ImVec4(1,1,0,1);
-        static float  alpha     = 1.0f;
-        static bool   line      = false;
-        static float  thickness = 1;
-        static bool   markers   = false;
-        static bool   shaded    = false;
-
-        static float vals[101];
-        for (int i = 0; i < 101; ++i)
-            vals[i] = amplitude * sinf(frequency * i);
-
-        ImPlot::SetNextPlotLimits(0,100,-1,1);
-        if (ImPlot::BeginPlot("Right Click the Legend")) {
-            // rendering logic
-            ImPlot::PushStyleVar(ImPlotStyleVar_FillAlpha, alpha);
-            if (!line) {
-                ImPlot::SetNextFillStyle(color);
-                ImPlot::PlotBars("Right Click Me", vals, 101);
-            }
-            else {
-                if (markers) ImPlot::SetNextMarkerStyle(ImPlotMarker_Circle);
-                ImPlot::SetNextLineStyle(color, thickness);
-                ImPlot::PlotLine("Right Click Me", vals, 101);
-                if (shaded) ImPlot::PlotShaded("Right Click Me",vals,101);
-            }
-            ImPlot::PopStyleVar();
-            // custom legend context menu
-            if (ImPlot::BeginLegendPopup("Right Click Me")) {
-                ImGui::SliderFloat("Frequency",&frequency,0,1,"%0.2f");
-                ImGui::SliderFloat("Amplitude",&amplitude,0,1,"%0.2f");
-                ImGui::Separator();
-                ImGui::ColorEdit3("Color",&color.x);
-                ImGui::SliderFloat("Transparency",&alpha,0,1,"%.2f");
-                ImGui::Checkbox("Line Plot", &line);
-                if (line) {
-                    ImGui::SliderFloat("Thickness", &thickness, 0, 5);
-                    ImGui::Checkbox("Markers", &markers);
-                    ImGui::Checkbox("Shaded",&shaded);
-                }
-                ImPlot::EndLegendPopup();
-            }
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
-    if (ImGui::CollapsingHeader("Custom Plotters and Tooltips")) {
-        ImGui::BulletText("You can create custom plotters or extend ImPlot using implot_internal.h.");
-		double dates[]  = {1546300800,1546387200,1546473600,1546560000,1546819200,1546905600,1546992000,1547078400,1547164800,1547424000,1547510400,1547596800,1547683200,1547769600,1547942400,1548028800,1548115200,1548201600,1548288000,1548374400,1548633600,1548720000,1548806400,1548892800,1548979200,1549238400,1549324800,1549411200,1549497600,1549584000,1549843200,1549929600,1550016000,1550102400,1550188800,1550361600,1550448000,1550534400,1550620800,1550707200,1550793600,1551052800,1551139200,1551225600,1551312000,1551398400,1551657600,1551744000,1551830400,1551916800,1552003200,1552262400,1552348800,1552435200,1552521600,1552608000,1552867200,1552953600,1553040000,1553126400,1553212800,1553472000,1553558400,1553644800,1553731200,1553817600,1554076800,1554163200,1554249600,1554336000,1554422400,1554681600,1554768000,1554854400,1554940800,1555027200,1555286400,1555372800,1555459200,1555545600,1555632000,1555891200,1555977600,1556064000,1556150400,1556236800,1556496000,1556582400,1556668800,1556755200,1556841600,1557100800,1557187200,1557273600,1557360000,1557446400,1557705600,1557792000,1557878400,1557964800,1558051200,1558310400,1558396800,1558483200,1558569600,1558656000,1558828800,1558915200,1559001600,1559088000,1559174400,1559260800,1559520000,1559606400,1559692800,1559779200,1559865600,1560124800,1560211200,1560297600,1560384000,1560470400,1560729600,1560816000,1560902400,1560988800,1561075200,1561334400,1561420800,1561507200,1561593600,1561680000,1561939200,1562025600,1562112000,1562198400,1562284800,1562544000,1562630400,1562716800,1562803200,1562889600,1563148800,1563235200,1563321600,1563408000,1563494400,1563753600,1563840000,1563926400,1564012800,1564099200,1564358400,1564444800,1564531200,1564617600,1564704000,1564963200,1565049600,1565136000,1565222400,1565308800,1565568000,1565654400,1565740800,1565827200,1565913600,1566172800,1566259200,1566345600,1566432000,1566518400,1566777600,1566864000,1566950400,1567036800,1567123200,1567296000,1567382400,1567468800,1567555200,1567641600,1567728000,1567987200,1568073600,1568160000,1568246400,1568332800,1568592000,1568678400,1568764800,1568851200,1568937600,1569196800,1569283200,1569369600,1569456000,1569542400,1569801600,1569888000,1569974400,1570060800,1570147200,1570406400,1570492800,1570579200,1570665600,1570752000,1571011200,1571097600,1571184000,1571270400,1571356800,1571616000,1571702400,1571788800,1571875200,1571961600};
-		double opens[]  = {1284.7,1319.9,1318.7,1328,1317.6,1321.6,1314.3,1325,1319.3,1323.1,1324.7,1321.3,1323.5,1322,1281.3,1281.95,1311.1,1315,1314,1313.1,1331.9,1334.2,1341.3,1350.6,1349.8,1346.4,1343.4,1344.9,1335.6,1337.9,1342.5,1337,1338.6,1337,1340.4,1324.65,1324.35,1349.5,1371.3,1367.9,1351.3,1357.8,1356.1,1356,1347.6,1339.1,1320.6,1311.8,1314,1312.4,1312.3,1323.5,1319.1,1327.2,1332.1,1320.3,1323.1,1328,1330.9,1338,1333,1335.3,1345.2,1341.1,1332.5,1314,1314.4,1310.7,1314,1313.1,1315,1313.7,1320,1326.5,1329.2,1314.2,1312.3,1309.5,1297.4,1293.7,1277.9,1295.8,1295.2,1290.3,1294.2,1298,1306.4,1299.8,1302.3,1297,1289.6,1302,1300.7,1303.5,1300.5,1303.2,1306,1318.7,1315,1314.5,1304.1,1294.7,1293.7,1291.2,1290.2,1300.4,1284.2,1284.25,1301.8,1295.9,1296.2,1304.4,1323.1,1340.9,1341,1348,1351.4,1351.4,1343.5,1342.3,1349,1357.6,1357.1,1354.7,1361.4,1375.2,1403.5,1414.7,1433.2,1438,1423.6,1424.4,1418,1399.5,1435.5,1421.25,1434.1,1412.4,1409.8,1412.2,1433.4,1418.4,1429,1428.8,1420.6,1441,1460.4,1441.7,1438.4,1431,1439.3,1427.4,1431.9,1439.5,1443.7,1425.6,1457.5,1451.2,1481.1,1486.7,1512.1,1515.9,1509.2,1522.3,1513,1526.6,1533.9,1523,1506.3,1518.4,1512.4,1508.8,1545.4,1537.3,1551.8,1549.4,1536.9,1535.25,1537.95,1535.2,1556,1561.4,1525.6,1516.4,1507,1493.9,1504.9,1506.5,1513.1,1506.5,1509.7,1502,1506.8,1521.5,1529.8,1539.8,1510.9,1511.8,1501.7,1478,1485.4,1505.6,1511.6,1518.6,1498.7,1510.9,1510.8,1498.3,1492,1497.7,1484.8,1494.2,1495.6,1495.6,1487.5,1491.1,1495.1,1506.4};
-		double highs[]  = {1284.75,1320.6,1327,1330.8,1326.8,1321.6,1326,1328,1325.8,1327.1,1326,1326,1323.5,1322.1,1282.7,1282.95,1315.8,1316.3,1314,1333.2,1334.7,1341.7,1353.2,1354.6,1352.2,1346.4,1345.7,1344.9,1340.7,1344.2,1342.7,1342.1,1345.2,1342,1350,1324.95,1330.75,1369.6,1374.3,1368.4,1359.8,1359,1357,1356,1353.4,1340.6,1322.3,1314.1,1316.1,1312.9,1325.7,1323.5,1326.3,1336,1332.1,1330.1,1330.4,1334.7,1341.1,1344.2,1338.8,1348.4,1345.6,1342.8,1334.7,1322.3,1319.3,1314.7,1316.6,1316.4,1315,1325.4,1328.3,1332.2,1329.2,1316.9,1312.3,1309.5,1299.6,1296.9,1277.9,1299.5,1296.2,1298.4,1302.5,1308.7,1306.4,1305.9,1307,1297.2,1301.7,1305,1305.3,1310.2,1307,1308,1319.8,1321.7,1318.7,1316.2,1305.9,1295.8,1293.8,1293.7,1304.2,1302,1285.15,1286.85,1304,1302,1305.2,1323,1344.1,1345.2,1360.1,1355.3,1363.8,1353,1344.7,1353.6,1358,1373.6,1358.2,1369.6,1377.6,1408.9,1425.5,1435.9,1453.7,1438,1426,1439.1,1418,1435,1452.6,1426.65,1437.5,1421.5,1414.1,1433.3,1441.3,1431.4,1433.9,1432.4,1440.8,1462.3,1467,1443.5,1444,1442.9,1447,1437.6,1440.8,1445.7,1447.8,1458.2,1461.9,1481.8,1486.8,1522.7,1521.3,1521.1,1531.5,1546.1,1534.9,1537.7,1538.6,1523.6,1518.8,1518.4,1514.6,1540.3,1565,1554.5,1556.6,1559.8,1541.9,1542.9,1540.05,1558.9,1566.2,1561.9,1536.2,1523.8,1509.1,1506.2,1532.2,1516.6,1519.7,1515,1519.5,1512.1,1524.5,1534.4,1543.3,1543.3,1542.8,1519.5,1507.2,1493.5,1511.4,1525.8,1522.2,1518.8,1515.3,1518,1522.3,1508,1501.5,1503,1495.5,1501.1,1497.9,1498.7,1492.1,1499.4,1506.9,1520.9};
-		double lows[]   = {1282.85,1315,1318.7,1309.6,1317.6,1312.9,1312.4,1319.1,1319,1321,1318.1,1321.3,1319.9,1312,1280.5,1276.15,1308,1309.9,1308.5,1312.3,1329.3,1333.1,1340.2,1347,1345.9,1338,1340.8,1335,1332,1337.9,1333,1336.8,1333.2,1329.9,1340.4,1323.85,1324.05,1349,1366.3,1351.2,1349.1,1352.4,1350.7,1344.3,1338.9,1316.3,1308.4,1306.9,1309.6,1306.7,1312.3,1315.4,1319,1327.2,1317.2,1320,1323,1328,1323,1327.8,1331.7,1335.3,1336.6,1331.8,1311.4,1310,1309.5,1308,1310.6,1302.8,1306.6,1313.7,1320,1322.8,1311,1312.1,1303.6,1293.9,1293.5,1291,1277.9,1294.1,1286,1289.1,1293.5,1296.9,1298,1299.6,1292.9,1285.1,1288.5,1296.3,1297.2,1298.4,1298.6,1302,1300.3,1312,1310.8,1301.9,1292,1291.1,1286.3,1289.2,1289.9,1297.4,1283.65,1283.25,1292.9,1295.9,1290.8,1304.2,1322.7,1336.1,1341,1343.5,1345.8,1340.3,1335.1,1341.5,1347.6,1352.8,1348.2,1353.7,1356.5,1373.3,1398,1414.7,1427,1416.4,1412.7,1420.1,1396.4,1398.8,1426.6,1412.85,1400.7,1406,1399.8,1404.4,1415.5,1417.2,1421.9,1415,1413.7,1428.1,1434,1435.7,1427.5,1429.4,1423.9,1425.6,1427.5,1434.8,1422.3,1412.1,1442.5,1448.8,1468.2,1484.3,1501.6,1506.2,1498.6,1488.9,1504.5,1518.3,1513.9,1503.3,1503,1506.5,1502.1,1503,1534.8,1535.3,1541.4,1528.6,1525.6,1535.25,1528.15,1528,1542.6,1514.3,1510.7,1505.5,1492.1,1492.9,1496.8,1493.1,1503.4,1500.9,1490.7,1496.3,1505.3,1505.3,1517.9,1507.4,1507.1,1493.3,1470.5,1465,1480.5,1501.7,1501.4,1493.3,1492.1,1505.1,1495.7,1478,1487.1,1480.8,1480.6,1487,1488.3,1484.8,1484,1490.7,1490.4,1503.1};
-		double closes[] = {1283.35,1315.3,1326.1,1317.4,1321.5,1317.4,1323.5,1319.2,1321.3,1323.3,1319.7,1325.1,1323.6,1313.8,1282.05,1279.05,1314.2,1315.2,1310.8,1329.1,1334.5,1340.2,1340.5,1350,1347.1,1344.3,1344.6,1339.7,1339.4,1343.7,1337,1338.9,1340.1,1338.7,1346.8,1324.25,1329.55,1369.6,1372.5,1352.4,1357.6,1354.2,1353.4,1346,1341,1323.8,1311.9,1309.1,1312.2,1310.7,1324.3,1315.7,1322.4,1333.8,1319.4,1327.1,1325.8,1330.9,1325.8,1331.6,1336.5,1346.7,1339.2,1334.7,1313.3,1316.5,1312.4,1313.4,1313.3,1312.2,1313.7,1319.9,1326.3,1331.9,1311.3,1313.4,1309.4,1295.2,1294.7,1294.1,1277.9,1295.8,1291.2,1297.4,1297.7,1306.8,1299.4,1303.6,1302.2,1289.9,1299.2,1301.8,1303.6,1299.5,1303.2,1305.3,1319.5,1313.6,1315.1,1303.5,1293,1294.6,1290.4,1291.4,1302.7,1301,1284.15,1284.95,1294.3,1297.9,1304.1,1322.6,1339.3,1340.1,1344.9,1354,1357.4,1340.7,1342.7,1348.2,1355.1,1355.9,1354.2,1362.1,1360.1,1408.3,1411.2,1429.5,1430.1,1426.8,1423.4,1425.1,1400.8,1419.8,1432.9,1423.55,1412.1,1412.2,1412.8,1424.9,1419.3,1424.8,1426.1,1423.6,1435.9,1440.8,1439.4,1439.7,1434.5,1436.5,1427.5,1432.2,1433.3,1441.8,1437.8,1432.4,1457.5,1476.5,1484.2,1519.6,1509.5,1508.5,1517.2,1514.1,1527.8,1531.2,1523.6,1511.6,1515.7,1515.7,1508.5,1537.6,1537.2,1551.8,1549.1,1536.9,1529.4,1538.05,1535.15,1555.9,1560.4,1525.5,1515.5,1511.1,1499.2,1503.2,1507.4,1499.5,1511.5,1513.4,1515.8,1506.2,1515.1,1531.5,1540.2,1512.3,1515.2,1506.4,1472.9,1489,1507.9,1513.8,1512.9,1504.4,1503.9,1512.8,1500.9,1488.7,1497.6,1483.5,1494,1498.3,1494.1,1488.1,1487.5,1495.7,1504.7,1505.3};
-        static bool tooltip = true;
-        ImGui::Checkbox("Show Tooltip", &tooltip);
-        ImGui::SameLine();
-        static ImVec4 bullCol = ImVec4(0.000f, 1.000f, 0.441f, 1.000f);
-        static ImVec4 bearCol = ImVec4(0.853f, 0.050f, 0.310f, 1.000f);
-        ImGui::SameLine(); ImGui::ColorEdit4("##Bull", &bullCol.x, ImGuiColorEditFlags_NoInputs);
-        ImGui::SameLine(); ImGui::ColorEdit4("##Bear", &bearCol.x, ImGuiColorEditFlags_NoInputs);
-        ImPlot::GetStyle().UseLocalTime = false;
-        ImPlot::SetNextPlotFormatY("$%.0f");
-        ImPlot::SetNextPlotLimits(1546300800, 1571961600, 1250, 1600);
-        if (ImPlot::BeginPlot("Candlestick Chart",NULL,NULL,ImVec2(-1,0),0,ImPlotAxisFlags_Time,ImPlotAxisFlags_AutoFit|ImPlotAxisFlags_RangeFit)) {
-            MyImPlot::PlotCandlestick("GOOGL",dates, opens, closes, lows, highs, 218, tooltip, 0.25f, bullCol, bearCol);
-            ImPlot::EndPlot();
-        }
-    }
-    //-------------------------------------------------------------------------
     ImGui::End();
 }
 

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -965,7 +965,7 @@ ImPlotPoint SinewaveGetter(void* data, int i) {
 void ShowDemo_SubplotsSizing() {
 
     static ImPlotSubplotFlags flags = ImPlotSubplotFlags_None;
-    ImGui::CheckboxFlags("ImPlotSubplotFlags_NoSplitters", (unsigned int*)&flags, ImPlotSubplotFlags_NoSplitters); 
+    ImGui::CheckboxFlags("ImPlotSubplotFlags_NoResize", (unsigned int*)&flags, ImPlotSubplotFlags_NoResize); 
     ImGui::CheckboxFlags("ImPlotSubplotFlags_NoTitle", (unsigned int*)&flags, ImPlotSubplotFlags_NoTitle);
 
     static int rows = 3;
@@ -1004,13 +1004,13 @@ void ShowDemo_SubplotItemSharing() {
             if (ImPlot::BeginPlot("")) {
                 char buffer[8];
                 float fc = 0.01f;
-                float fi = 0.01f * (i+1);
+                float fi = 0.01f * (i+2);
                 sprintf(buffer, "data%d", i);
                 ImPlot::PlotLineG("common",SinewaveGetter,&fc,1000);
                 ImPlot::PlotLineG(buffer,SinewaveGetter,&fi,1000);
                 ImPlot::EndPlot();
             }
-        }            
+        }   
         ImPlot::EndSubplots();
     }
 }
@@ -1760,7 +1760,7 @@ void ShowDemoWindow(bool* p_open) {
             ImGui::EndTabItem();
         }
         if (ImGui::BeginTabItem("Subplots")) {
-            if (ImGui::CollapsingHeader("Grid Sizing"))
+            if (ImGui::CollapsingHeader("Sizing"))
                 ShowDemo_SubplotsSizing();
             if (ImGui::CollapsingHeader("Item Sharing"))
                 ShowDemo_SubplotItemSharing();

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -993,21 +993,38 @@ void ShowDemo_SubplotsSizing() {
 }
 
 void ShowDemo_SubplotItemSharing() {
-
     static ImPlotSubplotFlags flags = ImPlotSubplotFlags_ShareItems;
     ImGui::CheckboxFlags("ImPlotSubplotFlags_ShareItems", (unsigned int*)&flags, ImPlotSubplotFlags_ShareItems);
-
+    ImGui::CheckboxFlags("ImPlotSubplotFlags_ColMajor", (unsigned int*)&flags, ImPlotSubplotFlags_ColMajor); 
     static int rows = 2;
-    static int cols = 2;
+    static int cols = 3;
+    static int id[] = {0,1,2,3,4,5};
+    static int curj = -1;
     if (ImPlot::BeginSubplots("##ItemSharing", rows, cols, ImVec2(-1,400), flags)) {
         for (int i = 0; i < rows*cols; ++i) {
             if (ImPlot::BeginPlot("")) {
-                char buffer[8];
                 float fc = 0.01f;
-                float fi = 0.01f * (i+2);
-                sprintf(buffer, "data%d", i);
                 ImPlot::PlotLineG("common",SinewaveGetter,&fc,1000);
-                ImPlot::PlotLineG(buffer,SinewaveGetter,&fi,1000);
+                for (int j = 0; j < 6; ++j) {
+                    if (id[j] == i) {
+                        char label[8];
+                        float fj = 0.01f * (j+2);
+                        sprintf(label, "data%d", j);
+                        ImPlot::PlotLineG(label,SinewaveGetter,&fj,1000);
+                        if (ImPlot::BeginDragDropSourceItem(label)) {
+                            curj = j;
+                            ImGui::SetDragDropPayload("MY_DND",NULL,0);
+                            ImPlot::ItemIcon(GetLastItemColor()); ImGui::SameLine();
+                            ImGui::TextUnformatted(label);
+                            ImPlot::EndDragDropSource();
+                        }
+                    }
+                }
+                if (ImPlot::BeginDragDropTarget()) {
+                    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) 
+                        id[curj] = i;                    
+                    ImPlot::EndDragDropTarget();
+                }
                 ImPlot::EndPlot();
             }
         }   

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -216,8 +216,12 @@ void ShowDemo_Configuration() {
     ImPlot::ShowStyleSelector("ImPlot Style");
     ImPlot::ShowColormapSelector("ImPlot Colormap");
     float indent = ImGui::CalcItemWidth() - ImGui::GetFrameHeight();
-    ImGui::Indent(ImGui::CalcItemWidth() - ImGui::GetFrameHeight());
+    ImGui::Separator();
     ImGui::Checkbox("Anti-Aliased Lines", &ImPlot::GetStyle().AntiAliasedLines);
+    ImGui::Separator();
+    ImGui::Checkbox("Use Local Time", &ImPlot::GetStyle().UseLocalTime);
+    ImGui::Checkbox("Use ISO 8601", &ImPlot::GetStyle().UseISO8601);
+    ImGui::Checkbox("Use 24 Hour Clock", &ImPlot::GetStyle().Use24HourClock);
     ImGui::Unindent(indent);
 }
 
@@ -965,7 +969,7 @@ ImPlotPoint SinewaveGetter(void* data, int i) {
 void ShowDemo_SubplotsSizing() {
 
     static ImPlotSubplotFlags flags = ImPlotSubplotFlags_None;
-    ImGui::CheckboxFlags("ImPlotSubplotFlags_NoResize", (unsigned int*)&flags, ImPlotSubplotFlags_NoResize); 
+    ImGui::CheckboxFlags("ImPlotSubplotFlags_NoResize", (unsigned int*)&flags, ImPlotSubplotFlags_NoResize);
     ImGui::CheckboxFlags("ImPlotSubplotFlags_NoTitle", (unsigned int*)&flags, ImPlotSubplotFlags_NoTitle);
 
     static int rows = 3;
@@ -987,7 +991,7 @@ void ShowDemo_SubplotsSizing() {
                 ImPlot::PlotLineG(buffer,SinewaveGetter,&fi,1000);
                 ImPlot::EndPlot();
             }
-        }            
+        }
         ImPlot::EndSubplots();
     }
 }
@@ -995,7 +999,7 @@ void ShowDemo_SubplotsSizing() {
 void ShowDemo_SubplotItemSharing() {
     static ImPlotSubplotFlags flags = ImPlotSubplotFlags_ShareItems;
     ImGui::CheckboxFlags("ImPlotSubplotFlags_ShareItems", (unsigned int*)&flags, ImPlotSubplotFlags_ShareItems);
-    ImGui::CheckboxFlags("ImPlotSubplotFlags_ColMajor", (unsigned int*)&flags, ImPlotSubplotFlags_ColMajor); 
+    ImGui::CheckboxFlags("ImPlotSubplotFlags_ColMajor", (unsigned int*)&flags, ImPlotSubplotFlags_ColMajor);
     static int rows = 2;
     static int cols = 3;
     static int id[] = {0,1,2,3,4,5};
@@ -1021,13 +1025,13 @@ void ShowDemo_SubplotItemSharing() {
                     }
                 }
                 if (ImPlot::BeginDragDropTarget()) {
-                    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND")) 
-                        id[curj] = i;                    
+                    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND"))
+                        id[curj] = i;
                     ImPlot::EndDragDropTarget();
                 }
                 ImPlot::EndPlot();
             }
-        }   
+        }
         ImPlot::EndSubplots();
     }
 }
@@ -1049,7 +1053,7 @@ void ShowDemo_SubplotAxisLinking() {
                 ImPlot::PlotLineG("common",SinewaveGetter,&fc,1000);
                 ImPlot::EndPlot();
             }
-        }            
+        }
         ImPlot::EndSubplots();
     }
 }
@@ -1837,11 +1841,12 @@ void ShowDemoWindow(bool* p_open) {
                 ShowDemo_CustomPlottersAndTooltips();
             ImGui::EndTabItem();
         }
+        if (ImGui::BeginTabItem("Config")) {
+            ShowDemo_Configuration();
+            ImGui::EndTabItem();
+        }
         if (ImGui::BeginTabItem("Help")) {
-            if (ImGui::CollapsingHeader("Help"))
-                ShowDemo_Help();
-            if (ImGui::CollapsingHeader("Configuration"))
-                ShowDemo_Configuration();
+            ShowDemo_Help();
             ImGui::EndTabItem();
         }
         ImGui::EndTabBar();

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -967,18 +967,17 @@ void ShowDemoWindow(bool* p_open) {
         ImGui::CheckboxFlags("ImPlotSubplotFlags_LinkCols", (unsigned int*)&flags, ImPlotSubplotFlags_LinkCols);
         ImGui::CheckboxFlags("ImPlotSubplotFlags_LinkAllX", (unsigned int*)&flags, ImPlotSubplotFlags_LinkAllX);
         ImGui::CheckboxFlags("ImPlotSubplotFlags_LinkAllY", (unsigned int*)&flags, ImPlotSubplotFlags_LinkAllY);
-        ImGui::CheckboxFlags("ImPlotSubplotFlags_Tight", (unsigned int*)&flags, ImPlotSubplotFlags_Tight);
-        ImGui::CheckboxFlags("ImPlotSubplotFlags_MultiFrame", (unsigned int*)&flags, ImPlotSubplotFlags_MultiFrame);
         ImGui::CheckboxFlags("ImPlotSubplotFlags_NoAlign", (unsigned int*)&flags, ImPlotSubplotFlags_NoAlign);
 
         static int rows = 2;
         static int cols = 2;
         ImGui::SliderInt("Rows",&rows,1,5);
         ImGui::SliderInt("Cols",&cols,1,5);
-        if (ImPlot::BeginSubplots("Subplots", rows, cols, ImVec2(800,600), flags)) {
+        static MyImPlot::WaveData wd(1,1,10,0);
+        if (ImPlot::BeginSubplots("Subplots", rows, cols, ImVec2(600,450), flags)) {
             for (int i = 0; i < rows*cols; ++i) {
-                if (ImPlot::BeginPlot("")) {
-                    
+                if (ImPlot::BeginPlot("title","x-axis","y-axis",ImVec2(0,0),0,ImPlotAxisFlags_NoTickLabels,ImPlotAxisFlags_NoTickLabels)) {
+                    ImPlot::PlotLineG("data",MyImPlot::SineWave,&wd,1000);
                     ImPlot::EndPlot();
                 }
             }

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -968,15 +968,16 @@ void ShowDemoWindow(bool* p_open) {
         ImGui::CheckboxFlags("ImPlotSubplotFlags_LinkAllX", (unsigned int*)&flags, ImPlotSubplotFlags_LinkAllX);
         ImGui::CheckboxFlags("ImPlotSubplotFlags_LinkAllY", (unsigned int*)&flags, ImPlotSubplotFlags_LinkAllY);
         ImGui::CheckboxFlags("ImPlotSubplotFlags_NoAlign", (unsigned int*)&flags, ImPlotSubplotFlags_NoAlign);
+        ImGui::CheckboxFlags("ImPlotSubplotFlags_NoTitle", (unsigned int*)&flags, ImPlotSubplotFlags_NoTitle);
 
         static int rows = 2;
         static int cols = 2;
         ImGui::SliderInt("Rows",&rows,1,5);
         ImGui::SliderInt("Cols",&cols,1,5);
         static MyImPlot::WaveData wd(1,1,10,0);
-        if (ImPlot::BeginSubplots("Subplots", rows, cols, ImVec2(600,450), flags)) {
+        if (ImPlot::BeginSubplots("Subplots", rows, cols, ImVec2(-1,450), flags)) {
             for (int i = 0; i < rows*cols; ++i) {
-                if (ImPlot::BeginPlot("title","x-axis","y-axis",ImVec2(0,0),0,ImPlotAxisFlags_NoTickLabels,ImPlotAxisFlags_NoTickLabels)) {
+                if (ImPlot::BeginPlot("title","x-axis","y-axis",ImVec2(0,0),0)) {
                     ImPlot::PlotLineG("data",MyImPlot::SineWave,&wd,1000);
                     ImPlot::EndPlot();
                 }

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -977,9 +977,7 @@ void ShowDemoWindow(bool* p_open) {
         ImGui::SliderInt("Cols",&cols,1,5);
         if (ImPlot::BeginSubplots("Subplots", rows, cols, ImVec2(800,600), flags)) {
             for (int i = 0; i < rows*cols; ++i) {
-                char buffer[16];
-                sprintf(buffer,"Subplot %d",i);
-                if (ImPlot::BeginPlot(buffer,"X","Y")) {
+                if (ImPlot::BeginPlot("")) {
                     
                     ImPlot::EndPlot();
                 }

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1026,6 +1026,7 @@ void ShowDemo_SubplotAxisLinking() {
     static int cols = 2;
     if (ImPlot::BeginSubplots("##AxisLinking", rows, cols, ImVec2(-1,400), flags)) {
         for (int i = 0; i < rows*cols; ++i) {
+            ImPlot::SetNextPlotLimits(0,1000,-1,1);
             if (ImPlot::BeginPlot("")) {
                 float fc = 0.01f;
                 ImPlot::PlotLineG("common",SinewaveGetter,&fc,1000);

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1251,7 +1251,7 @@ void ShowDemo_DragAndDrop() {
     ImGui::BulletText("Drag/drop items between plots.");
     ImGui::Indent();
     ImGui::BulletText("Plot 1 Targets: Plot, Y-Axes, Legend");
-    ImGui::BulletText("Plot 1 Sources: Legend Items");
+    ImGui::BulletText("Plot 1 Sources: Legend Item Labels");
     ImGui::BulletText("Plot 2 Targets: Plot, X-Axis, Y-Axis");
     ImGui::BulletText("Plot 2 Sources: Plot, X-Axis, Y-Axis (hold Ctrl)");
     ImGui::Unindent();

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -987,12 +987,37 @@ static inline ImPlotScale GetCurrentScale() { return GImPlot->Scales[GetCurrentY
 
 // Returns true if the user has requested data to be fit.
 static inline bool FitThisFrame() { return GImPlot->FitThisFrame; }
-// Extends the current plot's axes so that it encompasses point p
-IMPLOT_API void FitPoint(const ImPlotPoint& p);
+// Extend the the extents of an axis on current plot so that it encompes v
+static inline void FitPointAxis(ImPlotAxis& axis, ImPlotRange& ext, double v) {
+    if (!ImNanOrInf(v) && !(ImHasFlag(axis.Flags, ImPlotAxisFlags_LogScale) && v <= 0)) {
+        ext.Min = v < ext.Min ? v : ext.Min;
+        ext.Max = v > ext.Max ? v : ext.Max;
+    }
+}
+// Extend the the extents of an axis on current plot so that it encompes v
+static inline void FitPointMultiAxis(ImPlotAxis& axis, ImPlotAxis& alt, ImPlotRange& ext, double v, double v_alt) {
+    if (ImHasFlag(axis.Flags, ImPlotAxisFlags_RangeFit) && !alt.Range.Contains(v_alt))
+        return;
+    if (!ImNanOrInf(v) && !(ImHasFlag(axis.Flags, ImPlotAxisFlags_LogScale) && v <= 0)) {
+        ext.Min = v < ext.Min ? v : ext.Min;
+        ext.Max = v > ext.Max ? v : ext.Max;
+    }
+}
 // Extends the current plot's axes so that it encompasses a vertical line at x
-IMPLOT_API void FitPointX(double x);
+static inline void FitPointX(double x) {
+    FitPointAxis(GImPlot->CurrentPlot->XAxis, GImPlot->ExtentsX, x);
+}
 // Extends the current plot's axes so that it encompasses a horizontal line at y
-IMPLOT_API void FitPointY(double y);
+static inline void FitPointY(double y) {
+    const ImPlotYAxis y_axis  = GImPlot->CurrentPlot->CurrentYAxis;
+    FitPointAxis(GImPlot->CurrentPlot->YAxis[y_axis], GImPlot->ExtentsY[y_axis], y);
+}
+// Extends the current plot's axes so that it encompasses point p
+static inline void FitPoint(const ImPlotPoint& p) {
+    const ImPlotYAxis y_axis  = GImPlot->CurrentPlot->CurrentYAxis;
+    FitPointMultiAxis(GImPlot->CurrentPlot->XAxis, GImPlot->CurrentPlot->YAxis[y_axis], GImPlot->ExtentsX, p.x, p.y);
+    FitPointMultiAxis(GImPlot->CurrentPlot->YAxis[y_axis], GImPlot->CurrentPlot->XAxis, GImPlot->ExtentsY[y_axis], p.y, p.x);
+}
 
 // Returns true if two ranges overlap
 static inline bool RangesOverlap(const ImPlotRange& r1, const ImPlotRange& r2)

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -599,7 +599,9 @@ struct ImPlotAxis
         ColorMaj    = ColorMin = ColorTxt = 0;
     }
 
-    bool SetMin(double _min) {
+    bool SetMin(double _min, bool force=false) {
+        if (!force && IsLockedMin())
+            return false;
         _min = ImConstrainNan(ImConstrainInf(_min));
         if (ImHasFlag(Flags, ImPlotAxisFlags_LogScale))
             _min = ImConstrainLog(_min);
@@ -612,7 +614,9 @@ struct ImPlotAxis
         return true;
     };
 
-    bool SetMax(double _max) {
+    bool SetMax(double _max, bool force=false) {
+        if (!force && IsLockedMax())
+            return false;
         _max = ImConstrainNan(ImConstrainInf(_max));
         if (ImHasFlag(Flags, ImPlotAxisFlags_LogScale))
             _max = ImConstrainLog(_max);
@@ -672,11 +676,11 @@ struct ImPlotAxis
 
     inline bool IsAutoFitting()     const { return ImHasFlag(Flags, ImPlotAxisFlags_AutoFit);                                }
     inline bool IsRangeLocked()     const { return HasRange && RangeCond == ImGuiCond_Always;                                }
-    
+
     inline bool IsLockedMin()       const { return !Present || IsRangeLocked() || ImHasFlag(Flags, ImPlotAxisFlags_LockMin); }
     inline bool IsLockedMax()       const { return !Present || IsRangeLocked() || ImHasFlag(Flags, ImPlotAxisFlags_LockMax); }
     inline bool IsLocked()          const { return IsLockedMin() && IsLockedMax();                                           }
-    
+
     inline bool IsInputLockedMin()  const { return IsLockedMin() || IsAutoFitting();                                         }
     inline bool IsInputLockedMax()  const { return IsLockedMax() || IsAutoFitting();                                         }
     inline bool IsInputLocked()     const { return IsLocked()    || IsAutoFitting();                                         }
@@ -697,7 +701,6 @@ struct ImPlotItem
 
     ImPlotItem() {
         ID            = 0;
-        // Color         = ImPlot::NextColormapColor();
         NameOffset    = -1;
         Show          = true;
         SeenThisFrame = false;
@@ -769,8 +772,9 @@ struct ImPlotPlot
     ImPlotItem* GetLegendItem(int i);
     const char* GetLegendLabel(int i);
 
-    inline bool AnyYLocked() const    { return YAxis[0].IsInputLocked() || YAxis[1].Present ? YAxis[1].IsInputLocked() : false || YAxis[2].Present ? YAxis[2].IsInputLocked() : false; }
-    inline bool IsInputLocked() const { return XAxis.IsInputLocked() && YAxis[0].IsInputLocked() && YAxis[1].IsInputLocked() && YAxis[2].IsInputLocked();                              }
+    inline bool AnyYInputLocked() const { return YAxis[0].IsInputLocked() || (YAxis[1].Present ? YAxis[1].IsInputLocked() : false) || (YAxis[2].Present ? YAxis[2].IsInputLocked() : false); }
+    inline bool AllYInputLocked() const { return YAxis[0].IsInputLocked() && (YAxis[1].Present ? YAxis[1].IsInputLocked() : true ) && (YAxis[2].Present ? YAxis[2].IsInputLocked() : true ); }
+    inline bool IsInputLocked() const   { return XAxis.IsInputLocked() && YAxis[0].IsInputLocked() && YAxis[1].IsInputLocked() && YAxis[2].IsInputLocked();                                  }
 };
 
 // Temporary data storage for upcoming plot
@@ -1053,6 +1057,8 @@ static inline ImVec2 CalcTextSizeVertical(const char *text) {
 // Returns white or black text given background color
 static inline ImU32 CalcTextColor(const ImVec4& bg) { return (bg.x * 0.299 + bg.y * 0.587 + bg.z * 0.114) > 0.5 ? IM_COL32_BLACK : IM_COL32_WHITE; }
 static inline ImU32 CalcTextColor(ImU32 bg)         { return CalcTextColor(ImGui::ColorConvertU32ToFloat4(bg)); }
+// Lights or darkens a color for hover
+static inline ImU32 CalcHoverColor(ImU32 col)       {  return ImMixU32(col, CalcTextColor(col), 32); }
 
 // Clamps a label position so that it fits a rect defined by Min/Max
 static inline ImVec2 ClampLabelPos(ImVec2 pos, const ImVec2& size, const ImVec2& Min, const ImVec2& Max) {

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -696,6 +696,28 @@ struct ImPlotAxis
     inline bool IsLog()             const { return ImHasFlag(Flags, ImPlotAxisFlags_LogScale);                               }
 };
 
+// Align plots group data
+struct ImPlotAlignmentData {
+    ImPlotOrientation Orientation;
+    float PadA;
+    float PadB;
+    float PadAMax;
+    float PadBMax;
+    ImPlotAlignmentData() {
+        Orientation = ImPlotOrientation_Vertical;
+        PadA = PadB = PadAMax = PadBMax = 0;
+    }
+    void Begin() { PadAMax = PadBMax = 0; }
+    void Update(float& pad_a, float& pad_b) {
+        if (PadAMax < pad_a) PadAMax = pad_a;
+        if (pad_a < PadA)    pad_a   = PadA;
+        if (PadBMax < pad_b) PadBMax = pad_b;
+        if (pad_b < PadB)    pad_b   = PadB;
+    }
+    void End()   { PadA = PadAMax; PadB = PadBMax;      }
+    void Reset() { PadA = PadB = PadAMax = PadBMax = 0; }
+};
+
 // State information for Plot items
 struct ImPlotItem
 {
@@ -786,12 +808,19 @@ struct ImPlotPlot
 
 // Holds subplot data that must persist afer EndSubplot
 struct ImPlotSubplot {
-    ImGuiID            ID;
-    ImPlotSubplotFlags Flags;
-    int                Rows;
-    int                Cols;
-    int                CurrentIdx;
-    ImVec2             PlotFrameSize;
+    ImGuiID                       ID;
+    ImPlotSubplotFlags            Flags;
+    int                           Rows;
+    int                           Cols;
+    int                           CurrentIdx;
+    ImVec2                        PlotFrameSize;
+    ImVector<ImPlotAlignmentData> RowAlignmentData;
+    ImVector<ImPlotAlignmentData> ColAlignmentData;
+    ImVector<ImPlotRange>         RowLinkData;
+    ImVector<ImPlotRange>         ColLinkData;
+    ImPlotSubplot() {
+        Rows = Cols = CurrentIdx = 0;
+    }
 };
 
 // Temporary data storage for upcoming plot
@@ -862,20 +891,6 @@ struct ImPlotNextItemData {
         Marker        = IMPLOT_AUTO;
         HasHidden     = Hidden = false;
     }
-};
-
-// Align plots group data
-struct ImPlotAlignmentData {
-    ImPlotOrientation Orientation;
-    float PadA;
-    float PadB;
-    float PadAMax;
-    float PadBMax;
-    ImPlotAlignmentData() {
-        Orientation = ImPlotOrientation_Vertical;
-        PadA = PadB = PadAMax = PadBMax = 0;
-    }
-    void Reset() { PadA = PadB = PadAMax = PadBMax = 0; }
 };
 
 // Holds state information that must persist between calls to BeginPlot()/EndPlot()

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -784,6 +784,16 @@ struct ImPlotPlot
     inline bool IsInputLocked() const   { return XAxis.IsInputLocked() && YAxis[0].IsInputLocked() && YAxis[1].IsInputLocked() && YAxis[2].IsInputLocked();                                  }
 };
 
+// Holds subplot data that must persist afer EndSubplot
+struct ImPlotSubplot {
+    ImGuiID            ID;
+    ImPlotSubplotFlags Flags;
+    int                Rows;
+    int                Cols;
+    int                CurrentIdx;
+    ImVec2             PlotFrameSize;
+};
+
 // Temporary data storage for upcoming plot
 struct ImPlotNextPlotData
 {
@@ -865,15 +875,18 @@ struct ImPlotAlignmentData {
         Orientation = ImPlotOrientation_Vertical;
         PadA = PadB = PadAMax = PadBMax = 0;
     }
+    void Reset() { PadA = PadB = PadAMax = PadBMax = 0; }
 };
 
 // Holds state information that must persist between calls to BeginPlot()/EndPlot()
 struct ImPlotContext {
     // Plot States
-    ImPool<ImPlotPlot> Plots;
-    ImPlotPlot*        CurrentPlot;
-    ImPlotItem*        CurrentItem;
-    ImPlotItem*        PreviousItem;
+    ImPool<ImPlotPlot>    Plots;
+    ImPool<ImPlotSubplot> Subplots;
+    ImPlotPlot*           CurrentPlot;
+    ImPlotSubplot*        CurrentSubplot;
+    ImPlotItem*           CurrentItem;
+    ImPlotItem*           PreviousItem;
 
     // Tick Marks and Labels
     ImPlotTickCollection CTicks;
@@ -929,8 +942,9 @@ struct ImPlotContext {
     ImPlotPoint        MousePos[IMPLOT_Y_AXES];
 
     // Align plots
-    ImPool<ImPlotAlignmentData> AlignPlotGroup;
-    ImPlotAlignmentData*        CurrentAlignPlotGroup;
+    ImPool<ImPlotAlignmentData> AlignmentData;
+    ImPlotAlignmentData*        CurrentAlignmentH;
+    ImPlotAlignmentData*        CurrentAlignmentV;
 };
 
 //-----------------------------------------------------------------------------
@@ -947,7 +961,11 @@ namespace ImPlot {
 // Initializes an ImPlotContext
 IMPLOT_API void Initialize(ImPlotContext* ctx);
 // Resets an ImPlot context for the next call to BeginPlot
-IMPLOT_API void Reset(ImPlotContext* ctx);
+IMPLOT_API void ResetCtxForNextPlot(ImPlotContext* ctx);
+// Restes an ImPlot context for the next call to BeginAlignedPlots
+IMPLOT_API void ResetCtxForNextAlignedPlots(ImPlotContext* ctx);
+// Resets an ImPlot context for the next call to BeginSubplot
+IMPLOT_API void ResetCtxForNextSubplot(ImPlotContext* ctx);
 
 //-----------------------------------------------------------------------------
 // [SECTION] Input Utils
@@ -969,6 +987,13 @@ IMPLOT_API void BustPlotCache();
 
 // Shows a plot's context menu.
 IMPLOT_API void ShowPlotContextMenu(ImPlotPlot& plot);
+
+//-----------------------------------------------------------------------------
+// [SECTION] Subplot Utils
+//-----------------------------------------------------------------------------
+
+// Advances subplot to next plot
+IMPLOT_API void NextSubplot();
 
 //-----------------------------------------------------------------------------
 // [SECTION] Item Utils

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -815,7 +815,9 @@ struct ImPlotSubplot {
     int                           Rows;
     int                           Cols;
     int                           CurrentIdx;
-    ImVec2                        PlotFrameSize;
+    ImRect                        FrameRect;
+    ImVec2                        Pos;
+    ImVec2                        CellSize;
     ImVector<ImPlotAlignmentData> RowAlignmentData;
     ImVector<ImPlotAlignmentData> ColAlignmentData;
     ImVector<ImPlotRange>         RowLinkData;

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -857,13 +857,11 @@ struct ImPlotSubplot {
     ImVector<float>               ColRatios;
     ImVector<ImPlotRange>         RowLinkData;
     ImVector<ImPlotRange>         ColLinkData;
-    int                           ActiveSeparator;
     float                         TempSizes[2];
     bool                          FrameHovered;
     
     ImPlotSubplot() {
         Rows = Cols = CurrentIdx  = 0;
-        ActiveSeparator           = -1;
         FrameHovered              = false;
         Items.Legend.Location     = ImPlotLocation_North;
         Items.Legend.Orientation  = ImPlotOrientation_Horizontal;
@@ -998,7 +996,6 @@ struct ImPlotContext {
     ImVector<double>   Temp1, Temp2;
 
     // Misc
-    bool               DisableUserInput;
     int                DigitalPlotItemCnt;
     int                DigitalPlotOffset;
     ImPlotNextPlotData NextPlotData;

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -773,7 +773,7 @@ struct ImPlotLegendData
 };
 
 // Holds Items and Legend data
-struct ImPlotItemGroup 
+struct ImPlotItemGroup
 {
     ImGuiID            ID;
     ImPlotLegendData   Legend;
@@ -783,7 +783,7 @@ struct ImPlotItemGroup
     ImPlotItemGroup() { ColormapIdx = 0; }
 
     int         GetItemCount() const             { return ItemPool.GetBufSize();                                 }
-    ImGuiID     GetItemID(const char*  label_id) { return ImGui::GetID(label_id); /* GetIDWithSeed ? */          } 
+    ImGuiID     GetItemID(const char*  label_id) { return ImGui::GetID(label_id); /* GetIDWithSeed */            }
     ImPlotItem* GetItem(ImGuiID id)              { return ItemPool.GetByKey(id);                                 }
     ImPlotItem* GetItem(const char* label_id)    { return GetItem(GetItemID(label_id));                          }
     ImPlotItem* GetOrAddItem(ImGuiID id)         { return ItemPool.GetOrAddByKey(id);                            }
@@ -861,7 +861,7 @@ struct ImPlotSubplot {
     ImVector<ImPlotRange>         ColLinkData;
     float                         TempSizes[2];
     bool                          FrameHovered;
-    
+
     ImPlotSubplot() {
         Rows = Cols = CurrentIdx  = 0;
         FrameHovered              = false;

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -773,6 +773,7 @@ struct ImPlotLegendData
 // Holds Items and Legend data
 struct ImPlotItemGroup 
 {
+    ImGuiID            ID;
     ImPlotLegendData   Legend;
     ImPool<ImPlotItem> ItemPool;
     int                ColormapIdx;
@@ -839,7 +840,7 @@ struct ImPlotPlot
 struct ImPlotSubplot {
     ImGuiID                       ID;
     ImPlotSubplotFlags            Flags;
-    ImPlotItemGroup          Items;
+    ImPlotItemGroup               Items;
     int                           Rows;
     int                           Cols;
     int                           CurrentIdx;
@@ -942,6 +943,7 @@ struct ImPlotContext {
     ImPool<ImPlotSubplot> Subplots;
     ImPlotPlot*           CurrentPlot;
     ImPlotSubplot*        CurrentSubplot;
+    ImPlotItemGroup*      CurrentItems;
     ImPlotItem*           CurrentItem;
     ImPlotItem*           PreviousItem;
 
@@ -973,9 +975,6 @@ struct ImPlotContext {
     bool RenderX;
     bool RenderY[IMPLOT_Y_AXES];
 
-    // Subplot Flags
-    bool SubplotCaptureInput;
-    bool SubplotCaptureItems;
 
     // Axis Locking Flags
     bool ChildWindowMade;
@@ -994,6 +993,7 @@ struct ImPlotContext {
     ImVector<double>   Temp1, Temp2;
 
     // Misc
+    bool               DisableUserInput;
     int                DigitalPlotItemCnt;
     int                DigitalPlotOffset;
     ImPlotNextPlotData NextPlotData;
@@ -1046,7 +1046,7 @@ IMPLOT_API ImPlotPlot* GetCurrentPlot();
 IMPLOT_API void BustPlotCache();
 
 // Shows a plot's context menu.
-IMPLOT_API void ShowPlotContextMenu(ImPlotPlot& plot, bool has_legend);
+IMPLOT_API void ShowPlotContextMenu(ImPlotPlot& plot, bool owns_legend);
 
 //-----------------------------------------------------------------------------
 // [SECTION] Subplot Utils

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -814,6 +814,7 @@ struct ImPlotPlot
     bool            Queried;
     bool            DraggingQuery;
     bool            FrameHovered;
+    bool            FrameHeld;
     bool            PlotHovered;
     int             CurrentYAxis;
     ImPlotLocation  MousePosLocation;

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -1144,6 +1144,8 @@ static inline ImU32  GetStyleColorU32(ImPlotCol idx)  { return ImGui::ColorConve
 
 // Draws vertical text. The position is the bottom left of the text rect.
 IMPLOT_API void AddTextVertical(ImDrawList *DrawList, ImVec2 pos, ImU32 col, const char* text_begin, const char* text_end = NULL);
+// Draws multiline horizontal text centered.
+IMPLOT_API void AddTextCentered(ImDrawList* DrawList, ImVec2 top_center, ImU32 col, const char* text_begin, const char* text_end = NULL);
 // Calculates the size of vertical text
 static inline ImVec2 CalcTextSizeVertical(const char *text) {
     ImVec2 sz = ImGui::CalcTextSize(text);

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -1153,10 +1153,9 @@ IMPLOT_API ImVec2 GetLocationPos(const ImRect& outer_rect, const ImVec2& inner_s
 // Calculates the bounding box size of a legend
 IMPLOT_API ImVec2 CalcLegendSize(ImPlotItemGroup& items, const ImVec2& pad, const ImVec2& spacing, ImPlotOrientation orientation);
 // Renders legend entries into a bounding box
-IMPLOT_API void ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool interactable, const ImVec2& pad, const ImVec2& spacing, ImPlotOrientation orientation, ImDrawList& DrawList);
+IMPLOT_API bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool interactable, const ImVec2& pad, const ImVec2& spacing, ImPlotOrientation orientation, ImDrawList& DrawList);
 // Shows an alternate legend for the plot identified by #title_id, outside of the plot frame (can be called before or after of Begin/EndPlot but must occur in the same ImGui window!).
 IMPLOT_API void ShowAltLegend(const char* title_id, ImPlotOrientation orientation = ImPlotOrientation_Vertical, const ImVec2 size = ImVec2(0,0), bool interactable = true);
-
 // Shows an legends's context menu.
 IMPLOT_API bool ShowLegendContextMenu(ImPlotLegendData& legend, bool visible);
 

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -783,7 +783,7 @@ struct ImPlotItemGroup
     ImPlotItemGroup() { ColormapIdx = 0; }
 
     int         GetItemCount() const             { return ItemPool.GetBufSize();                                 }
-    ImGuiID     GetItemID(const char*  label_id) { return ImGui::GetIDWithSeed(label_id, NULL, ID);              }
+    ImGuiID     GetItemID(const char*  label_id) { return ImGui::GetID(label_id); /* GetIDWithSeed ? */          } 
     ImPlotItem* GetItem(ImGuiID id)              { return ItemPool.GetByKey(id);                                 }
     ImPlotItem* GetItem(const char* label_id)    { return GetItem(GetItemID(label_id));                          }
     ImPlotItem* GetOrAddItem(ImGuiID id)         { return ItemPool.GetOrAddByKey(id);                            }
@@ -1057,7 +1057,7 @@ IMPLOT_API void ShowPlotContextMenu(ImPlotPlot& plot);
 //-----------------------------------------------------------------------------
 
 // Advances to next subplot
-IMPLOT_API void NextSubplot();
+IMPLOT_API void SubplotNextCell();
 
 // Shows a subplot's context menu.
 IMPLOT_API void ShowSubplotsContextMenu(ImPlotSubplot& subplot);

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -816,14 +816,20 @@ struct ImPlotSubplot {
     int                           Cols;
     int                           CurrentIdx;
     ImRect                        FrameRect;
-    ImVec2                        Pos;
+    ImRect                        GridRect;
     ImVec2                        CellSize;
     ImVector<ImPlotAlignmentData> RowAlignmentData;
     ImVector<ImPlotAlignmentData> ColAlignmentData;
+    ImVector<float>               RowSizes;
+    ImVector<float>               ColSizes;
     ImVector<ImPlotRange>         RowLinkData;
     ImVector<ImPlotRange>         ColLinkData;
+    int                           ActiveSeparator;
+    float                         TempSizes[2];
+    bool                          FrameHovered;
     ImPlotSubplot() {
         Rows = Cols = CurrentIdx = 0;
+        ActiveSeparator = -1;
     }
 };
 

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -139,6 +139,14 @@ static inline void ImMinMaxArray(const T* values, int count, T* min_out, T* max_
     }
     *min_out = Min; *max_out = Max;
 }
+// Finds the sim of an array
+template <typename T>
+static inline T ImSum(const T* values, int count) {
+    T sum  = 0;
+    for (int i = 0; i < count; ++i)
+        sum += values[i];
+    return sum;
+}
 // Finds the mean of an array
 template <typename T>
 static inline double ImMean(const T* values, int count) {

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -756,15 +756,17 @@ struct ImPlotLegendData
     ImGuiTextBuffer   Labels;
     bool              Hovered;
     bool              Outside;
+    bool              CanGoOutside;
     bool              FlipSideNextFrame;
     ImPlotLocation    Location;
     ImPlotOrientation Orientation;
     ImRect            Rect;
 
     ImPlotLegendData() {
-        Hovered     = Outside = FlipSideNextFrame = false;
-        Location    = ImPlotLocation_North | ImPlotLocation_West;
-        Orientation = ImPlotOrientation_Vertical;
+        CanGoOutside = true;
+        Hovered      = Outside = FlipSideNextFrame = false;
+        Location     = ImPlotLocation_North | ImPlotLocation_West;
+        Orientation  = ImPlotOrientation_Vertical;
     }
 
     void Reset() { Indices.shrink(0); Labels.Buf.shrink(0); }
@@ -840,6 +842,7 @@ struct ImPlotPlot
 struct ImPlotSubplot {
     ImGuiID                       ID;
     ImPlotSubplotFlags            Flags;
+    ImPlotSubplotFlags            PreviousFlags;
     ImPlotItemGroup               Items;
     int                           Rows;
     int                           Cols;
@@ -858,11 +861,12 @@ struct ImPlotSubplot {
     bool                          FrameHovered;
     
     ImPlotSubplot() {
-        Rows = Cols = CurrentIdx = 0;
-        ActiveSeparator          = -1;
-        FrameHovered             = false;
-        Items.Legend.Location    = ImPlotLocation_North;
-        Items.Legend.Orientation = ImPlotOrientation_Horizontal;
+        Rows = Cols = CurrentIdx  = 0;
+        ActiveSeparator           = -1;
+        FrameHovered              = false;
+        Items.Legend.Location     = ImPlotLocation_North;
+        Items.Legend.Orientation  = ImPlotOrientation_Horizontal;
+        Items.Legend.CanGoOutside = false;
     }
 };
 
@@ -1052,8 +1056,11 @@ IMPLOT_API void ShowPlotContextMenu(ImPlotPlot& plot, bool owns_legend);
 // [SECTION] Subplot Utils
 //-----------------------------------------------------------------------------
 
-// Advances subplot to next plot
+// Advances to next subplot
 IMPLOT_API void NextSubplot();
+
+// Shows a subplot's context menu.
+IMPLOT_API void ShowSubplotsContextMenu(ImPlotSubplot& subplot);
 
 //-----------------------------------------------------------------------------
 // [SECTION] Item Utils
@@ -1149,6 +1156,9 @@ IMPLOT_API ImVec2 CalcLegendSize(ImPlotItemGroup& items, const ImVec2& pad, cons
 IMPLOT_API void ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool interactable, const ImVec2& pad, const ImVec2& spacing, ImPlotOrientation orientation, ImDrawList& DrawList);
 // Shows an alternate legend for the plot identified by #title_id, outside of the plot frame (can be called before or after of Begin/EndPlot but must occur in the same ImGui window!).
 IMPLOT_API void ShowAltLegend(const char* title_id, ImPlotOrientation orientation = ImPlotOrientation_Vertical, const ImVec2 size = ImVec2(0,0), bool interactable = true);
+
+// Shows an legends's context menu.
+IMPLOT_API bool ShowLegendContextMenu(ImPlotLegendData& legend, bool visible);
 
 //-----------------------------------------------------------------------------
 // [SECTION] Tick Utils

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -756,14 +756,14 @@ struct ImPlotLegendData
     ImGuiTextBuffer   Labels;
     bool              Hovered;
     bool              Outside;
-    bool              CanGoOutside;
+    bool              CanGoInside;
     bool              FlipSideNextFrame;
     ImPlotLocation    Location;
     ImPlotOrientation Orientation;
     ImRect            Rect;
 
     ImPlotLegendData() {
-        CanGoOutside = true;
+        CanGoInside = true;
         Hovered      = Outside = FlipSideNextFrame = false;
         Location     = ImPlotLocation_North | ImPlotLocation_West;
         Orientation  = ImPlotOrientation_Vertical;
@@ -782,15 +782,17 @@ struct ImPlotItemGroup
 
     ImPlotItemGroup() { ColormapIdx = 0; }
 
-    int         GetItemCount() const           { return ItemPool.GetBufSize();                                 }
-    ImPlotItem* GetItem(ImGuiID id)            { return ItemPool.GetByKey(id);                                 }
-    ImPlotItem* GetOrAddItem(ImGuiID id)       { return ItemPool.GetOrAddByKey(id);                            }
-    ImPlotItem* GetItemByIndex(int i)          { return ItemPool.GetByIndex(i);                                }
-    int         GetItemIndex(ImPlotItem* item) { return ItemPool.GetIndex(item);                               }
-    int         GetLegendCount() const         { return Legend.Indices.size();                                 }
-    ImPlotItem* GetLegendItem(int i)           { return ItemPool.GetByIndex(Legend.Indices[i]);                }
-    const char* GetLegendLabel(int i)          { return Legend.Labels.Buf.Data + GetLegendItem(i)->NameOffset; }
-    void        Reset()                        { ItemPool.Clear(); Legend.Reset(); ColormapIdx = 0;            }
+    int         GetItemCount() const             { return ItemPool.GetBufSize();                                 }
+    ImGuiID     GetItemID(const char*  label_id) { return ImGui::GetIDWithSeed(label_id, NULL, ID);              }
+    ImPlotItem* GetItem(ImGuiID id)              { return ItemPool.GetByKey(id);                                 }
+    ImPlotItem* GetItem(const char* label_id)    { return GetItem(GetItemID(label_id));                          }
+    ImPlotItem* GetOrAddItem(ImGuiID id)         { return ItemPool.GetOrAddByKey(id);                            }
+    ImPlotItem* GetItemByIndex(int i)            { return ItemPool.GetByIndex(i);                                }
+    int         GetItemIndex(ImPlotItem* item)   { return ItemPool.GetIndex(item);                               }
+    int         GetLegendCount() const           { return Legend.Indices.size();                                 }
+    ImPlotItem* GetLegendItem(int i)             { return ItemPool.GetByIndex(Legend.Indices[i]);                }
+    const char* GetLegendLabel(int i)            { return Legend.Labels.Buf.Data + GetLegendItem(i)->NameOffset; }
+    void        Reset()                          { ItemPool.Clear(); Legend.Reset(); ColormapIdx = 0;            }
 };
 
 // Holds Plot state information that must persist after EndPlot
@@ -865,7 +867,7 @@ struct ImPlotSubplot {
         FrameHovered              = false;
         Items.Legend.Location     = ImPlotLocation_North;
         Items.Legend.Orientation  = ImPlotOrientation_Horizontal;
-        Items.Legend.CanGoOutside = false;
+        Items.Legend.CanGoInside  = false;
     }
 };
 
@@ -1048,7 +1050,7 @@ IMPLOT_API ImPlotPlot* GetCurrentPlot();
 IMPLOT_API void BustPlotCache();
 
 // Shows a plot's context menu.
-IMPLOT_API void ShowPlotContextMenu(ImPlotPlot& plot, bool owns_legend);
+IMPLOT_API void ShowPlotContextMenu(ImPlotPlot& plot);
 
 //-----------------------------------------------------------------------------
 // [SECTION] Subplot Utils

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -918,6 +918,8 @@ inline void PlotLineEx(const char* label_id, const Getter& getter) {
         }
         // render markers
         if (s.Marker != ImPlotMarker_None) {
+            PopPlotClipRect();
+            PushPlotClipRect(s.MarkerSize);
             const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
             const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
             switch (GetCurrentScale()) {
@@ -989,6 +991,8 @@ inline void PlotScatterEx(const char* label_id, const Getter& getter) {
         // render markers
         ImPlotMarker marker = s.Marker == ImPlotMarker_None ? ImPlotMarker_Circle : s.Marker;
         if (marker != ImPlotMarker_None) {
+            PopPlotClipRect();
+            PushPlotClipRect(s.MarkerSize);
             const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
             const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
             switch (GetCurrentScale()) {
@@ -1068,6 +1072,8 @@ inline void PlotStairsEx(const char* label_id, const Getter& getter) {
         }
         // render markers
         if (s.Marker != ImPlotMarker_None) {
+            PopPlotClipRect();
+            PushPlotClipRect(s.MarkerSize);
             const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
             const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
             switch (GetCurrentScale()) {
@@ -1550,6 +1556,8 @@ inline void PlotStemsEx(const char* label_id, const GetterM& get_mark, const Get
         // render markers
         ImPlotMarker marker = s.Marker == ImPlotMarker_None ? ImPlotMarker_Circle : s.Marker;
         if (marker != ImPlotMarker_None) {
+            PopPlotClipRect();
+            PushPlotClipRect(s.MarkerSize);
             const ImU32 col_line = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerOutline]);
             const ImU32 col_fill = ImGui::GetColorU32(s.Colors[ImPlotCol_MarkerFill]);
             switch (GetCurrentScale()) {

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -61,8 +61,7 @@ namespace ImPlot {
 
 ImPlotItem* RegisterOrGetItem(const char* label_id, bool* just_created) {
     ImPlotContext& gp = *GImPlot;
-    ImPlotItemGroup& Items = gp.SubplotCaptureItems ? gp.CurrentSubplot->Items : gp.CurrentPlot->Items;
-
+    ImPlotItemGroup& Items = *gp.CurrentItems;
     ImGuiID id = ImGui::GetID(label_id); // pre subplots
     if (just_created != NULL)
         *just_created = Items.GetItem(id) == NULL;
@@ -86,7 +85,7 @@ ImPlotItem* RegisterOrGetItem(const char* label_id, bool* just_created) {
 ImPlotItem* GetItem(const char* label_id) {
     ImPlotContext& gp = *GImPlot;
     ImGuiID id = ImGui::GetID(label_id);
-    return gp.SubplotCaptureItems ? gp.CurrentSubplot->Items.GetItem(id) : gp.CurrentPlot->Items.GetItem(id);
+    return gp.CurrentItems->GetItem(id);
 }
 
 ImPlotItem* GetCurrentItem() {

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -61,7 +61,7 @@ namespace ImPlot {
 
 ImPlotItem* RegisterOrGetItem(const char* label_id, bool* just_created) {
     ImPlotContext& gp = *GImPlot;
-    ImPlotItemCollection& Items = gp.SubplotCaptureItems ? gp.CurrentSubplot->Items : gp.CurrentPlot->Items;
+    ImPlotItemGroup& Items = gp.SubplotCaptureItems ? gp.CurrentSubplot->Items : gp.CurrentPlot->Items;
 
     ImGuiID id = ImGui::GetID(label_id); // pre subplots
     if (just_created != NULL)
@@ -73,9 +73,9 @@ ImPlotItem* RegisterOrGetItem(const char* label_id, bool* just_created) {
     int idx = Items.GetItemIndex(item);
     item->ID = id;
     if (ImGui::FindRenderedTextEnd(label_id, NULL) != label_id) {
-        Items.LegendData.Indices.push_back(idx);
-        item->NameOffset = Items.LegendData.Labels.size();
-        Items.LegendData.Labels.append(label_id, label_id + strlen(label_id) + 1);
+        Items.Legend.Indices.push_back(idx);
+        item->NameOffset = Items.Legend.Labels.size();
+        Items.Legend.Labels.append(label_id, label_id + strlen(label_id) + 1);
     }
     else {
         item->Show = true;

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -142,8 +142,8 @@ void BustItemCache() {
         plot.Items.Reset();
     }
     for (int p = 0; p < gp.Subplots.GetBufSize(); ++p) {
-        ImPlotSubplot& plot = *gp.Subplots.GetByIndex(p);
-        plot.Items.Reset();
+        ImPlotSubplot& subplot = *gp.Subplots.GetByIndex(p);
+        subplot.Items.Reset();
     }
 }
 
@@ -153,10 +153,15 @@ void BustColorCache(const char* plot_title_id) {
         BustItemCache();
     }
     else {
-        ImPlotPlot* plot = gp.Plots.GetByKey(ImGui::GetCurrentWindow()->GetID(plot_title_id));
-        if (plot == NULL)
-            return;
-        plot->Items.Reset();
+        ImGuiID id = ImGui::GetCurrentWindow()->GetID(plot_title_id);
+        ImPlotPlot* plot = gp.Plots.GetByKey(id);
+        if (plot != NULL)
+            plot->Items.Reset();
+        else {
+            ImPlotSubplot* subplot = gp.Subplots.GetByKey(id);
+            if (subplot != NULL)
+                subplot->Items.Reset();
+        }
     }
 }
 

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -62,7 +62,7 @@ namespace ImPlot {
 ImPlotItem* RegisterOrGetItem(const char* label_id, bool* just_created) {
     ImPlotContext& gp = *GImPlot;
     ImPlotItemGroup& Items = *gp.CurrentItems;
-    ImGuiID id = ImGui::GetID(label_id); // pre subplots
+    ImGuiID id = Items.GetItemID(label_id);
     if (just_created != NULL)
         *just_created = Items.GetItem(id) == NULL;
     ImPlotItem* item = Items.GetOrAddItem(id);
@@ -84,8 +84,7 @@ ImPlotItem* RegisterOrGetItem(const char* label_id, bool* just_created) {
 
 ImPlotItem* GetItem(const char* label_id) {
     ImPlotContext& gp = *GImPlot;
-    ImGuiID id = ImGui::GetID(label_id);
-    return gp.CurrentItems->GetItem(id);
+    return gp.CurrentItems->GetItem(label_id);
 }
 
 ImPlotItem* GetCurrentItem() {


### PR DESCRIPTION
This PR extends the work of @ozlb's aligned plots #144. It adds a new API for creating both 1D and 2D sublots with automatic alignment along rows and columns. I expect this PR to be a WIP for a few weeks, as I want to make subplots a first-class feature and I have several `ImPlotSubplotFlags_` options in mind for them. 

Looping in interested parties and regulars: @yaman, @peterwilson136, @Mrgoodbytes13, @arximboldi, @ocornut, @bear24rw, @jvannugteren, @mindv0rtex, @PeterJohnson, @hoffstadt

What features would you like to see in a subplot API? How could this be more useful than plots inside of ImGui tables?

Current API prototype (feel free to try, but very rough at the moment). Usage is a simple a matter of surrounding `rows`*`cols` calls to `Begin/EndPlot` inside of `Begin/EndSubplot`. Plots are arranged in row-major order. Currently it is not possible to plot out of order (and I don't see an easy path forward for that). IDs are handled behind the scenes, so no need to Push/Pop IDs or use different titles. The `ImVe2 size` parameter of BeginPlot is ignored when inside of a Subplot context, as the size is determind from the parameter passed to `BeginSubplot`. Otherwise, everything else is the same as using `BeginPlot`.

```cpp
ImGui::Begin("Subplots Test");
if (ImPlot::BeginSubplot("Subplots", 3, 3, ImVec2(800,600))) {
    for (int i = 0; i < 9; ++i) {
        if (ImPlot::BeginPlot("Subplot","X","Y") {
            ...
            ImPlot::EndPlot();
        }
    }
    ImPlot::EndSubplot();
}
ImGui::End();
```
![subplot](https://user-images.githubusercontent.com/29577475/112791812-212a4d00-9017-11eb-853b-5a02da85aa9e.gif)
