### PR TITLE
improve indexing, line rendering performance by 45%

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,31 +9,38 @@ The list below represents a combination of high-priority work, nice-to-have feat
 ## Axes
 
 - add support for multiple x-axes and don't limit count to 3
-    - will require `SetupNextAxis(...)` API
+    - will require `SetupNextAxis` API
 - make axis side configurable (top/left, right/bottom) via new flag `ImPlotAxisFlags_Opposite`
 - add support for setting tick label strings via callback
+- add flag to remove weekends on Time axis
 
 ## Plot Items
 
-- add ImPlotLineFlags, etc. for each plot type
+- add `ImPlotLineFlags`, `ImPlotBarsFlags`, etc. for each plot type
 - add `PlotBarGroups` wrapper that makes rendering groups of bars easier
+- add non-zero references for `PlotBars` etc.
+
 
 ## Styling
 
 - support gradient and/or colormap sampled fills (e.g. ImPlotFillStyle_)
+- add hover/active color for plot
 
 ## Legend
 
 - change `SetLegendLocation` API to be more consistent, i.e. `SetNextLegendLocation`
 - add legend scroll
 - improve legend icons (e.g. adopt markers, gradients, etc)
+- `ImPlotLegendFlags`
 
 ## Tools / Misc.
 
 - add `IsPlotChanging` to detect change in limits
 - add ability to extend plot/axis context menus
+- add LTTB downsampling for lines
 
 ## Optimizations
 
+- find faster way to buffer data into ImDrawList (very slow)
+- reduce number of calls to `PushClipRect`
 - explore SIMD operations for high density plot items
-- find faster way to buffer data into ImDrawList

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,39 @@
+The list below represents a combination of high-priority work, nice-to-have features, and random ideas. We make no guarantees that all of this work will be completed or even started. If you see something that you need or would like to have, let us know, or better yet consider submitting a PR for the feature.
+
+## Plots
+
+- remove axis-related args from signature of `BeginPlot` and add `SetupNextAxis` API
+    - add a few overloads of `BeginPlot` that bypass `SetupNextAxis` for common scenarios
+    - make current `BeginPlot` a wrapper to this API
+
+## Axes
+
+- add support for multiple x-axes and don't limit count to 3
+    - will require `SetupNextAxis(...)` API
+- make axis side configurable (top/left, right/bottom) via new flag `ImPlotAxisFlags_Opposite`
+- add support for setting tick label strings via callback
+
+## Plot Items
+
+- add ImPlotLineFlags, etc. for each plot type
+- add `PlotBarGroups` wrapper that makes rendering groups of bars easier
+
+## Styling
+
+- support gradient and/or colormap sampled fills (e.g. ImPlotFillStyle_)
+
+## Legend
+
+- change `SetLegendLocation` API to be more consistent, i.e. `SetNextLegendLocation`
+- add legend scroll
+- improve legend icons (e.g. adopt markers, gradients, etc)
+
+## Tools / Misc.
+
+- add `IsPlotChanging` to detect change in limits
+- add ability to extend plot/axis context menus
+
+## Optimizations
+
+- explore SIMD operations for high density plot items
+- find faster way to buffer data into ImDrawList

--- a/implot.cpp
+++ b/implot.cpp
@@ -437,6 +437,7 @@ void Initialize(ImPlotContext* ctx) {
     IMPLOT_APPEND_CMAP(Spectral, false);
     IMPLOT_APPEND_CMAP(Greys, false);
 
+    memset(ctx->DebugBools, 0, sizeof(ctx->DebugBools));
 }
 
 void ResetCtxForNextPlot(ImPlotContext* ctx) {
@@ -2812,7 +2813,7 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
 
     // calc plot frame sizes
     ImVec2 title_size(0.0f, 0.0f);
-    const float txt_height = ImGui::GetTextLineHeight();
+    // const float txt_height = ImGui::GetTextLineHeight();
     if (!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoTitle))
          title_size = ImGui::CalcTextSize(title, NULL, true);
     const float pad_top = title_size.x > 0.0f ? title_size.y + gp.Style.LabelPadding.y : 0;
