### PR TITLE
Update implot_internal.h

### DIFF
--- a/implot_internal.h
+++ b/implot_internal.h
@@ -668,7 +668,7 @@ struct ImPlotAxis
             _min = ImConstrainLog(_min);
         if (ImHasFlag(Flags, ImPlotAxisFlags_Time))
             _min = ImConstrainTime(_min);
-        if (_min >= Range.Max)
+        if (!force && _min >= Range.Max)
             return false;
         Range.Min = _min;
         PickerTimeMin = ImPlotTime::FromDouble(Range.Min);
@@ -684,7 +684,7 @@ struct ImPlotAxis
             _max = ImConstrainLog(_max);
         if (ImHasFlag(Flags, ImPlotAxisFlags_Time))
             _max = ImConstrainTime(_max);
-        if (_max <= Range.Min)
+        if (!force && _max <= Range.Min)
             return false;
         Range.Max = _max;
         PickerTimeMax = ImPlotTime::FromDouble(Range.Max);


### PR DESCRIPTION
### Take the existing force-flag into account in SetMin(), SetMax()

When trying to set a new linked axis (SetupAxisLinks()) with min > 1.0, SetMin() is called with flag force, but as force flag is not implemented the linked axis is set to 0.0 and the new value is discarded.

I changed the check with (_max<= Range.Min) to (!force && _max<= Range.Min) for SetMax() and vice versa for SetMin() as the force flag is not functional as it is now.

I stumbled uppon this problem when trying to use linked axis with ImPlotAxisFlags_Time as i didn't want to show x-axis from unixtimestamp 0.0 ( = 1970) until now, but after the first EndPlot() Call my linkedaxis.Min was set to 0.0 . Further investigation showed, that SetupAxisLinks() calls  axis.PullLinks() which then uses SetMin(*LinkedMin, true), where true is the force flag, to set the new Minimum. Problem is, the force flag does in fact not force a change of the axis range. Instead it is checked whether _min is smaller than Range.Max. As SetMax() is called after SetMin(), the Range.Max value is still its initialization value 1.0 and thus a new Minequal to the current unix time (something in the range of 1.6 billion) is definitely larger than 1.0 and will not be set!