### PR TITLE
Remove support for IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES

### DIFF
--- a/.github/CMakeLists.txt
+++ b/.github/CMakeLists.txt
@@ -71,22 +71,21 @@ if (UNIX)
     target_link_libraries(implot PUBLIC m stdc++)
 endif()
 
-# Switch between several sets of numeric types (by adding `-DIMPLOT_NUMERIC_SET=default|custom|all`)
-if (DEFINED IMPLOT_NUMERIC_SET)
-    if ("${IMPLOT_NUMERIC_SET}" STREQUAL "default")
-        message(STATUS "Compiling for default types")
-    elseif("${IMPLOT_NUMERIC_SET}" STREQUAL "custom")
-        message(STATUS "Compiling for custom types (float and double)")
-        target_compile_definitions(implot PRIVATE "IMPLOT_CUSTOM_NUMERIC_TYPES=(float)(double)")
-    elseif("${IMPLOT_NUMERIC_SET}" STREQUAL "all")
-        message(STATUS "Compiling for all types")
-        target_compile_definitions(implot PRIVATE "IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES=1")
-    else()
-        message(FATAL_ERROR "unhandled IMPLOT_NUMERIC_SET=${IMPLOT_NUMERIC_SET}")
-    endif()
+# Define supported types via command line:
+#   - With no choice all types are supported (so that the CI provides support for all known types)
+#   - with -DIMPLOT_CUSTOM_NUMERIC_TYPES="default" the default set defined in implot_items.cpp is used
+#   - with -DIMPLOT_CUSTOM_NUMERIC_TYPES="(int)(float)(double)" only int, float and double are supported
+if (NOT DEFINED IMPLOT_CUSTOM_NUMERIC_TYPES)
+    set(IMPLOT_CUSTOM_NUMERIC_TYPES "all")
+endif()
+if ("${IMPLOT_CUSTOM_NUMERIC_TYPES}" STREQUAL "default")
+    message("==== Compiling for default types ====")
+elseif("${IMPLOT_CUSTOM_NUMERIC_TYPES}" STREQUAL "all")
+    message("==== Compiling for all types ====")
+    target_compile_definitions(implot PRIVATE "IMPLOT_CUSTOM_NUMERIC_TYPES=(signed char)(unsigned char)(signed short)(unsigned short)(signed int)(unsigned int)(signed long)(unsigned long)(signed long long)(unsigned long long)(float)(double)(long double)")
 else()
-    # By default, the CI provides support for all known types
-    target_compile_definitions(implot PRIVATE IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES)
+    message("==== Compiling for custom types: ${IMPLOT_CUSTOM_NUMERIC_TYPES} ====")
+    target_compile_definitions(implot PRIVATE "IMPLOT_CUSTOM_NUMERIC_TYPES=${IMPLOT_CUSTOM_NUMERIC_TYPES}")
 endif()
 
 #

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ A: Yes, within reason. You can plot tens to hundreds of thousands of points with
 **Q: What data types can I plot?**
 
 A: ImPlot plotting functions accept most scalar types:
-`float`, `double`, `int8`, `uint8`, `int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`. Arrays of custom structs or classes (e.g. `Vector2f` or similar) are easily passed to ImPlot functions using the built-in striding features (see `implot.h` for documentation), and many plotters provide a "getter" overload which accepts data generating callbacks. Additional support for `long`, `unsigned long` and `long double` can be added by defining `IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES` at compile-time. Also, you can fully customize the list of accepted types: see doc in `implot_items.cpp`.
+`float`, `double`, `int8`, `uint8`, `int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`. Arrays of custom structs or classes (e.g. `Vector2f` or similar) are easily passed to ImPlot functions using the built-in striding features (see `implot.h` for documentation), and many plotters provide a "getter" overload which accepts data generating callbacks. You can fully customize the list of accepted types by defining `IMPLOT_CUSTOM_NUMERIC_TYPES` at compile time: see doc in `implot_items.cpp`.
 
 **Q: Can plot styles be modified?**
 

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -83,13 +83,14 @@ static IMPLOT_INLINE float  ImInvSqrt(float x) { return 1.0f / sqrtf(x); }
 //
 // You can customize the supported types in two ways:
 // 1. Define IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES at compile time to add support for all known types.
