### PR TITLE
Support long & long double, add macro INSTANTIATE_FOR_NUMERIC_TYPES (Fix #319)

### DIFF
--- a/.github/CMakeLists.txt
+++ b/.github/CMakeLists.txt
@@ -23,3 +23,4 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU" AND DEFINED GCC_ARCH)
 endif ()
 
 target_include_directories(implot PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../imgui)
+target_compile_definitions(implot PRIVATE IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES=1)

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ A: Yes, within reason. You can plot tens to hundreds of thousands of points with
 **Q: What data types can I plot?**
 
 A: ImPlot plotting functions accept most scalar types:
-`float`, `double`, `int8`, `uint8`, `int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`. Arrays of custom structs or classes (e.g. `Vector2f` or similar) are easily passed to ImPlot functions using the built in striding features (see `implot.h` for documentation), and many plotters provide a "getter" overload which accepts data generating callbacks.
+`float`, `double`, `int8`, `uint8`, `int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`. Arrays of custom structs or classes (e.g. `Vector2f` or similar) are easily passed to ImPlot functions using the built-in striding features (see `implot.h` for documentation), and many plotters provide a "getter" overload which accepts data generating callbacks. Additional support for `long`, `unsigned long` and `long double` can be added by defining `IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES` at compile-time (see `implot_items.cpp`).
 
 **Q: Can plot styles be modified?**
 

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -167,7 +167,7 @@ static inline double ImMean(const T* values, int count) {
     double den = 1.0 / count;
     double mu  = 0;
     for (int i = 0; i < count; ++i)
-        mu += values[i] * den;
+        mu += (double)values[i] * den;
     return mu;
 }
 // Finds the sample standard deviation of an array
@@ -177,7 +177,7 @@ static inline double ImStdDev(const T* values, int count) {
     double mu  = ImMean(values, count);
     double x   = 0;
     for (int i = 0; i < count; ++i)
-        x += (values[i] - mu) * (values[i] - mu) * den;
+        x += ((double)values[i] - mu) * ((double)values[i] - mu) * den;
     return sqrt(x);
 }
 // Mix color a and b by factor s in [0 256]

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -93,7 +93,7 @@ static IMPLOT_INLINE float  ImInvSqrt(float x) { return 1.0f / sqrtf(x); }
 // Uncomment the next line (#define IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES) in order to define versions for those types
 // (or define it via a compilation option). In this case, the compilation time for this specific file will be 33% longer
 
-#define IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES
+// #define IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES
 
 #define INSTANTIATE_FOR_REMAINING_NUMERIC_TYPES(instantiate_macro) \
     instantiate_macro(long);                                                                              \

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -1618,16 +1618,17 @@ void PlotLine(const char* label_id, const T* values, int count, double xscale, d
     GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,offset,stride),count);
     PlotLineEx(label_id, getter, flags);
 }
-#define instantiate_PlotLine(T) template IMPLOT_API void PlotLine<T> (const char* label_id, const T* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotLine);
 
 template <typename T>
 void PlotLine(const char* label_id, const T* xs, const T* ys, int count, ImPlotLineFlags flags, int offset, int stride) {
     GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
     PlotLineEx(label_id, getter, flags);
 }
-#define instantiate_PlotLine2(T) template IMPLOT_API void PlotLine<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotLineFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotLine2);
+
+#define INSTANTIATE_PLOT_LINE(T) \
+    template IMPLOT_API void PlotLine<T> (const char* label_id, const T* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotLine<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotLineFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(INSTANTIATE_PLOT_LINE);
 
 // custom
 void PlotLineG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotLineFlags flags) {
@@ -1662,16 +1663,17 @@ void PlotScatter(const char* label_id, const T* values, int count, double xscale
     GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,offset,stride),count);
     PlotScatterEx(label_id, getter, flags);
 }
-#define instantiate_PlotScatter(T) template IMPLOT_API void PlotScatter<T>(const char* label_id, const T* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotScatter);
 
 template <typename T>
 void PlotScatter(const char* label_id, const T* xs, const T* ys, int count, ImPlotScatterFlags flags, int offset, int stride) {
     GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
     return PlotScatterEx(label_id, getter, flags);
 }
-#define instantiate_PlotScatter_2(T) template IMPLOT_API void PlotScatter<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotScatter_2);
+
+#define INSTANTIATE_PLOT_SCATTER(T) \
+    template IMPLOT_API void PlotScatter<T>(const char* label_id, const T* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotScatter<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(INSTANTIATE_PLOT_SCATTER);
 
 // custom
 void PlotScatterG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotScatterFlags flags) {
@@ -1720,16 +1722,17 @@ void PlotStairs(const char* label_id, const T* values, int count, double xscale,
     GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,offset,stride),count);
     PlotStairsEx(label_id, getter, flags);
 }
-#define instantiate_PlotStairs(T) template IMPLOT_API void PlotStairs<T> (const char* label_id, const T* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotStairs);
 
 template <typename T>
 void PlotStairs(const char* label_id, const T* xs, const T* ys, int count, ImPlotStairsFlags flags, int offset, int stride) {
     GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
     return PlotStairsEx(label_id, getter, flags);
 }
