### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ You should be good to go!
 
 If you want to test ImPlot quickly, consider trying [mahi-gui](https://github.com/mahilab/mahi-gui), which bundles ImGui, ImPlot, and several other packages for you.
 
+## Installing implot using vcpkg
+
+You can download and install implot using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install implot
+```
+
+The implot port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Extremely Important Note
 
 Dear ImGui uses **16-bit indexing by default**, so high-density ImPlot widgets like `ImPlot::PlotHeatmap()` may produce too many vertices into `ImDrawList`, which causes an assertion failure and will result in data truncation and/or visual glitches. Therefore, it is **HIGHLY** recommended that you EITHER:

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ You should be good to go!
 
 If you want to test ImPlot quickly, consider trying [mahi-gui](https://github.com/mahilab/mahi-gui), which bundles ImGui, ImPlot, and several other packages for you.
 
-## Installing implot using vcpkg
+## Installing ImPlot using vcpkg
 
-You can download and install implot using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+You can download and install ImPlot using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
 
 ```bash
 git clone https://github.com/Microsoft/vcpkg.git
@@ -107,7 +107,7 @@ cd vcpkg
 ./vcpkg install implot
 ```
 
-The implot port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+The ImPlot port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ## Extremely Important Note
 


### PR DESCRIPTION
`implot `is available as a port in vcpkg, a C++ library manager that simplifies installation for implot and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build implot, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/implot/portfile.cmake). We try to keep the library maintained as close as possible to the original library.