### PR TITLE
PlotShaded creates Opposite triangle winding

### DIFF
--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -673,8 +673,8 @@ struct ShadedRenderer {
         DrawList._IdxWritePtr[1] = (ImDrawIdx)(DrawList._VtxCurrentIdx + 1 + intersect);
         DrawList._IdxWritePtr[2] = (ImDrawIdx)(DrawList._VtxCurrentIdx + 3);
         DrawList._IdxWritePtr[3] = (ImDrawIdx)(DrawList._VtxCurrentIdx + 1);
-        DrawList._IdxWritePtr[4] = (ImDrawIdx)(DrawList._VtxCurrentIdx + 3 - intersect);
-        DrawList._IdxWritePtr[5] = (ImDrawIdx)(DrawList._VtxCurrentIdx + 4);
+        DrawList._IdxWritePtr[4] = (ImDrawIdx)(DrawList._VtxCurrentIdx + 4);
+        DrawList._IdxWritePtr[5] = (ImDrawIdx)(DrawList._VtxCurrentIdx + 3 - intersect);
         DrawList._IdxWritePtr += 6;
         DrawList._VtxCurrentIdx += 5;
         P11 = P21;


### PR DESCRIPTION
Triangle winding in this line creates one triangle clockwise and another counter-clockwise. This leads to one of the triangles being culled when culling is enabled.

Clockwise
https://github.com/epezent/implot/blob/507459fd5f7d6b210ad2a8663d0ae765251fcedf/implot_items.cpp#L672-L674

Counter-clockwise
https://github.com/epezent/implot/blob/507459fd5f7d6b210ad2a8663d0ae765251fcedf/implot_items.cpp#L675-L677