### PR TITLE
RemoveColormap API function added

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -442,6 +442,7 @@ void SetCurrentContext(ImPlotContext* ctx) {
 
 #define IMPLOT_APPEND_CMAP(name, qual) ctx->ColormapData.Append(#name, name, sizeof(name)/sizeof(ImU32), qual)
 #define IM_RGB(r,g,b) IM_COL32(r,g,b,255)
+#define IMPLOT_CMAP_COUNT_BUILT_IN 16
 
 void Initialize(ImPlotContext* ctx) {
     ResetCtxForNextPlot(ctx);
@@ -4350,6 +4351,18 @@ ImPlotColormap AddColormap(const char* name, const ImU32*  colormap, int size, b
     return gp.ColormapData.Append(name, colormap, size, qual);
 }
 
+void RemoveColormap(const char* name) {
+    ImPlotContext& gp = *GImPlot;
+    RemoveColormap(gp.ColormapData.GetIndex(name));
+}
+
+void RemoveColormap(ImPlotColormap colormap) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(colormap >= IMPLOT_CMAP_COUNT_BUILT_IN, "You cannot remove built-in colormaps!");
+    IM_ASSERT_USER_ERROR(colormap < gp.ColormapData.Count, "The colormap does not exist!");
+    gp.ColormapData.Remove(colormap);
+}
+
 int GetColormapCount() {
     ImPlotContext& gp = *GImPlot;
     return gp.ColormapData.Count;
@@ -4993,6 +5006,8 @@ void ShowStyleEditor(ImPlotStyle* ref) {
             ImGui::Checkbox("Qualitative",&qual);
             if (ImGui::Button("Add", ImVec2(100, 0)) && gp.ColormapData.GetIndex(name)==-1)
                 AddColormap(name,custom.Data,custom.Size,qual);
+            if (ImGui::Button("Remove", ImVec2(100, 0)) && gp.ColormapData.GetIndex(name)>=IMPLOT_CMAP_COUNT_BUILT_IN)
+                RemoveColormap(name);
 
             ImGui::EndGroup();
             ImGui::SameLine();

--- a/implot.cpp
+++ b/implot.cpp
@@ -4960,6 +4960,16 @@ void ShowStyleEditor(ImPlotStyle* ref) {
                 if (!selected)
                     ImGui::PopStyleVar();
                 ImGui::SameLine();
+                if (i < IMPLOT_CMAP_COUNT_BUILT_IN)
+                    ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.25f);
+                if (ImGui::Button("X", ImVec2(20, 0)) && i >= IMPLOT_CMAP_COUNT_BUILT_IN) {
+                    RemoveColormap(name);
+                    if (i < gp.Style.Colormap || (gp.Style.Colormap == gp.ColormapData.Count && gp.ColormapData.Count == IMPLOT_CMAP_COUNT_BUILT_IN))
+                        gp.Style.Colormap--;
+                }
+                if (i < IMPLOT_CMAP_COUNT_BUILT_IN)
+                    ImGui::PopStyleVar();
+                ImGui::SameLine();
                 ImGui::BeginGroup();
                 if (edit) {
                     for (int c = 0; c < size; ++c) {
@@ -5006,8 +5016,6 @@ void ShowStyleEditor(ImPlotStyle* ref) {
             ImGui::Checkbox("Qualitative",&qual);
             if (ImGui::Button("Add", ImVec2(100, 0)) && gp.ColormapData.GetIndex(name)==-1)
                 AddColormap(name,custom.Data,custom.Size,qual);
-            if (ImGui::Button("Remove", ImVec2(100, 0)) && gp.ColormapData.GetIndex(name)>=IMPLOT_CMAP_COUNT_BUILT_IN)
-                RemoveColormap(name);
 
             ImGui::EndGroup();
             ImGui::SameLine();

--- a/implot.h
+++ b/implot.h
@@ -1141,6 +1141,11 @@ IMPLOT_API const char* GetMarkerName(ImPlotMarker idx);
 IMPLOT_API ImPlotColormap AddColormap(const char* name, const ImVec4* cols, int size, bool qual=true);
 IMPLOT_API ImPlotColormap AddColormap(const char* name, const ImU32*  cols, int size, bool qual=true);
 
+// Remove the specified colormap from the list of available colormaps. The colormap must exist in the internal list.
+// Only user-added colormaps can be removed. You will receive an assert otherwise!
+IMPLOT_API void RemoveColormap(const char* name);
+IMPLOT_API void RemoveColormap(ImPlotColormap colormap);
+
 // Returns the number of available colormaps (i.e. the built-in + user-added count).
 IMPLOT_API int GetColormapCount();
 // Returns a null terminated string name for a colormap given an index. Returns NULL if index is invalid.

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -392,6 +392,35 @@ struct ImPlotColormapData {
         }
     }
 
+    void Remove(ImPlotColormap cmap) {
+        if (cmap >= Count)
+            return;
+        ImGuiID key = ImHashStr(GetName(cmap));
+        ImGuiStorage::ImGuiStoragePair* cmapIt = NULL;
+        for (ImGuiStorage::ImGuiStoragePair* it = Map.Data.begin(); it != Map.Data.end(); ++it) {
+            if (it->key == key)
+                cmapIt = it;
+            else if (it->val_i > cmap)
+                it->val_i--;
+        }
+        if (cmapIt)
+            Map.Data.erase(cmapIt);
+        Quals.erase(Quals.begin() + cmap);
+        int textLen = strlen(Text.Buf.Data + TextOffsets[cmap]) + 1;
+        Text.Buf.erase(Text.Buf.begin() + TextOffsets[cmap], Text.Buf.begin() + TextOffsets[cmap] + textLen);
+        for (int i = cmap + 1; i < Count; ++i)
+            TextOffsets[i] -= textLen;
+        TextOffsets.erase(TextOffsets.begin() + cmap);
+        Keys.erase(Keys.begin() + KeyOffsets[cmap], Keys.begin() + KeyOffsets[cmap] + KeyCounts[cmap]);
+        for (int i = cmap + 1; i < Count; ++i)
+            KeyOffsets[i] -= KeyCounts[cmap];
+        KeyCounts.erase(KeyCounts.begin() + cmap);
+        KeyOffsets.erase(KeyOffsets.begin() + cmap);
+        --Count;
+
+        RebuildTables();
+    }
+
     void RebuildTables() {
         Tables.resize(0);
         TableSizes.resize(0);


### PR DESCRIPTION
Following up on #341 I implemented the feature.

There are 2 issues I would like your input with:
1. Where or how would you define the number of built-in colormaps? I just defined it as `IMPLOT_CMAP_COUNT_BUILT_IN` directly above the `Initialize` function. However there might be a better place to put it, to fit into the library structure.
2. I actually don't remove the respective entry out of the tables, but rather call the `RebuildTables` function at the end. That was kinda out of laziness from my side. If you prefer it, I can still implement a `void _RemoveTable(ImPlotColormap cmap)` function which only removes the needed entries.