@@ -2855,12 +2856,12 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
     // render splitters
     if (!ImHasFlag(subplot.Flags, ImPlotSubplotFlags_NoResize)) {
         ImDrawList& DrawList = *ImGui::GetWindowDrawList();
-        const ImU32 nrm_col = ImGui::ColorConvertFloat4ToU32(GImGui->Style.Colors[ImGuiCol_Separator]);
+        // const ImU32 nrm_col = ImGui::ColorConvertFloat4ToU32(GImGui->Style.Colors[ImGuiCol_Separator]);
         const ImU32 hov_col = ImGui::ColorConvertFloat4ToU32(GImGui->Style.Colors[ImGuiCol_SeparatorHovered]);
         const ImU32 act_col = ImGui::ColorConvertFloat4ToU32(GImGui->Style.Colors[ImGuiCol_SeparatorActive]);
         float xpos = subplot.GridRect.Min.x;
         float ypos = subplot.GridRect.Min.y;
-        const ImVec2 mouse = ImGui::GetIO().MousePos;
+        // const ImVec2 mouse = ImGui::GetIO().MousePos;
         int separator = 1;
         // bool pass = false;
         for (int r = 0; r < subplot.Rows-1; ++r) {

--- a/implot.cpp
+++ b/implot.cpp
@@ -31,6 +31,7 @@ Below is a change-log of API breaking changes only. If you are using one of the 
 When you are not sure about a old symbol or function name, try using the Search/Find function of your IDE to look for comments or references in all implot files.
 You can read releases logs https://github.com/epezent/implot/releases for more details.
 
+- 2021/07/30 (0.12) - The offset argument of `PlotXG` functions was been removed. Implement offsetting in your getter callback instead.
 - 2021/03/08 (0.9)  - SetColormap and PushColormap(ImVec4*) were removed. Use AddColormap for custom colormap support. LerpColormap was changed to SampleColormap.
                       ShowColormapScale was changed to ColormapScale and requires additional arguments.
 - 2021/03/07 (0.9)  - The signature of ShowColormapScale was modified to accept a ImVec2 size.
@@ -436,8 +437,6 @@ void Initialize(ImPlotContext* ctx) {
     IMPLOT_APPEND_CMAP(PiYG, false);
     IMPLOT_APPEND_CMAP(Spectral, false);
     IMPLOT_APPEND_CMAP(Greys, false);
-
-    memset(ctx->DebugBools, 0, sizeof(ctx->DebugBools));
 }
 
 void ResetCtxForNextPlot(ImPlotContext* ctx) {

--- a/implot.cpp
+++ b/implot.cpp
@@ -4908,7 +4908,7 @@ bool ShowTimePicker(const char* id, ImPlotTime* t) {
     }
     if (!hour24) {
         ImGui::SameLine();
-        if (ImGui::Button(am_pm[ap],ImVec2(height,height))) {
+        if (ImGui::Button(am_pm[ap],ImVec2(0,height))) {
             ap = 1 - ap;
             changed = true;
         }

--- a/implot.h
+++ b/implot.h
@@ -509,33 +509,33 @@ IMPLOT_API void EndSubplots();
 // Plots a standard 2D line plot.
 template <typename T> IMPLOT_API void PlotLine(const char* label_id, const T* values, int count, double xscale=1, double x0=0, int offset=0, int stride=sizeof(T));
 template <typename T> IMPLOT_API void PlotLine(const char* label_id, const T* xs, const T* ys, int count, int offset=0, int stride=sizeof(T));
-                      IMPLOT_API void PlotLineG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, int offset=0);
+                      IMPLOT_API void PlotLineG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count);
 
 // Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
 template <typename T> IMPLOT_API  void PlotScatter(const char* label_id, const T* values, int count, double xscale=1, double x0=0, int offset=0, int stride=sizeof(T));
 template <typename T> IMPLOT_API  void PlotScatter(const char* label_id, const T* xs, const T* ys, int count, int offset=0, int stride=sizeof(T));
-                      IMPLOT_API  void PlotScatterG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, int offset=0);
+                      IMPLOT_API  void PlotScatterG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count);
 
 // Plots a a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
 template <typename T> IMPLOT_API void PlotStairs(const char* label_id, const T* values, int count, double xscale=1, double x0=0, int offset=0, int stride=sizeof(T));
 template <typename T> IMPLOT_API void PlotStairs(const char* label_id, const T* xs, const T* ys, int count, int offset=0, int stride=sizeof(T));
-                      IMPLOT_API void PlotStairsG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, int offset=0);
+                      IMPLOT_API void PlotStairsG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count);
 
 // Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
 template <typename T> IMPLOT_API void PlotShaded(const char* label_id, const T* values, int count, double y_ref=0, double xscale=1, double x0=0, int offset=0, int stride=sizeof(T));
 template <typename T> IMPLOT_API void PlotShaded(const char* label_id, const T* xs, const T* ys, int count, double y_ref=0, int offset=0, int stride=sizeof(T));
 template <typename T> IMPLOT_API void PlotShaded(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, int offset=0, int stride=sizeof(T));