-#define instantiate_PlotStairs2(T) template IMPLOT_API void PlotStairs<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotStairs2);
+
+#define INSTANTIATE_PLOT_STAIRS(T) \
+    template IMPLOT_API void PlotStairs<T> (const char* label_id, const T* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotStairs<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(INSTANTIATE_PLOT_STAIRS);
 
 // custom
 void PlotStairsG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotStairsFlags flags) {
@@ -1763,8 +1766,6 @@ void PlotShaded(const char* label_id, const T* values, int count, double y_ref, 
     GetterXY<IndexerLin,IndexerConst>  getter2(IndexerLin(xscale,x0),IndexerConst(y_ref),count);
     PlotShadedEx(label_id, getter1, getter2, flags);
 }
-#define instantiate_PlotShaded(T) template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotShaded);
 
 template <typename T>
 void PlotShaded(const char* label_id, const T* xs, const T* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride) {
@@ -1776,8 +1777,7 @@ void PlotShaded(const char* label_id, const T* xs, const T* ys, int count, doubl
     GetterXY<IndexerIdx<T>,IndexerConst>  getter2(IndexerIdx<T>(xs,count,offset,stride),IndexerConst(y_ref),count);
     PlotShadedEx(label_id, getter1, getter2, flags);
 }
-#define instantiate_PlotShaded2(T) template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* xs, const T* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotShaded2);
+
 
 template <typename T>
 void PlotShaded(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, ImPlotShadedFlags flags, int offset, int stride) {
@@ -1785,8 +1785,12 @@ void PlotShaded(const char* label_id, const T* xs, const T* ys1, const T* ys2, i
     GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter2(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys2,count,offset,stride),count);
     PlotShadedEx(label_id, getter1, getter2, flags);
 }
-#define instantiate_PlotShaded3(T) template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotShaded3);
+
+#define INSTANTIATE_PLOT_SHADED(T) \
+    template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* xs, const T* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(INSTANTIATE_PLOT_SHADED);
 
 // custom
 void PlotShadedG(const char* label_id, ImPlotGetter getter_func1, void* data1, ImPlotGetter getter_func2, void* data2, int count, ImPlotShadedFlags flags) {
@@ -1852,8 +1856,6 @@ void PlotBars(const char* label_id, const T* values, int count, double bar_size,
         PlotBarsVEx(label_id, getter1, getter2, bar_size, flags);
     }
 }
-#define instantiate_PlotBars(T) template IMPLOT_API void PlotBars<T>(const char* label_id, const T* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotBars);
 
 template <typename T>
 void PlotBars(const char* label_id, const T* xs, const T* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride) {
@@ -1868,8 +1870,11 @@ void PlotBars(const char* label_id, const T* xs, const T* ys, int count, double 
         PlotBarsVEx(label_id, getter1, getter2, bar_size, flags);
     }
 }
-#define instantiate_PlotBars2(T) template IMPLOT_API void PlotBars<T>(const char* label_id, const T* xs, const T* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotBars2);
+
+#define INSTANTIATE_PLOT_BARS(T) \
+    template IMPLOT_API void PlotBars<T>(const char* label_id, const T* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotBars<T>(const char* label_id, const T* xs, const T* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(INSTANTIATE_PLOT_BARS);
 
 void PlotBarsG(const char* label_id, ImPlotGetter getter_func, void* data, int count, double bar_size, ImPlotBarsFlags flags) {
     if (ImHasFlag(flags, ImPlotBarsFlags_Horizontal)) {
@@ -1963,8 +1968,9 @@ void PlotBarGroups(const char* const label_ids[], const T* values, int item_coun
         }
     }
 }
-#define instantiate_PlotBarGroups(T) template IMPLOT_API void PlotBarGroups<T>(const char* const label_ids[], const T* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotBarGroups);
+
+#define INSTANTIATE_PLOT_BAR_GROUPS(T) template IMPLOT_API void PlotBarGroups<T>(const char* const label_ids[], const T* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
+INSTANTIATE_FOR_NUMERIC_TYPES(INSTANTIATE_PLOT_BAR_GROUPS);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotErrorBars
@@ -2016,8 +2022,6 @@ template <typename T>
 void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride) {
     PlotErrorBars(label_id, xs, ys, err, err, count, flags, offset, stride);
 }
-#define instantiate_PlotErrorBars(T) template IMPLOT_API void PlotErrorBars<T>(const char* label_id, const T* xs, const T* ys, const T* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotErrorBars);
 
 template <typename T>
 void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* neg, const T* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride) {
@@ -2041,8 +2045,11 @@ void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* neg,
         PlotErrorBarsVEx(label_id, getter_p, getter_n, flags);
     }
 }
-#define instantiate_PlotErrorBars2(T) template IMPLOT_API void PlotErrorBars<T>(const char* label_id, const T* xs, const T* ys, const T* neg, const T* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotErrorBars2);
+
+#define INSTANTIATE_PLOT_ERROR_BARS(T) \
+    template IMPLOT_API void PlotErrorBars<T>(const char* label_id, const T* xs, const T* ys, const T* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotErrorBars<T>(const char* label_id, const T* xs, const T* ys, const T* neg, const T* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(INSTANTIATE_PLOT_ERROR_BARS);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotStems
@@ -2082,8 +2089,6 @@ void PlotStems(const char* label_id, const T* values, int count, double ref, dou
         PlotStemsEx(label_id, get_mark, get_base, flags);
     }
 }
-#define instantiate_PlotStems(T) template IMPLOT_API void PlotStems<T>(const char* label_id, const T* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotStems);
 
 template <typename T>
 void PlotStems(const char* label_id, const T* xs, const T* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride) {
@@ -2098,8 +2103,12 @@ void PlotStems(const char* label_id, const T* xs, const T* ys, int count, double
         PlotStemsEx(label_id, get_mark, get_base, flags);
     }
 }
-#define instantiate_PlotStems2(T) template IMPLOT_API void PlotStems<T>(const char* label_id, const T* xs, const T* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotStems2);
+
+#define INSTANTIATE_PLOT_STEMS(T) \
+    template IMPLOT_API void PlotStems<T>(const char* label_id, const T* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride); \
+    template IMPLOT_API void PlotStems<T>(const char* label_id, const T* xs, const T* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(INSTANTIATE_PLOT_STEMS);
+
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotInfLines
@@ -2131,8 +2140,8 @@ void PlotInfLines(const char* label_id, const T* values, int count, ImPlotInfLin
         }
     }
 }
-#define instantiate_PlotInfLines(T) template IMPLOT_API void PlotInfLines<T>(const char* label_id, const T* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotInfLines);
+#define INSTANTIATE_PLOT_INF_LINES(T) template IMPLOT_API void PlotInfLines<T>(const char* label_id, const T* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(INSTANTIATE_PLOT_INF_LINES);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotPieChart
@@ -2207,8 +2216,8 @@ void PlotPieChart(const char* const label_ids[], const T* values, int count, dou
     }
     PopPlotClipRect();
 }
-#define instantiate_PlotPieChart(T) template IMPLOT_API void PlotPieChart<T>(const char* const label_ids[], const T* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotPieChart);
+#define INSTANTIATE_PLOT_PIE_CHART(T) template IMPLOT_API void PlotPieChart<T>(const char* const label_ids[], const T* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
+INSTANTIATE_FOR_NUMERIC_TYPES(INSTANTIATE_PLOT_PIE_CHART);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotHeatmap
@@ -2363,8 +2372,8 @@ void PlotHeatmap(const char* label_id, const T* values, int rows, int cols, doub
         EndItem();
     }
 }
