### PR TITLE
add appropriate space for X tick labels with newlines

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -1532,7 +1532,7 @@ bool BeginPlot(const char* title, const char* x_label, const char* y1_label, con
     const bool show_x_label = x_label && !ImHasFlag(plot.XAxis.Flags, ImPlotAxisFlags_NoLabel);
 
     const float pad_top = title_size.x > 0.0f ? txt_height + gp.Style.LabelPadding.y : 0;
-    const float pad_bot = (plot.XAxis.IsLabeled() ? txt_height + gp.Style.LabelPadding.y + (plot.XAxis.IsTime() ? txt_height + gp.Style.LabelPadding.y : 0) : 0)
+    const float pad_bot = (plot.XAxis.IsLabeled() ? ImMax(txt_height, gp.XTicks.MaxHeight) + gp.Style.LabelPadding.y + (plot.XAxis.IsTime() ? txt_height + gp.Style.LabelPadding.y : 0) : 0)
                         + (show_x_label ? txt_height + gp.Style.LabelPadding.y : 0);
 
     const float plot_height = plot.CanvasRect.GetHeight() - pad_top - pad_bot;


### PR DESCRIPTION
When painting a graph with densely labeled ticks on the X axis, it may be
necessary to add newlines in the labels to avoid label text overlap.

Reserve appropriate padding space for that.

Before this change:
![newline-x-tick-orig](https://user-images.githubusercontent.com/499370/114275144-ae12d480-9a21-11eb-9a29-8fff8d93dd16.png)
After this change:
![newline-x-tick-fixed](https://user-images.githubusercontent.com/499370/114275151-b2d78880-9a21-11eb-8f2f-64ad2e5c4256.png)
