### PR TITLE
Fixes for ImGuiModFlags_XXX -> ImGuiMod_XXX (v1.89) (#347)

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -4635,32 +4635,32 @@ ImPlotInputMap& GetInputMap() {
 void MapInputDefault(ImPlotInputMap* dst) {
     ImPlotInputMap& map = dst ? *dst : GetInputMap();
     map.Pan             = ImGuiMouseButton_Left;
-    map.PanMod          = ImGuiModFlags_None;
+    map.PanMod          = ImGuiMod_None;
     map.Fit             = ImGuiMouseButton_Left;
     map.Menu            = ImGuiMouseButton_Right;
     map.Select          = ImGuiMouseButton_Right;
-    map.SelectMod       = ImGuiModFlags_None;
+    map.SelectMod       = ImGuiMod_None;
     map.SelectCancel    = ImGuiMouseButton_Left;
-    map.SelectHorzMod   = ImGuiModFlags_Alt;
-    map.SelectVertMod   = ImGuiModFlags_Shift;
-    map.OverrideMod     = ImGuiModFlags_Ctrl;
-    map.ZoomMod         = ImGuiModFlags_None;
+    map.SelectHorzMod   = ImGuiMod_Alt;
+    map.SelectVertMod   = ImGuiMod_Shift;
+    map.OverrideMod     = ImGuiMod_Ctrl;
+    map.ZoomMod         = ImGuiMod_None;
     map.ZoomRate        = 0.1f;
 }
 
 void MapInputReverse(ImPlotInputMap* dst) {
     ImPlotInputMap& map = dst ? *dst : GetInputMap();
     map.Pan             = ImGuiMouseButton_Right;
-    map.PanMod          = ImGuiModFlags_None;
+    map.PanMod          = ImGuiMod_None;
     map.Fit             = ImGuiMouseButton_Left;
     map.Menu            = ImGuiMouseButton_Right;
     map.Select          = ImGuiMouseButton_Left;
-    map.SelectMod       = ImGuiModFlags_None;
+    map.SelectMod       = ImGuiMod_None;
     map.SelectCancel    = ImGuiMouseButton_Right;
-    map.SelectHorzMod   = ImGuiModFlags_Alt;
-    map.SelectVertMod   = ImGuiModFlags_Shift;
-    map.OverrideMod     = ImGuiModFlags_Ctrl;
-    map.ZoomMod         = ImGuiModFlags_None;
+    map.SelectHorzMod   = ImGuiMod_Alt;
+    map.SelectVertMod   = ImGuiMod_Shift;
+    map.OverrideMod     = ImGuiMod_Ctrl;
+    map.ZoomMod         = ImGuiMod_None;
     map.ZoomRate        = 0.1f;
 }
 

--- a/implot.h
+++ b/implot.h
@@ -543,28 +543,34 @@ struct ImPlotStyle {
     IMPLOT_API ImPlotStyle();
 };
 
+// Support for legacy versions
 #if (IMGUI_VERSION_NUM < 18716) // Renamed in 1.88
-#define ImGuiModFlags       ImGuiKeyModFlags
-#define ImGuiModFlags_None  ImGuiKeyModFlags_None
-#define ImGuiModFlags_Ctrl  ImGuiKeyModFlags_Ctrl
-#define ImGuiModFlags_Shift ImGuiKeyModFlags_Shift
-#define ImGuiModFlags_Alt   ImGuiKeyModFlags_Alt
-#define ImGuiModFlags_Super ImGuiKeyModFlags_Super
+#define ImGuiMod_None       0
+#define ImGuiMod_Ctrl       ImGuiKeyModFlags_Ctrl
+#define ImGuiMod_Shift      ImGuiKeyModFlags_Shift
+#define ImGuiMod_Alt        ImGuiKeyModFlags_Alt
+#define ImGuiMod_Super      ImGuiKeyModFlags_Super
+#elif (IMGUI_VERSION_NUM < 18823) // Renamed in 1.89, sorry
+#define ImGuiMod_None       0
+#define ImGuiMod_Ctrl       ImGuiModFlags_Ctrl
+#define ImGuiMod_Shift      ImGuiModFlags_Shift
+#define ImGuiMod_Alt        ImGuiModFlags_Alt
+#define ImGuiMod_Super      ImGuiModFlags_Super
 #endif
 
 // Input mapping structure. Default values listed. See also MapInputDefault, MapInputReverse.
 struct ImPlotInputMap {
     ImGuiMouseButton Pan;           // LMB    enables panning when held,
-    ImGuiModFlags    PanMod;        // none   optional modifier that must be held for panning/fitting
+    int              PanMod;        // none   optional modifier that must be held for panning/fitting
     ImGuiMouseButton Fit;           // LMB    initiates fit when double clicked
     ImGuiMouseButton Select;        // RMB    begins box selection when pressed and confirms selection when released
     ImGuiMouseButton SelectCancel;  // LMB    cancels active box selection when pressed; cannot be same as Select
-    ImGuiModFlags    SelectMod;     // none   optional modifier that must be held for box selection
-    ImGuiModFlags    SelectHorzMod; // Alt    expands active box selection horizontally to plot edge when held
-    ImGuiModFlags    SelectVertMod; // Shift  expands active box selection vertically to plot edge when held
+    int              SelectMod;     // none   optional modifier that must be held for box selection
+    int              SelectHorzMod; // Alt    expands active box selection horizontally to plot edge when held
+    int              SelectVertMod; // Shift  expands active box selection vertically to plot edge when held
     ImGuiMouseButton Menu;          // RMB    opens context menus (if enabled) when clicked
-    ImGuiModFlags    OverrideMod;   // Ctrl   when held, all input is ignored; used to enable axis/plots as DND sources
-    ImGuiModFlags    ZoomMod;       // none   optional modifier that must be held for scroll wheel zooming
+    int              OverrideMod;   // Ctrl   when held, all input is ignored; used to enable axis/plots as DND sources
+    int              ZoomMod;       // none   optional modifier that must be held for scroll wheel zooming
     float            ZoomRate;      // 0.1f   zoom rate for scroll (e.g. 0.1f = 10% plot range every scroll click); make negative to invert
     IMPLOT_API ImPlotInputMap();
 };
@@ -1023,7 +1029,7 @@ IMPLOT_API bool BeginDragDropTargetLegend();
 IMPLOT_API void EndDragDropTarget();
 
 // NB: By default, plot and axes drag and drop *sources* require holding the Ctrl modifier to initiate the drag.
-// You can change the modifier if desired. If ImGuiModFlags_None is provided, the axes will be locked from panning.
+// You can change the modifier if desired. If ImGuiMod_None is provided, the axes will be locked from panning.
 
 // Turns the current plot's plotting area into a drag and drop source. You must hold Ctrl. Don't forget to call EndDragDropSource!
 IMPLOT_API bool BeginDragDropSourcePlot(ImGuiDragDropFlags flags=0);

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -221,16 +221,16 @@ void ButtonSelector(const char* label, ImGuiMouseButton* b) {
     ImGui::PopID();
 }
 
-void ModSelector(const char* label, ImGuiModFlags* k) {
+void ModSelector(const char* label, int* k) {
     ImGui::PushID(label);
-    ImGui::CheckboxFlags("Ctrl", (unsigned int*)k, ImGuiModFlags_Ctrl); ImGui::SameLine();
-    ImGui::CheckboxFlags("Shift", (unsigned int*)k, ImGuiModFlags_Shift); ImGui::SameLine();
-    ImGui::CheckboxFlags("Alt", (unsigned int*)k, ImGuiModFlags_Alt); ImGui::SameLine();
-    ImGui::CheckboxFlags("Super", (unsigned int*)k, ImGuiModFlags_Super);
+    ImGui::CheckboxFlags("Ctrl", (unsigned int*)k, ImGuiMod_Ctrl); ImGui::SameLine();
+    ImGui::CheckboxFlags("Shift", (unsigned int*)k, ImGuiMod_Shift); ImGui::SameLine();
+    ImGui::CheckboxFlags("Alt", (unsigned int*)k, ImGuiMod_Alt); ImGui::SameLine();
+    ImGui::CheckboxFlags("Super", (unsigned int*)k, ImGuiMod_Super);
     ImGui::PopID();
 }
 
-void InputMapping(const char* label, ImGuiMouseButton* b, ImGuiModFlags* k) {
+void InputMapping(const char* label, ImGuiMouseButton* b, int* k) {
     ImGui::LabelText("##","%s",label);
     if (b != NULL) {
         ImGui::SameLine(100);


### PR DESCRIPTION
This is a followup to #347 and an update following this change in core lib:
https://github.com/ocornut/imgui/commit/fd408c97904fbf9f3b4c786318e8389de11bc681

Like with #347 this is only required for users building with `IMGUI_DISABLE_OBSOLETE_FUNCTIONS` + aiming to support a few older versions.

----

If you don't mind raising minimum imgui version to latest, you can start taking advantage of the fact that ImGuiMod_XXX values can be safely or-ed with an ImGuiKey, so stuff like:

```
ImGuiMouseButton Pan;           // LMB    enables panning when held,
ImGuiModFlags    PanMod;        // none   optional modifier that must be held for panning/fitting
```

Could become:
```
ImGuiKeyChord Pan;    // == ImGuiKey_MouseLeft | ImGuiMod_Ctrl
```
(adding Ctrl for the example but PanMod default to None).

I would however suggest not making those changes yet, wait until at least 1.89 releases.