-#define instantiate_PlotHeatmap(T) template IMPLOT_API void PlotHeatmap<T>(const char* label_id, const T* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotHeatmap);
+#define INSTANTIATE_PLOT_HEATMAP(T) template IMPLOT_API void PlotHeatmap<T>(const char* label_id, const T* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
+INSTANTIATE_FOR_NUMERIC_TYPES(INSTANTIATE_PLOT_HEATMAP);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotHistogram
@@ -2447,8 +2456,8 @@ double PlotHistogram(const char* label_id, const T* values, int count, int bins,
         PlotBars(label_id, &bin_centers.Data[0], &bin_counts.Data[0], bins, bar_scale*width);
     return max_count;
 }
-#define instantiate_PlotHistogram(T) template IMPLOT_API double PlotHistogram<T>(const char* label_id, const T* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotHistogram);
+#define INSTANTIATE_PLOT_HISTOGRAM(T) template IMPLOT_API double PlotHistogram<T>(const char* label_id, const T* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
+INSTANTIATE_FOR_NUMERIC_TYPES(INSTANTIATE_PLOT_HISTOGRAM);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotHistogram2D
@@ -2523,8 +2532,8 @@ double PlotHistogram2D(const char* label_id, const T* xs, const T* ys, int count
     }
     return max_count;
 }
-#define instantiate_PlotHistogram2D(T) template IMPLOT_API double PlotHistogram2D<T>(const char* label_id,   const T*   xs, const T*   ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotHistogram2D);
+#define INSTANTIATE_PLOT_HISTOGRAM_2D(T) template IMPLOT_API double PlotHistogram2D<T>(const char* label_id,   const T*   xs, const T*   ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
+INSTANTIATE_FOR_NUMERIC_TYPES(INSTANTIATE_PLOT_HISTOGRAM_2D);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotDigital
@@ -2597,8 +2606,8 @@ void PlotDigital(const char* label_id, const T* xs, const T* ys, int count, ImPl
     GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
     return PlotDigitalEx(label_id, getter, flags);
 }
-#define instantiate_PlotDigital(T) template IMPLOT_API void PlotDigital<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
-INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotDigital);
+#define INSTANTIATE_PLOT_DIGITAL(T) template IMPLOT_API void PlotDigital<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(INSTANTIATE_PLOT_DIGITAL);
 
 // custom
 void PlotDigitalG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotDigitalFlags flags) {

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -69,9 +69,8 @@ static IMPLOT_INLINE float  ImInvSqrt(float x) { return 1.0f / sqrtf(x); }
 //-----------------------------------------------------------------------------
 // [SECTION] Template instantiation utility
 //-----------------------------------------------------------------------------
-// (INSTANTIATE_FOR_NUMERIC_TYPES is a macro which instantiates templated plotting functions for numeric types)
 
-// By default, templates are instantiated for the following types, which are defined in imgui.h:
+// By default, templates are instantiated for the following types, which are defined in imgui.h. Note: this list does not include `long`, `unsigned long` and `long double`: define `IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES` at compile-time to add support for them.
 #define INSTANTIATE_FOR_STANDARD_NUMERIC_TYPES(instantiate_macro)                                         \
     instantiate_macro(ImS8);    /* typedef signed char         ImS8;   // 8-bit signed integer */         \
     instantiate_macro(ImU8);    /* typedef unsigned char       ImU8;   // 8-bit unsigned integer */       \
@@ -83,17 +82,6 @@ static IMPLOT_INLINE float  ImInvSqrt(float x) { return 1.0f / sqrtf(x); }
     instantiate_macro(ImU64);   /* typedef unsigned long long  ImU64;  // 64-bit unsigned integer */      \
     instantiate_macro(float);                                                                             \
     instantiate_macro(double);
-
-// The previous type list does not include "long", "unsigned long" and "long double".
-// Most of the time, it is not an issue when linking statically.
-// However, when linking dynamically, issues related to undefined functions can arise: although those types
-// might have the same size, they are considered separate. As a consequence, on linux 64b bits,
-// `ImPlot::PlotLine<unsigned long>(...)` might be considered as undefined.
-//
-// Uncomment the next line (#define IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES) in order to define versions for those types
-// (or define it via a compilation option). In this case, the compilation time for this specific file will be 33% longer
-
-// #define IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES
 
 #define INSTANTIATE_FOR_REMAINING_NUMERIC_TYPES(instantiate_macro) \
     instantiate_macro(long);                                                                              \

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -66,6 +66,48 @@ static IMPLOT_INLINE float  ImInvSqrt(float x) { return 1.0f / sqrtf(x); }
 #define ImDrawFlags_RoundCornersAll ImDrawCornerFlags_All
 #endif
 
+//-----------------------------------------------------------------------------
+// [SECTION] Template instantiation utility
+//-----------------------------------------------------------------------------
+// (INSTANTIATE_FOR_NUMERIC_TYPES is a macro which instantiates templated plotting functions for numeric types)
+
+// By default, templates are instantiated for the following types, which are defined in imgui.h:
+#define INSTANTIATE_FOR_STANDARD_NUMERIC_TYPES(instantiate_macro)                                         \
+    instantiate_macro(ImS8);    /* typedef signed char         ImS8;   // 8-bit signed integer */         \
+    instantiate_macro(ImU8);    /* typedef unsigned char       ImU8;   // 8-bit unsigned integer */       \
+    instantiate_macro(ImS16);   /* typedef signed short        ImS16;  // 16-bit signed integer */        \
+    instantiate_macro(ImU16);   /* typedef unsigned short      ImU16;  // 16-bit unsigned integer */      \
+    instantiate_macro(ImS32);   /* typedef signed int          ImS32;  // 32-bit signed integer == int */ \
+    instantiate_macro(ImU32);   /* typedef unsigned int        ImU32;  // 32-bit unsigned integer */      \
+    instantiate_macro(ImS64);   /* typedef signed   long long  ImS64;  // 64-bit signed integer */        \
+    instantiate_macro(ImU64);   /* typedef unsigned long long  ImU64;  // 64-bit unsigned integer */      \
+    instantiate_macro(float);                                                                             \
+    instantiate_macro(double);
+
+// The previous type list does not include "long", "unsigned long" and "long double".
+// Most of the time, it is not an issue when linking statically.
+// However, when linking dynamically, issues related to undefined functions can arise: although those types
+// might have the same size, they are considered separate. As a consequence, on linux 64b bits,
+// `ImPlot::PlotLine<unsigned long>(...)` might be considered as undefined.
+//
+// Uncomment the next line (#define IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES) in order to define versions for those types
+// (or define it via a compilation option). In this case, the compilation time for this specific file will be 33% longer
+
+#define IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES
+
+#define INSTANTIATE_FOR_REMAINING_NUMERIC_TYPES(instantiate_macro) \
+    instantiate_macro(long);                                                                              \
+    instantiate_macro(unsigned long);                                                                     \
+    instantiate_macro(long double);
+
+#ifdef IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES
+    #define INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_macro)                                               \
+        INSTANTIATE_FOR_STANDARD_NUMERIC_TYPES(instantiate_macro)                                          \
+        INSTANTIATE_FOR_REMAINING_NUMERIC_TYPES(instantiate_macro)
+#else
+    #define INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_macro) INSTANTIATE_FOR_STANDARD_NUMERIC_TYPES(instantiate_macro)
+#endif
+
 namespace ImPlot {
 
 //-----------------------------------------------------------------------------
@@ -1576,34 +1618,16 @@ void PlotLine(const char* label_id, const T* values, int count, double xscale, d
     GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,offset,stride),count);
     PlotLineEx(label_id, getter, flags);
 }
