### PR TITLE
intel compiler warning fixes (and fastmath in general)

### DIFF
--- a/implot_internal.h
+++ b/implot_internal.h
@@ -121,11 +121,11 @@ static inline T ImRemap01(T x, T x0, T x1) { return (x - x0) / (x1 - x0); }
 // Returns always positive modulo (assumes r != 0)
 static inline int ImPosMod(int l, int r) { return (l % r + r) % r; }
 // Returns true if val is NAN or INFINITY
-static inline bool ImNanOrInf(double val) { return val == HUGE_VAL || val == -HUGE_VAL || isnan(val); }
+static inline bool ImNanOrInf(double val) { return !(val >= -DBL_MAX && val <= DBL_MAX) || isnan(val); }
 // Turns NANs to 0s
 static inline double ImConstrainNan(double val) { return isnan(val) ? 0 : val; }
 // Turns infinity to floating point maximums
-static inline double ImConstrainInf(double val) { return val == HUGE_VAL ?  DBL_MAX : val == -HUGE_VAL ? - DBL_MAX : val; }
+static inline double ImConstrainInf(double val) { return val >= DBL_MAX ?  DBL_MAX : val <= -DBL_MAX ? - DBL_MAX : val; }
 // Turns numbers less than or equal to 0 to 0.001 (sort of arbitrary, is there a better way?)
 static inline double ImConstrainLog(double val) { return val <= 0 ? 0.001f : val; }
 // Turns numbers less than 0 to zero

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -1195,11 +1195,11 @@ IMPLOT_INLINE void PlotShadedEx(const char* label_id, const Getter1& getter1, co
 template <typename T>
 void PlotShaded(const char* label_id, const T* values, int count, double y_ref, double xscale, double x0, int offset, int stride) {
     bool fit2 = true;
-    if (y_ref == -HUGE_VAL) {
+    if (!(y_ref > -DBL_MAX)) { // filters out nans too
         fit2 = false;
         y_ref = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO).Y.Min;
     }
-    if (y_ref == HUGE_VAL) {
+    if (!(y_ref < DBL_MAX)) { // filters out nans too
         fit2 = false;
         y_ref = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO).Y.Max;
     }
@@ -1222,11 +1222,11 @@ template IMPLOT_API void PlotShaded<double>(const char* label_id, const double* 
 template <typename T>
 void PlotShaded(const char* label_id, const T* xs, const T* ys, int count, double y_ref, int offset, int stride) {
     bool fit2 = true;
-    if (y_ref == -HUGE_VAL) {
+    if (!(y_ref > -DBL_MAX)) { // filters out nans too
         fit2 = false;
         y_ref = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO).Y.Min;
     }
-    if (y_ref == HUGE_VAL) {
+    if (!(y_ref < DBL_MAX)) { // filters out nans too
         fit2 = false;
         y_ref = GetPlotLimits(IMPLOT_AUTO,IMPLOT_AUTO).Y.Max;
     }


### PR DESCRIPTION
This PR Fixes warnings when built under intel compiler:
1>In file included from implot\implot.cpp:112:
1>implot/implot_internal.h(124,56): : warning : comparison with infinity always evaluates to false in fast floating point modes [-Wtautological-constant-compare]
1>static inline bool ImNanOrInf(double val) { return val == HUGE_VAL || val == -HUGE_VAL || isnan(val); }

And in general, it's not valid to compare with inf/nans when -ffastmath is used, since it is assumed to be a false comparison always.