### PR TITLE
Add Java bindings to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ A: Like ImGui, it is recommended that you compile and link ImPlot as a *static* 
 
 **Q: Can ImPlot be used with other languages/bindings?**
 
-A: Yes, you can use the generated C binding, [cimplot](https://github.com/cimgui/cimplot) with most high level languages. [DearPyGui](https://github.com/hoffstadt/DearPyGui) provides a Python wrapper, among other things. A Rust binding, [implot-rs](https://github.com/4bb4/implot-rs), is currently in the works. An example using Emscripten can be found [here](https://github.com/pthom/implot_demo).
+A: Yes, you can use the generated C binding, [cimplot](https://github.com/cimgui/cimplot) with most high level languages. [DearPyGui](https://github.com/hoffstadt/DearPyGui) provides a Python wrapper, among other things. [imgui-java](https://github.com/SpaiR/imgui-java) provides bindings for Java. A Rust binding, [implot-rs](https://github.com/4bb4/implot-rs), is currently in the works. An example using Emscripten can be found [here](https://github.com/pthom/implot_demo).


### PR DESCRIPTION
Hello! I recently finished with Java bindings for ImPlot as an extension in [imgui-java](https://github.com/SpaiR/imgui-java), and I noticed the FAQ here had links to some available bindings. I thought it might be useful to provide a link for the Java bindings as well.