-
-template IMPLOT_API void PlotLine<ImS8> (const char* label_id, const ImS8* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<ImU8> (const char* label_id, const ImU8* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<ImS16>(const char* label_id, const ImS16* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<ImU16>(const char* label_id, const ImU16* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<ImS32>(const char* label_id, const ImS32* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<ImU32>(const char* label_id, const ImU32* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<ImS64>(const char* label_id, const ImS64* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<ImU64>(const char* label_id, const ImU64* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<float>(const char* label_id, const float* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<double>(const char* label_id, const double* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride);
+#define instantiate_PlotLine(T) template IMPLOT_API void PlotLine<T> (const char* label_id, const T* values, int count, double xscale, double x0, ImPlotLineFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotLine);
 
 template <typename T>
 void PlotLine(const char* label_id, const T* xs, const T* ys, int count, ImPlotLineFlags flags, int offset, int stride) {
     GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
     PlotLineEx(label_id, getter, flags);
 }
-
-template IMPLOT_API void PlotLine<ImS8>(const char* label_id, const ImS8* xs, const ImS8* ys, int count, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<ImU8>(const char* label_id, const ImU8* xs, const ImU8* ys, int count, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<ImS16>(const char* label_id, const ImS16* xs, const ImS16* ys, int count, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<ImU16>(const char* label_id, const ImU16* xs, const ImU16* ys, int count, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<ImS32>(const char* label_id, const ImS32* xs, const ImS32* ys, int count, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<ImU32>(const char* label_id, const ImU32* xs, const ImU32* ys, int count, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<ImS64>(const char* label_id, const ImS64* xs, const ImS64* ys, int count, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<ImU64>(const char* label_id, const ImU64* xs, const ImU64* ys, int count, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<float>(const char* label_id, const float* xs, const float* ys, int count, ImPlotLineFlags flags, int offset, int stride);
-template IMPLOT_API void PlotLine<double>(const char* label_id, const double* xs, const double* ys, int count, ImPlotLineFlags flags, int offset, int stride);
+#define instantiate_PlotLine2(T) template IMPLOT_API void PlotLine<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotLineFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotLine2);
 
 // custom
 void PlotLineG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotLineFlags flags) {
@@ -1638,34 +1662,16 @@ void PlotScatter(const char* label_id, const T* values, int count, double xscale
     GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,offset,stride),count);
     PlotScatterEx(label_id, getter, flags);
 }
-
-template IMPLOT_API void PlotScatter<ImS8>(const char* label_id, const ImS8* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<ImU8>(const char* label_id, const ImU8* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<ImS16>(const char* label_id, const ImS16* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<ImU16>(const char* label_id, const ImU16* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<ImS32>(const char* label_id, const ImS32* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<ImU32>(const char* label_id, const ImU32* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<ImS64>(const char* label_id, const ImS64* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<ImU64>(const char* label_id, const ImU64* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<float>(const char* label_id, const float* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<double>(const char* label_id, const double* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride);
+#define instantiate_PlotScatter(T) template IMPLOT_API void PlotScatter<T>(const char* label_id, const T* values, int count, double xscale, double x0, ImPlotScatterFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotScatter);
 
 template <typename T>
 void PlotScatter(const char* label_id, const T* xs, const T* ys, int count, ImPlotScatterFlags flags, int offset, int stride) {
     GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
     return PlotScatterEx(label_id, getter, flags);
 }
-
-template IMPLOT_API void PlotScatter<ImS8>(const char* label_id, const ImS8* xs, const ImS8* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<ImU8>(const char* label_id, const ImU8* xs, const ImU8* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<ImS16>(const char* label_id, const ImS16* xs, const ImS16* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<ImU16>(const char* label_id, const ImU16* xs, const ImU16* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<ImS32>(const char* label_id, const ImS32* xs, const ImS32* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<ImU32>(const char* label_id, const ImU32* xs, const ImU32* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<ImS64>(const char* label_id, const ImS64* xs, const ImS64* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<ImU64>(const char* label_id, const ImU64* xs, const ImU64* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<float>(const char* label_id, const float* xs, const float* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
-template IMPLOT_API void PlotScatter<double>(const char* label_id, const double* xs, const double* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
+#define instantiate_PlotScatter_2(T) template IMPLOT_API void PlotScatter<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotScatterFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotScatter_2);
 
 // custom
 void PlotScatterG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotScatterFlags flags) {
@@ -1714,34 +1720,16 @@ void PlotStairs(const char* label_id, const T* values, int count, double xscale,
     GetterXY<IndexerLin,IndexerIdx<T>> getter(IndexerLin(xscale,x0),IndexerIdx<T>(values,count,offset,stride),count);
     PlotStairsEx(label_id, getter, flags);
 }
-
-template IMPLOT_API void PlotStairs<ImS8> (const char* label_id, const ImS8* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<ImU8> (const char* label_id, const ImU8* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<ImS16>(const char* label_id, const ImS16* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<ImU16>(const char* label_id, const ImU16* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<ImS32>(const char* label_id, const ImS32* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<ImU32>(const char* label_id, const ImU32* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<ImS64>(const char* label_id, const ImS64* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<ImU64>(const char* label_id, const ImU64* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<float>(const char* label_id, const float* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<double>(const char* label_id, const double* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride);
+#define instantiate_PlotStairs(T) template IMPLOT_API void PlotStairs<T> (const char* label_id, const T* values, int count, double xscale, double x0, ImPlotStairsFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotStairs);
 
 template <typename T>
 void PlotStairs(const char* label_id, const T* xs, const T* ys, int count, ImPlotStairsFlags flags, int offset, int stride) {
     GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
     return PlotStairsEx(label_id, getter, flags);
 }
-
-template IMPLOT_API void PlotStairs<ImS8>(const char* label_id, const ImS8* xs, const ImS8* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<ImU8>(const char* label_id, const ImU8* xs, const ImU8* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<ImS16>(const char* label_id, const ImS16* xs, const ImS16* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<ImU16>(const char* label_id, const ImU16* xs, const ImU16* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<ImS32>(const char* label_id, const ImS32* xs, const ImS32* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<ImU32>(const char* label_id, const ImU32* xs, const ImU32* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<ImS64>(const char* label_id, const ImS64* xs, const ImS64* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<ImU64>(const char* label_id, const ImU64* xs, const ImU64* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<float>(const char* label_id, const float* xs, const float* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStairs<double>(const char* label_id, const double* xs, const double* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
+#define instantiate_PlotStairs2(T) template IMPLOT_API void PlotStairs<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotStairsFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotStairs2);
 
 // custom
 void PlotStairsG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotStairsFlags flags) {
@@ -1775,17 +1763,8 @@ void PlotShaded(const char* label_id, const T* values, int count, double y_ref, 
     GetterXY<IndexerLin,IndexerConst>  getter2(IndexerLin(xscale,x0),IndexerConst(y_ref),count);
     PlotShadedEx(label_id, getter1, getter2, flags);
 }
-
-template IMPLOT_API void PlotShaded<ImS8>(const char* label_id, const ImS8* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImU8>(const char* label_id, const ImU8* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImS16>(const char* label_id, const ImS16* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImU16>(const char* label_id, const ImU16* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImS32>(const char* label_id, const ImS32* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImU32>(const char* label_id, const ImU32* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImS64>(const char* label_id, const ImS64* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImU64>(const char* label_id, const ImU64* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<float>(const char* label_id, const float* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<double>(const char* label_id, const double* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride);
+#define instantiate_PlotShaded(T) template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* values, int count, double y_ref, double xscale, double x0, ImPlotShadedFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotShaded);
 
 template <typename T>
 void PlotShaded(const char* label_id, const T* xs, const T* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride) {
@@ -1797,17 +1776,8 @@ void PlotShaded(const char* label_id, const T* xs, const T* ys, int count, doubl
     GetterXY<IndexerIdx<T>,IndexerConst>  getter2(IndexerIdx<T>(xs,count,offset,stride),IndexerConst(y_ref),count);
     PlotShadedEx(label_id, getter1, getter2, flags);
 }
-
-template IMPLOT_API void PlotShaded<ImS8>(const char* label_id, const ImS8* xs, const ImS8* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImU8>(const char* label_id, const ImU8* xs, const ImU8* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImS16>(const char* label_id, const ImS16* xs, const ImS16* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImU16>(const char* label_id, const ImU16* xs, const ImU16* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImS32>(const char* label_id, const ImS32* xs, const ImS32* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImU32>(const char* label_id, const ImU32* xs, const ImU32* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImS64>(const char* label_id, const ImS64* xs, const ImS64* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImU64>(const char* label_id, const ImU64* xs, const ImU64* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<float>(const char* label_id, const float* xs, const float* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<double>(const char* label_id, const double* xs, const double* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride);
+#define instantiate_PlotShaded2(T) template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* xs, const T* ys, int count, double y_ref, ImPlotShadedFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotShaded2);
 
 template <typename T>
 void PlotShaded(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, ImPlotShadedFlags flags, int offset, int stride) {
@@ -1815,17 +1785,8 @@ void PlotShaded(const char* label_id, const T* xs, const T* ys1, const T* ys2, i
     GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter2(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys2,count,offset,stride),count);
     PlotShadedEx(label_id, getter1, getter2, flags);
 }
-
-template IMPLOT_API void PlotShaded<ImS8>(const char* label_id, const ImS8* xs, const ImS8* ys1, const ImS8* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImU8>(const char* label_id, const ImU8* xs, const ImU8* ys1, const ImU8* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImS16>(const char* label_id, const ImS16* xs, const ImS16* ys1, const ImS16* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImU16>(const char* label_id, const ImU16* xs, const ImU16* ys1, const ImU16* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImS32>(const char* label_id, const ImS32* xs, const ImS32* ys1, const ImS32* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImU32>(const char* label_id, const ImU32* xs, const ImU32* ys1, const ImU32* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImS64>(const char* label_id, const ImS64* xs, const ImS64* ys1, const ImS64* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<ImU64>(const char* label_id, const ImU64* xs, const ImU64* ys1, const ImU64* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<float>(const char* label_id, const float* xs, const float* ys1, const float* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
-template IMPLOT_API void PlotShaded<double>(const char* label_id, const double* xs, const double* ys1, const double* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
+#define instantiate_PlotShaded3(T) template IMPLOT_API void PlotShaded<T>(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, ImPlotShadedFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotShaded3);
 
 // custom
 void PlotShadedG(const char* label_id, ImPlotGetter getter_func1, void* data1, ImPlotGetter getter_func2, void* data2, int count, ImPlotShadedFlags flags) {
@@ -1891,17 +1852,8 @@ void PlotBars(const char* label_id, const T* values, int count, double bar_size,
         PlotBarsVEx(label_id, getter1, getter2, bar_size, flags);
     }
 }
-
-template IMPLOT_API void PlotBars<ImS8>(const char* label_id, const ImS8* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<ImU8>(const char* label_id, const ImU8* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<ImS16>(const char* label_id, const ImS16* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<ImU16>(const char* label_id, const ImU16* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<ImS32>(const char* label_id, const ImS32* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<ImU32>(const char* label_id, const ImU32* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<ImS64>(const char* label_id, const ImS64* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<ImU64>(const char* label_id, const ImU64* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<float>(const char* label_id, const float* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<double>(const char* label_id, const double* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride);
+#define instantiate_PlotBars(T) template IMPLOT_API void PlotBars<T>(const char* label_id, const T* values, int count, double bar_size, double shift, ImPlotBarsFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotBars);
 
 template <typename T>
 void PlotBars(const char* label_id, const T* xs, const T* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride) {
@@ -1916,17 +1868,8 @@ void PlotBars(const char* label_id, const T* xs, const T* ys, int count, double 
         PlotBarsVEx(label_id, getter1, getter2, bar_size, flags);
     }
 }
-
-template IMPLOT_API void PlotBars<ImS8>(const char* label_id, const ImS8* xs, const ImS8* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<ImU8>(const char* label_id, const ImU8* xs, const ImU8* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<ImS16>(const char* label_id, const ImS16* xs, const ImS16* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<ImU16>(const char* label_id, const ImU16* xs, const ImU16* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<ImS32>(const char* label_id, const ImS32* xs, const ImS32* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<ImU32>(const char* label_id, const ImU32* xs, const ImU32* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<ImS64>(const char* label_id, const ImS64* xs, const ImS64* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<ImU64>(const char* label_id, const ImU64* xs, const ImU64* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<float>(const char* label_id, const float* xs, const float* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotBars<double>(const char* label_id, const double* xs, const double* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
+#define instantiate_PlotBars2(T) template IMPLOT_API void PlotBars<T>(const char* label_id, const T* xs, const T* ys, int count, double bar_size, ImPlotBarsFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotBars2);
 
 void PlotBarsG(const char* label_id, ImPlotGetter getter_func, void* data, int count, double bar_size, ImPlotBarsFlags flags) {
     if (ImHasFlag(flags, ImPlotBarsFlags_Horizontal)) {
@@ -2020,17 +1963,8 @@ void PlotBarGroups(const char* const label_ids[], const T* values, int item_coun
         }
     }
 }
-
-template IMPLOT_API void PlotBarGroups<ImS8>(const char* const label_ids[], const ImS8* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
-template IMPLOT_API void PlotBarGroups<ImU8>(const char* const label_ids[], const ImU8* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
-template IMPLOT_API void PlotBarGroups<ImS16>(const char* const label_ids[], const ImS16* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
-template IMPLOT_API void PlotBarGroups<ImU16>(const char* const label_ids[], const ImU16* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
-template IMPLOT_API void PlotBarGroups<ImS32>(const char* const label_ids[], const ImS32* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
-template IMPLOT_API void PlotBarGroups<ImU32>(const char* const label_ids[], const ImU32* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
-template IMPLOT_API void PlotBarGroups<ImS64>(const char* const label_ids[], const ImS64* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
-template IMPLOT_API void PlotBarGroups<ImU64>(const char* const label_ids[], const ImU64* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
-template IMPLOT_API void PlotBarGroups<float>(const char* const label_ids[], const float* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
-template IMPLOT_API void PlotBarGroups<double>(const char* const label_ids[], const double* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
+#define instantiate_PlotBarGroups(T) template IMPLOT_API void PlotBarGroups<T>(const char* const label_ids[], const T* values, int items, int groups, double width, double shift, ImPlotBarGroupsFlags flags);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotBarGroups);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotErrorBars
@@ -2082,17 +2016,8 @@ template <typename T>
 void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride) {
     PlotErrorBars(label_id, xs, ys, err, err, count, flags, offset, stride);
 }
-
-template IMPLOT_API void PlotErrorBars<ImS8>(const char* label_id, const ImS8* xs, const ImS8* ys, const ImS8* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<ImU8>(const char* label_id, const ImU8* xs, const ImU8* ys, const ImU8* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<ImS16>(const char* label_id, const ImS16* xs, const ImS16* ys, const ImS16* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<ImU16>(const char* label_id, const ImU16* xs, const ImU16* ys, const ImU16* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<ImS32>(const char* label_id, const ImS32* xs, const ImS32* ys, const ImS32* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<ImU32>(const char* label_id, const ImU32* xs, const ImU32* ys, const ImU32* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<ImS64>(const char* label_id, const ImS64* xs, const ImS64* ys, const ImS64* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<ImU64>(const char* label_id, const ImU64* xs, const ImU64* ys, const ImU64* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<float>(const char* label_id, const float* xs, const float* ys, const float* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<double>(const char* label_id, const double* xs, const double* ys, const double* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
+#define instantiate_PlotErrorBars(T) template IMPLOT_API void PlotErrorBars<T>(const char* label_id, const T* xs, const T* ys, const T* err, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotErrorBars);
 
 template <typename T>
 void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* neg, const T* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride) {
@@ -2116,17 +2041,8 @@ void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* neg,
         PlotErrorBarsVEx(label_id, getter_p, getter_n, flags);
     }
 }
-
-template IMPLOT_API void PlotErrorBars<ImS8>(const char* label_id, const ImS8* xs, const ImS8* ys, const ImS8* neg, const ImS8* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<ImU8>(const char* label_id, const ImU8* xs, const ImU8* ys, const ImU8* neg, const ImU8* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<ImS16>(const char* label_id, const ImS16* xs, const ImS16* ys, const ImS16* neg, const ImS16* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<ImU16>(const char* label_id, const ImU16* xs, const ImU16* ys, const ImU16* neg, const ImU16* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<ImS32>(const char* label_id, const ImS32* xs, const ImS32* ys, const ImS32* neg, const ImS32* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<ImU32>(const char* label_id, const ImU32* xs, const ImU32* ys, const ImU32* neg, const ImU32* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<ImS64>(const char* label_id, const ImS64* xs, const ImS64* ys, const ImS64* neg, const ImS64* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<ImU64>(const char* label_id, const ImU64* xs, const ImU64* ys, const ImU64* neg, const ImU64* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<float>(const char* label_id, const float* xs, const float* ys, const float* neg, const float* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotErrorBars<double>(const char* label_id, const double* xs, const double* ys, const double* neg, const double* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
+#define instantiate_PlotErrorBars2(T) template IMPLOT_API void PlotErrorBars<T>(const char* label_id, const T* xs, const T* ys, const T* neg, const T* pos, int count, ImPlotErrorBarsFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotErrorBars2);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotStems
@@ -2166,17 +2082,8 @@ void PlotStems(const char* label_id, const T* values, int count, double ref, dou
         PlotStemsEx(label_id, get_mark, get_base, flags);
     }
 }
-
-template IMPLOT_API void PlotStems<ImS8>(const char* label_id, const ImS8* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<ImU8>(const char* label_id, const ImU8* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<ImS16>(const char* label_id, const ImS16* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<ImU16>(const char* label_id, const ImU16* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<ImS32>(const char* label_id, const ImS32* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<ImU32>(const char* label_id, const ImU32* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<ImS64>(const char* label_id, const ImS64* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<ImU64>(const char* label_id, const ImU64* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<float>(const char* label_id, const float* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<double>(const char* label_id, const double* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride);
+#define instantiate_PlotStems(T) template IMPLOT_API void PlotStems<T>(const char* label_id, const T* values, int count, double ref, double scale, double start, ImPlotStemsFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotStems);
 
 template <typename T>
 void PlotStems(const char* label_id, const T* xs, const T* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride) {
@@ -2191,17 +2098,8 @@ void PlotStems(const char* label_id, const T* xs, const T* ys, int count, double
         PlotStemsEx(label_id, get_mark, get_base, flags);
     }
 }
-
-template IMPLOT_API void PlotStems<ImS8>(const char* label_id, const ImS8* xs, const ImS8* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<ImU8>(const char* label_id, const ImU8* xs, const ImU8* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<ImS16>(const char* label_id, const ImS16* xs, const ImS16* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<ImU16>(const char* label_id, const ImU16* xs, const ImU16* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<ImS32>(const char* label_id, const ImS32* xs, const ImS32* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<ImU32>(const char* label_id, const ImU32* xs, const ImU32* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<ImS64>(const char* label_id, const ImS64* xs, const ImS64* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<ImU64>(const char* label_id, const ImU64* xs, const ImU64* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<float>(const char* label_id, const float* xs, const float* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
-template IMPLOT_API void PlotStems<double>(const char* label_id, const double* xs, const double* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
+#define instantiate_PlotStems2(T) template IMPLOT_API void PlotStems<T>(const char* label_id, const T* xs, const T* ys, int count, double ref, ImPlotStemsFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotStems2);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotInfLines
@@ -2233,17 +2131,8 @@ void PlotInfLines(const char* label_id, const T* values, int count, ImPlotInfLin
         }
     }
 }
-
-template IMPLOT_API void PlotInfLines<ImS8>(const char* label_id, const ImS8* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
-template IMPLOT_API void PlotInfLines<ImU8>(const char* label_id, const ImU8* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
-template IMPLOT_API void PlotInfLines<ImS16>(const char* label_id, const ImS16* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
-template IMPLOT_API void PlotInfLines<ImU16>(const char* label_id, const ImU16* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
-template IMPLOT_API void PlotInfLines<ImS32>(const char* label_id, const ImS32* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
-template IMPLOT_API void PlotInfLines<ImU32>(const char* label_id, const ImU32* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
-template IMPLOT_API void PlotInfLines<ImS64>(const char* label_id, const ImS64* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
-template IMPLOT_API void PlotInfLines<ImU64>(const char* label_id, const ImU64* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
-template IMPLOT_API void PlotInfLines<float>(const char* label_id, const float* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
-template IMPLOT_API void PlotInfLines<double>(const char* label_id, const double* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
+#define instantiate_PlotInfLines(T) template IMPLOT_API void PlotInfLines<T>(const char* label_id, const T* xs, int count, ImPlotInfLinesFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotInfLines);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotPieChart
@@ -2318,17 +2207,8 @@ void PlotPieChart(const char* const label_ids[], const T* values, int count, dou
     }
     PopPlotClipRect();
 }
-
-template IMPLOT_API void PlotPieChart<ImS8>(const char* const label_ids[], const ImS8* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
-template IMPLOT_API void PlotPieChart<ImU8>(const char* const label_ids[], const ImU8* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
-template IMPLOT_API void PlotPieChart<ImS16>(const char* const label_ids[], const ImS16* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
-template IMPLOT_API void PlotPieChart<ImU16>(const char* const label_ids[], const ImU16* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
-template IMPLOT_API void PlotPieChart<ImS32>(const char* const label_ids[], const ImS32* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
-template IMPLOT_API void PlotPieChart<ImU32>(const char* const label_ids[], const ImU32* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
-template IMPLOT_API void PlotPieChart<ImS64>(const char* const label_ids[], const ImS64* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
-template IMPLOT_API void PlotPieChart<ImU64>(const char* const label_ids[], const ImU64* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
-template IMPLOT_API void PlotPieChart<float>(const char* const label_ids[], const float* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
-template IMPLOT_API void PlotPieChart<double>(const char* const label_ids[], const double* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
+#define instantiate_PlotPieChart(T) template IMPLOT_API void PlotPieChart<T>(const char* const label_ids[], const T* values, int count, double x, double y, double radius, const char* fmt, double angle0, ImPlotPieChartFlags flags);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotPieChart);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotHeatmap
@@ -2483,17 +2363,8 @@ void PlotHeatmap(const char* label_id, const T* values, int rows, int cols, doub
         EndItem();
     }
 }
-
-template IMPLOT_API void PlotHeatmap<ImS8>(const char* label_id, const ImS8* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
-template IMPLOT_API void PlotHeatmap<ImU8>(const char* label_id, const ImU8* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
-template IMPLOT_API void PlotHeatmap<ImS16>(const char* label_id, const ImS16* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
-template IMPLOT_API void PlotHeatmap<ImU16>(const char* label_id, const ImU16* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
-template IMPLOT_API void PlotHeatmap<ImS32>(const char* label_id, const ImS32* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
-template IMPLOT_API void PlotHeatmap<ImU32>(const char* label_id, const ImU32* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
-template IMPLOT_API void PlotHeatmap<ImS64>(const char* label_id, const ImS64* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
-template IMPLOT_API void PlotHeatmap<ImU64>(const char* label_id, const ImU64* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
-template IMPLOT_API void PlotHeatmap<float>(const char* label_id, const float* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
-template IMPLOT_API void PlotHeatmap<double>(const char* label_id, const double* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
+#define instantiate_PlotHeatmap(T) template IMPLOT_API void PlotHeatmap<T>(const char* label_id, const T* values, int rows, int cols, double scale_min, double scale_max, const char* fmt, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, ImPlotHeatmapFlags flags);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotHeatmap);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotHistogram
@@ -2576,17 +2447,8 @@ double PlotHistogram(const char* label_id, const T* values, int count, int bins,
         PlotBars(label_id, &bin_centers.Data[0], &bin_counts.Data[0], bins, bar_scale*width);
     return max_count;
 }
-
-template IMPLOT_API double PlotHistogram<ImS8>(const char* label_id, const ImS8* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram<ImU8>(const char* label_id, const ImU8* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram<ImS16>(const char* label_id, const ImS16* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram<ImU16>(const char* label_id, const ImU16* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram<ImS32>(const char* label_id, const ImS32* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram<ImU32>(const char* label_id, const ImU32* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram<ImS64>(const char* label_id, const ImS64* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram<ImU64>(const char* label_id, const ImU64* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram<float>(const char* label_id, const float* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram<double>(const char* label_id, const double* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
+#define instantiate_PlotHistogram(T) template IMPLOT_API double PlotHistogram<T>(const char* label_id, const T* values, int count, int bins, double bar_scale, ImPlotRange range, ImPlotHistogramFlags flags);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotHistogram);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotHistogram2D
@@ -2661,17 +2523,8 @@ double PlotHistogram2D(const char* label_id, const T* xs, const T* ys, int count
     }
     return max_count;
 }
-
-template IMPLOT_API double PlotHistogram2D<ImS8>(const char* label_id,   const ImS8*   xs, const ImS8*   ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram2D<ImU8>(const char* label_id,   const ImU8*   xs, const ImU8*   ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram2D<ImS16>(const char* label_id,  const ImS16*  xs, const ImS16*  ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram2D<ImU16>(const char* label_id,  const ImU16*  xs, const ImU16*  ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram2D<ImS32>(const char* label_id,  const ImS32*  xs, const ImS32*  ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram2D<ImU32>(const char* label_id,  const ImU32*  xs, const ImU32*  ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram2D<ImS64>(const char* label_id,  const ImS64*  xs, const ImS64*  ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram2D<ImU64>(const char* label_id,  const ImU64*  xs, const ImU64*  ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram2D<float>(const char* label_id,  const float*  xs, const float*  ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
-template IMPLOT_API double PlotHistogram2D<double>(const char* label_id, const double* xs, const double* ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
+#define instantiate_PlotHistogram2D(T) template IMPLOT_API double PlotHistogram2D<T>(const char* label_id,   const T*   xs, const T*   ys, int count, int x_bins, int y_bins, ImPlotRect range, ImPlotHistogramFlags flags);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotHistogram2D);
 
 //-----------------------------------------------------------------------------
 // [SECTION] PlotDigital
@@ -2744,17 +2597,8 @@ void PlotDigital(const char* label_id, const T* xs, const T* ys, int count, ImPl
     GetterXY<IndexerIdx<T>,IndexerIdx<T>> getter(IndexerIdx<T>(xs,count,offset,stride),IndexerIdx<T>(ys,count,offset,stride),count);
     return PlotDigitalEx(label_id, getter, flags);
 }
-
-template IMPLOT_API void PlotDigital<ImS8>(const char* label_id, const ImS8* xs, const ImS8* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
-template IMPLOT_API void PlotDigital<ImU8>(const char* label_id, const ImU8* xs, const ImU8* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
-template IMPLOT_API void PlotDigital<ImS16>(const char* label_id, const ImS16* xs, const ImS16* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
-template IMPLOT_API void PlotDigital<ImU16>(const char* label_id, const ImU16* xs, const ImU16* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
-template IMPLOT_API void PlotDigital<ImS32>(const char* label_id, const ImS32* xs, const ImS32* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
-template IMPLOT_API void PlotDigital<ImU32>(const char* label_id, const ImU32* xs, const ImU32* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
-template IMPLOT_API void PlotDigital<ImS64>(const char* label_id, const ImS64* xs, const ImS64* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
-template IMPLOT_API void PlotDigital<ImU64>(const char* label_id, const ImU64* xs, const ImU64* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
-template IMPLOT_API void PlotDigital<float>(const char* label_id, const float* xs, const float* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
-template IMPLOT_API void PlotDigital<double>(const char* label_id, const double* xs, const double* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
+#define instantiate_PlotDigital(T) template IMPLOT_API void PlotDigital<T>(const char* label_id, const T* xs, const T* ys, int count, ImPlotDigitalFlags flags, int offset, int stride);
+INSTANTIATE_FOR_NUMERIC_TYPES(instantiate_PlotDigital);
 
 // custom
 void PlotDigitalG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotDigitalFlags flags) {


### PR DESCRIPTION
This fixes the issue [#319](https://github.com/epezent/implot/issues/379) which stated that long double are not supported. 

As a matter of fact, `long double` as well as `unsigned long` and `signed long` are not supported when using dynamic linking: see demo repository for a minimal reproduction here : https://github.com/pthom/tmp_implot_dyn

#### Commit details

There are two commits: 

- [the first commit](https://github.com/pthom/implot/commit/df1a5a2f7664226e32a53c4f0da8cbcf7a0d96ca) introduces a macro `INSTANTIATE_FOR_NUMERIC_TYPES` that reduces some boilerplate code around template instantiations. It provides a "setting" (`IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES`) in order to enable / disable the addition of "long double" & "signed/unsigned long". 
[All the CI tests](https://github.com/pthom/implot/actions/runs/3007725925) succeed.
The compilation time of implot_items.cpp went up from 3.2 seconds to 4 seconds

- [the second commit](https://github.com/pthom/implot/commit/47409a46d13df801cb1072454f154142364fb3be) disables this setting (and it can be activated by the user via the compil time define `IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES`)
[All the CI tests](https://github.com/pthom/implot/actions/runs/3007735577) succeed.

####  Notes about numeric types ~~synonyms~~ quasi-synonyms:

  On some platforms, "unsigned long" might be the same size as "unsigned long long", but it is nonetheless a separate type: see https://godbolt.org/z/1KWv5re7q (example with GCC 64 bits)

  On some other platforms, "long double" might be the same size as "double", but it is nonetheless a separate type: see https://godbolt.org/z/ae71P7rqG (example with MSVC 64 bits)

---

#### Context: 

I discovered this issue while creating python bindings for imgui and implot. Since numpy uses "long double" as the default float type, and "long" as the default integer type, python code like this would fail under linux 64 bits:

````python
xs = np.array((1, 2, 3, 4))
implot.PlotBars("Bars", xs)  # xs is of type "signed long"
```` 
 
For info, the bindings I'm developing are not ready for production (hopefuly they will soon).  However my intent is to write an automatic binding generation tool that takes great care in reproducing the layout and the documentation found in the library header files. See [implot.pyi](https://github.com/pthom/lg_imgui_bundle/blob/main/bindings/lg_imgui_bundle/implot.pyi#L1194) and [imgui.pyi](https://github.com/pthom/lg_imgui_bundle/blob/main/bindings/lg_imgui_bundle/imgui.pyi). For the gory details, the generated code automatically transcribes between a numpy ndarray and the corresponding C++ buffer, such as here for the [plot_line function](https://github.com/pthom/lg_imgui_bundle/blob/main/bindings/pybind_implot.cpp#L589)  