-                      IMPLOT_API void PlotShadedG(const char* label_id, ImPlotPoint (*getter1)(void* data, int idx), void* data1, ImPlotPoint (*getter2)(void* data, int idx), void* data2, int count, int offset=0);
+                      IMPLOT_API void PlotShadedG(const char* label_id, ImPlotPoint (*getter1)(void* data, int idx), void* data1, ImPlotPoint (*getter2)(void* data, int idx), void* data2, int count);
 
 // Plots a vertical bar graph. #width and #shift are in X units.
 template <typename T> IMPLOT_API void PlotBars(const char* label_id, const T* values, int count, double width=0.67, double shift=0, int offset=0, int stride=sizeof(T));
 template <typename T> IMPLOT_API void PlotBars(const char* label_id, const T* xs, const T* ys, int count, double width, int offset=0, int stride=sizeof(T));
-                      IMPLOT_API void PlotBarsG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, double width, int offset=0);
+                      IMPLOT_API void PlotBarsG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, double width);
 
 // Plots a horizontal bar graph. #height and #shift are in Y units.
 template <typename T> IMPLOT_API void PlotBarsH(const char* label_id, const T* values, int count, double height=0.67, double shift=0, int offset=0, int stride=sizeof(T));
 template <typename T> IMPLOT_API void PlotBarsH(const char* label_id, const T* xs, const T* ys, int count, double height, int offset=0, int stride=sizeof(T));
-                      IMPLOT_API void PlotBarsHG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, double height,  int offset=0);
+                      IMPLOT_API void PlotBarsHG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, double height);
 
 // Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
 template <typename T> IMPLOT_API void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* err, int count, int offset=0, int stride=sizeof(T));
@@ -571,7 +571,7 @@ template <typename T> IMPLOT_API double PlotHistogram2D(const char* label_id, co
 
 // Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
 template <typename T> IMPLOT_API void PlotDigital(const char* label_id, const T* xs, const T* ys, int count, int offset=0, int stride=sizeof(T));
-                      IMPLOT_API void PlotDigitalG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, int offset=0);
+                      IMPLOT_API void PlotDigitalG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count);
 
 // Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinates (y-up) and #uv0/uv1 are in texture coordinates (y-down).
 IMPLOT_API void PlotImage(const char* label_id, ImTextureID user_texture_id, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, const ImVec2& uv0=ImVec2(0,0), const ImVec2& uv1=ImVec2(1,1), const ImVec4& tint_col=ImVec4(1,1,1,1));

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1025,7 +1025,7 @@ void ShowDemo_SubplotItemSharing() {
                     }
                 }
                 if (ImPlot::BeginDragDropTarget()) {
-                    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MY_DND"))
+                    if (ImGui::AcceptDragDropPayload("MY_DND"))
                         id[curj] = i;
                     ImPlot::EndDragDropTarget();
                 }

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -1014,6 +1014,9 @@ struct ImPlotContext {
     ImPool<ImPlotAlignmentData> AlignmentData;
     ImPlotAlignmentData*        CurrentAlignmentH;
     ImPlotAlignmentData*        CurrentAlignmentV;
+
+    // Debug/dev flags
+    bool DebugBools[4];
 };
 
 //-----------------------------------------------------------------------------
@@ -1267,12 +1270,6 @@ void FillRange(ImVector<T>& buffer, int n, T vmin, T vmax) {
     }
 }
 