-// 2. Or, define IMPLOT_CUSTOM_NUMERIC_TYPES at compile time to define your own type list. As an example, you could use the compile time define given by the line below in order to support only float and double.
+// 2. Or, define IMPLOT_CUSTOM_NUMERIC_TYPES at compile time to define your own type list. 
+//    As an example, you could use the compile time define given by the line below in order to support only float and double.
 //        -DIMPLOT_CUSTOM_NUMERIC_TYPES="(float)(double)"
+//    In order to support all known C++ types, use:
+//        -DIMPLOT_CUSTOM_NUMERIC_TYPES="(signed char)(unsigned char)(signed short)(unsigned short)(signed int)(unsigned int)(signed long)(unsigned long)(signed long long)(unsigned long long)(float)(double)(long double)"
 
 #ifdef IMPLOT_CUSTOM_NUMERIC_TYPES
     #define IMPLOT_NUMERIC_TYPES IMPLOT_CUSTOM_NUMERIC_TYPES
-#elif defined(IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES)
-    #define IMPLOT_NUMERIC_TYPES (signed char)(unsigned char)(signed short)(unsigned short)(signed int)(unsigned int)(signed long)(unsigned long)(signed long long)(unsigned long long)(float)(double)(long double)
 #else
     #define IMPLOT_NUMERIC_TYPES (ImS8)(ImU8)(ImS16)(ImU16)(ImS32)(ImU32)(ImS64)(ImU64)(float)(double)
 #endif


### PR DESCRIPTION
> My two cents: given full configurability (looks great!) i would suggest not adding “ IMPLOT_INSTANTIATE_ALL_NUMERIC_TYPES. For those rare types it seems reasonable to simply let the user express their needs explicitly.”

I do agree, and this PR removes them. 

--- 

> especially as it may be tempting for users and we don’t know what long double would carry in term of math runtimes. 

That is an interesting question! I made a quick study, and my findings are:

- the difference of speed between `float` and `double` can be as high as 20% (and the result do depend on the arch and compiler)
- when `double` and `long double` have the same size (8 bytes), `long double` is 20% to 30% slower (except on apple M1 processor)
- when `sizeof(long double) = 16` vs `sizeof(double) = 8`, long double can be 10 to 30 times slower (this depends on the compiler and platform)
--- 

> I haven’t poked in internals but wondered if small types <32 or <64 could somehow attempt to reuse larger types functions, with special adapters? Intuitively it seems like u8 u16 could use the code for u64. This is implying that generated code size and link size could be reduced. With custom type list this is now perhaps a little harder to setup, so perhaps it would need an hardcoded proof of concept because getting it to work with custom type lists.

There is perhaps a solution, but I suspect it would be very likely be "platform / compiler / arch / type" specific and maybe difficult to maintain. 

In the case of unsigned integers, a possible solution would be to:
- implement only the full code for the u64 version
- have a template function for u8, u16, u32 that would call the u64 version by first reading elements as u64.
- have a way to read u64 values inside a u8, u16 or u32 array. A possible solution would be to set  `u64 value = 0;`, then fill the right portion of `value`'s bytes with the bytes from the array

However, based on my observations, the memory layout for a 64 bits int (on a Mac M1) is a mix of:
- little-endian (for bits)
- big-endian (between bytes)
- big-endian (between groups of 4 bytes)
And I suspect that this is very much platform dependent.

Example, if I set 
`int64_t v64 = 0x123456789ABCDE00;` 
and examine the memory at &v64, it looks like this on my Mac:
````
    00 de bc 9a   78 56 34 12
````
