### PR TITLE
Support custom numeric types

### DIFF
--- a/.github/CMakeLists.txt
+++ b/.github/CMakeLists.txt
@@ -2,8 +2,58 @@
 cmake_minimum_required(VERSION 3.0)
 project(implot)
 
+#
+# Global options
+#
+
 # Same as Dear ImGui
 set(CMAKE_CXX_STANDARD 11)
+
+# Arch option for linux
+if (NOT APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU" AND DEFINED GCC_ARCH)
+    if ("${GCC_ARCH}" MATCHES "Win32|x86|32")
+        add_compile_options(-m32)
+        add_link_options(-m32)
+    elseif ("${GCC_ARCH}" MATCHES "Win64|x64|64")
+        add_compile_options(-m64)
+        add_link_options(-m64)
+    endif ()
+endif ()
+
+# Arch option for Mac: arm64 for M1 or x86_64 for intel (32 bits build are deprecated on Mac)
+if(APPLE AND DEFINED OSX_ARCH)
+    if ("${OSX_ARCH}" MATCHES "x86_64")
+        set(CMAKE_OSX_ARCHITECTURES "x86_64")
+    elseif ("${OSX_ARCH}" MATCHES "arm64")
+        set(CMAKE_OSX_ARCHITECTURES "arm64")
+    else()
+        message(FATAL_ERROR "Unhandled OSX_ARCH=${OSX_ARCH}")
+    endif()
+endif()
+
+#
+# Dear ImGui library with no backend
+#
+
+set(imgui_sources
+    ../imgui/imconfig.h
+    ../imgui/imgui.cpp
+    ../imgui/imgui.h
+    ../imgui/imgui_demo.cpp
+    ../imgui/imgui_draw.cpp
+    ../imgui/imgui_internal.h
+    ../imgui/imgui_tables.cpp
+    ../imgui/imgui_widgets.cpp
+    ../imgui/imstb_rectpack.h
+    ../imgui/imstb_textedit.h
+    ../imgui/imstb_truetype.h
+    )
+add_library(imgui ${imgui_sources})
+target_include_directories(imgui PUBLIC ../imgui)
+
+#
+# ImPlot library
+#
 
 file(GLOB SOURCE_CODE ../implot*.*)
 add_library(implot STATIC ${SOURCE_CODE})
@@ -14,13 +64,33 @@ else()
     target_compile_options(implot PRIVATE -Wall -Werror -pedantic)
 endif()
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU" AND DEFINED GCC_ARCH)
-    if ("${GCC_ARCH}" MATCHES "Win32|x86|32")
-        target_compile_options(implot PRIVATE -m32)
-    elseif ("${GCC_ARCH}" MATCHES "Win64|x64|64")
-        target_compile_options(implot PRIVATE -m64)
-    endif ()
-endif ()
+target_include_directories(implot PUBLIC ${CMAKE_CURRENT_LIST_DIR}/..)
+target_link_libraries(implot PUBLIC imgui)
 
-target_include_directories(implot PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../imgui)
-target_compile_definitions(implot PRIVATE IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES=1)
+if (UNIX)
+    target_link_libraries(implot PUBLIC m stdc++)
+endif()
+
+# Switch between several sets of numeric types (by adding `-DIMPLOT_NUMERIC_SET=default|custom|all`)
+if (DEFINED IMPLOT_NUMERIC_SET)
+    if ("${IMPLOT_NUMERIC_SET}" STREQUAL "default")
+        message(STATUS "Compiling for default types")
+    elseif("${IMPLOT_NUMERIC_SET}" STREQUAL "custom")
+        message(STATUS "Compiling for custom types (float and double)")
+        target_compile_definitions(implot PRIVATE "IMPLOT_CUSTOM_NUMERIC_TYPES=(float)(double)")
+    elseif("${IMPLOT_NUMERIC_SET}" STREQUAL "all")
+        message(STATUS "Compiling for all types")
+        target_compile_definitions(implot PRIVATE "IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES=1")
+    else()
+        message(FATAL_ERROR "unhandled IMPLOT_NUMERIC_SET=${IMPLOT_NUMERIC_SET}")
+    endif()
+else()
+    # By default, the CI provides support for all known types
+    target_compile_definitions(implot PRIVATE IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES)
+endif()
+
+#
+# implot example binary application (with no backend)
+#
+add_executable(example_implot example_implot.cpp)
+target_link_libraries(example_implot PRIVATE implot)

--- a/.github/example_implot.cpp
+++ b/.github/example_implot.cpp
@@ -1,0 +1,55 @@
+// Sample app built with Dear ImGui and ImPlot
+// This app uses implot and imgui, but does not output to any backend! It only serves as a proof that an app can be built, linked, and run.
+
+#include "imgui.h"
+#include "implot.h"
+#include "stdio.h"
+
+int main(int, char**)
+{    
+    printf("sample_implot: start\n");
+
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImPlot::CreateContext();
+
+    // Additional imgui initialization needed when no backend is present
+    ImGui::GetIO().DisplaySize = ImVec2(400.f, 400.f);
+    ImGui::GetIO().Fonts->Build();
+
+    // Render 500 frames
+    for(int counter = 0; counter < 500; ++counter)
+    {
+        ImGui::NewFrame();
+
+        if (ImGui::Begin("Hello, world!"))
+        {
+            ImGui::Text("Hello again");
+
+            if (ImPlot::BeginPlot("My Plot"))
+            {
+                static double values[] = {1., 3., 5.};
+                ImPlot::PlotLine("Values", values, 3);
+                ImPlot::EndPlot();
+            }
+
+            #ifdef IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES
+            if (ImPlot::BeginPlot("My Plot (long double)"))
+            {
+                static long double values[] = {1., 3., 5.};
+                ImPlot::PlotLine("Values", values, 3);
+                ImPlot::EndPlot();
+            }
+            #endif
+
+            ImGui::End();
+        }
+
+        ImGui::Render();
+    }
+
+    ImPlot::DestroyContext();
+    ImGui::DestroyContext();
+    printf("sample_implot: end\n");
+    return 0;
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Build
         run: cmake --build cmake-build --parallel $(nproc)
 
+      - name: Run
+        run: |
+          file cmake-build/example_implot
+          cmake-build/example_implot
 
   MacOS:
     runs-on: macos-11
@@ -49,7 +53,42 @@ jobs:
           - debug
           - release
         arch:
-          - x86
+          - x86_64
+          - arm64
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/checkout@v3
+        with:
+          repository: ocornut/imgui
+          path: imgui
+
+      - name: Configure
+        shell: bash
+        run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DOSX_ARCH=${{ matrix.arch }} -B cmake-build -S .github
+
+      - name: Build
+        shell: bash
+        run: cmake --build cmake-build --parallel $(sysctl -n hw.ncpu)
+
+      - name: Run
+        if: matrix.arch == 'x86_64' # github's CI hosts seem to be running intel and can not run ARM
+        run: |
+          file cmake-build/example_implot
+          cmake-build/example_implot
+
+  Windows_MSVC:
+    runs-on: windows-2022
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type:
+          - debug
+          - release
+        arch:
+          - Win32
           - x64
 
     steps:
@@ -62,13 +101,16 @@ jobs:
 
       - name: Configure
         shell: bash
-        run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DGCC_ARCH=${{ matrix.arch }} -B cmake-build -S .github
+        run: cmake -G 'Visual Studio 17 2022' -A ${{ matrix.arch }} -B cmake-build -S .github
 
       - name: Build
         shell: bash
-        run: cmake --build cmake-build --parallel $(sysctl -n hw.ncpu)
+        run: cmake --build cmake-build -- -p:Configuration=${{ matrix.build_type }} -maxcpucount:$NUMBER_OF_PROCESSORS
 
-  Windows:
+      - name: Run
+        run: .\cmake-build\${{matrix.build_type}}\example_implot.exe
+
+  Windows_MingW: # MingW on Github CI does not fully support 32 bits: link fails when it tries to link 64 bits system libraries.
     runs-on: windows-2022
 
     strategy:
@@ -78,11 +120,8 @@ jobs:
           - debug
           - release
         arch:
-          - Win32
           - x64
-        compiler:
-          - msvc
-          - mingw
+          # - Win32
 
     steps:
       - uses: actions/checkout@v3
@@ -92,22 +131,14 @@ jobs:
           repository: ocornut/imgui
           path: imgui
 
-      - name: Configure (MSVC)
-        if: matrix.compiler == 'msvc'
-        shell: bash
-        run: cmake -G 'Visual Studio 17 2022' -A ${{ matrix.arch }} -B cmake-build -S .github
-
-      - name: Build (MSVC)
-        if: matrix.compiler == 'msvc'
-        shell: bash
-        run: cmake --build cmake-build -- -p:Configuration=${{ matrix.build_type }} -maxcpucount:$NUMBER_OF_PROCESSORS
-
-      - name: Configure (MingW)
-        if: matrix.compiler == 'mingw'
+      - name: Configure
         shell: bash
         run: cmake -G 'MinGW Makefiles' -DGCC_ARCH=${{ matrix.arch }} -B cmake-build -S .github
 
-      - name: Build (MingW)
-        if: matrix.compiler == 'mingw'
+      - name: Build
         shell: bash
         run: cmake --build cmake-build --parallel $NUMBER_OF_PROCESSORS
+
+      - name: Run (MingW)
+        run: .\cmake-build\example_implot.exe
+  

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ A: Yes, within reason. You can plot tens to hundreds of thousands of points with
 **Q: What data types can I plot?**
 
 A: ImPlot plotting functions accept most scalar types:
-`float`, `double`, `int8`, `uint8`, `int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`. Arrays of custom structs or classes (e.g. `Vector2f` or similar) are easily passed to ImPlot functions using the built-in striding features (see `implot.h` for documentation), and many plotters provide a "getter" overload which accepts data generating callbacks. Additional support for `long`, `unsigned long` and `long double` can be added by defining `IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES` at compile-time (see `implot_items.cpp`).
+`float`, `double`, `int8`, `uint8`, `int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`. Arrays of custom structs or classes (e.g. `Vector2f` or similar) are easily passed to ImPlot functions using the built-in striding features (see `implot.h` for documentation), and many plotters provide a "getter" overload which accepts data generating callbacks. Additional support for `long`, `unsigned long` and `long double` can be added by defining `IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES` at compile-time. Also, you can fully customize the list of accepted types: see doc in `implot_items.cpp`.
 
 **Q: Can plot styles be modified?**
 


### PR DESCRIPTION
This PR adds support for a custom list of supported types.

There are actually two commits. If required, the second could become a second PR. 

* 47909c04: implot_items.cpp: support types customization
  adds full types customization via `-DIMPLOT_CUSTOM_NUMERIC_TYPES="(float)(double)"` for example
* 874437f9: CI: link example app, with null backend
Github's CI will now compile ImGui, compile ImPlot, link and run an example application (with no backend). This serves as a proof that specific templates instantiations are actually compiled, and that link succeeds.