-// Offsets and strides a data buffer
-template <typename T>
-static inline T OffsetAndStride(const T* data, int idx, int count, int offset, int stride) {
-    idx = ImPosMod(offset + idx, count);
-    return *(const T*)(const void*)((const unsigned char*)data + (size_t)idx * stride);
-}
 // Calculate histogram bin counts and widths
 template <typename T>
 static inline void CalculateBins(const T* values, int count, ImPlotBin meth, const ImPlotRange& range, int& bins_out, double& width_out) {

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -1014,9 +1014,6 @@ struct ImPlotContext {
     ImPool<ImPlotAlignmentData> AlignmentData;
     ImPlotAlignmentData*        CurrentAlignmentH;
     ImPlotAlignmentData*        CurrentAlignmentV;
-
-    // Debug/dev flags
-    bool DebugBools[4];
 };
 
 //-----------------------------------------------------------------------------

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -1291,6 +1291,13 @@ void PlotBarsEx(const char* label_id, const Getter& getter, double width) {
                 continue;
             ImVec2 a = PlotToPixels(p.x - half_width, p.y);
             ImVec2 b = PlotToPixels(p.x + half_width, 0);
+            float width_px = ImAbs(a.x-b.x);
+            if (width_px < 1.0f) {
+                a.x += a.x > b.x ? (1-width_px) / 2 : (width_px-1) / 2;
+                b.x += b.x > a.x ? (1-width_px) / 2 : (width_px-1) / 2;
+            }
+            // a.x = IM_ROUND(a.x);
+            // b.x = IM_ROUND(b.x);
             if (s.RenderFill)
                 DrawList.AddRectFilled(a, b, col_fill);
             if (rend_line)

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -32,8 +32,7 @@
 #define SQRT_1_2 0.70710678118f
 #define SQRT_3_2 0.86602540378f
 
-#define IMPLOT_FORCE_INLINE
-#ifdef IMPLOT_FORCE_INLINE
+#ifndef IMPLOT_NO_FORCE_INLINE
     #ifdef _MSC_VER
         #define IMPLOT_INLINE __forceinline
     #elif defined(__GNUC__)
@@ -52,9 +51,9 @@
 #endif
 
 #if defined __SSE__ || defined __x86_64__ || defined _M_X64
-static inline float  ImInvSqrt(float x)           { return _mm_cvtss_f32(_mm_rsqrt_ss(_mm_set_ss(x))); }
+static IMPLOT_INLINE float  ImInvSqrt(float x)           { return _mm_cvtss_f32(_mm_rsqrt_ss(_mm_set_ss(x))); }
 #else
-static inline float  ImInvSqrt(float x)           { return 1.0f / sqrtf(x); }
+static IMPLOT_INLINE float  ImInvSqrt(float x)           { return 1.0f / sqrtf(x); }
 #endif
 
 #define IMPLOT_NORMALIZE2F_OVER_ZERO(VX,VY) do { float d2 = VX*VX + VY*VY; if (d2 > 0.0f) { float inv_len = ImInvSqrt(d2); VX *= inv_len; VY *= inv_len; } } while (0)

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -278,12 +278,12 @@ void EndItem() {
 // Offsets and strides a data buffer
 template <typename T>
 IMPLOT_INLINE T IndexData(const T* data, int idx, int count, int offset, int stride) {
-    const int s = 3 - ((offset == 0) << 0) | ((stride == sizeof(float)) << 1);
+    const int s = ((offset == 0) << 0) | ((stride == sizeof(float)) << 1);
     switch (s) {
-        case 0 : return data[idx];
-        case 1 : return data[(offset + idx) % count];  
-        case 2 : return *(const T*)(const void*)((const unsigned char*)data + (size_t)((idx) ) * stride);  
-        case 3 : return *(const T*)(const void*)((const unsigned char*)data + (size_t)((offset + idx) % count) * stride);    
+        case 3 : return data[idx];
+        case 2 : return data[(offset + idx) % count];
+        case 1 : return *(const T*)(const void*)((const unsigned char*)data + (size_t)((idx) ) * stride);
+        case 0 : return *(const T*)(const void*)((const unsigned char*)data + (size_t)((offset + idx) % count) * stride);
         default: return T(0);
     }
 }
@@ -455,7 +455,7 @@ struct GetterError {
 
 // Transforms convert points in plot space (i.e. ImPlotPoint) to pixel space (i.e. ImVec2)
 
-struct TransformerLin { 
+struct TransformerLin {
     TransformerLin(double pixMin, double pltMin, double,       double m, double    ) : PixMin(pixMin), PltMin(pltMin), M(m) { }
     template <typename T> IMPLOT_INLINE float operator()(T p) const { return (float)(PixMin + M * (p - PltMin)); }
     double PixMin, PltMin, M;
@@ -961,7 +961,7 @@ IMPLOT_INLINE void PlotLineEx(const char* label_id, const Getter& getter) {
 template <typename T>
 void PlotLine(const char* label_id, const T* values, int count, double xscale, double x0, int offset, int stride) {
     GetterYs<T> getter(values,count,xscale,x0,offset,stride);
-    PlotLineEx(label_id, getter);    
+    PlotLineEx(label_id, getter);
 }
 
 template IMPLOT_API void PlotLine<ImS8> (const char* label_id, const ImS8* values, int count, double xscale, double x0, int offset, int stride);


### PR DESCRIPTION
Improves performance of line rendering by ~45% by:

1) using better data indexing schemes (see issues raise in #122)
2) using SSE intrinsics for inverse sqrt (taken from https://github.com/ocornut/imgui/pull/4091)
3) forcing inlining of code in `implot_items.cpp` (consequentially also results in smaller binary sizes)

![image](https://user-images.githubusercontent.com/29577475/127726774-49ccf3b2-81ff-4f8e-9851-7c827f983069.png)

Confirmed to produce similar results for multiple compilers:

![image](https://user-images.githubusercontent.com/29577475/127726356-e056b986-7c7a-47e5-8cb6-adb0af7530cd.png)
