### PR TITLE
Small Pie Chart enhancements

### DIFF
--- a/implot.h
+++ b/implot.h
@@ -287,8 +287,9 @@ enum ImPlotInfLinesFlags_ {
 
 // Flags for PlotPieChart
 enum ImPlotPieChartFlags_ {
-    ImPlotPieChartFlags_None      = 0,      // default
-    ImPlotPieChartFlags_Normalize = 1 << 10 // force normalization of pie chart values (i.e. always make a full circle if sum < 0)
+    ImPlotPieChartFlags_None         = 0,       // default
+    ImPlotPieChartFlags_Normalize    = 1 << 10, // force normalization of pie chart values (i.e. always make a full circle if sum < 0)
+    ImPlotPieChartFlags_IgnoreHidden = 1 << 11  // ignore hidden slices when drawing the pie chart (as if they were not there)
 };
 
 // Flags for PlotHeatmap
@@ -891,6 +892,7 @@ IMPLOT_TMP void PlotStems(const char* label_id, const T* xs, const T* ys, int co
 IMPLOT_TMP void PlotInfLines(const char* label_id, const T* values, int count, ImPlotInfLinesFlags flags=0, int offset=0, int stride=sizeof(T));
 
 // Plots a pie chart. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
+IMPLOT_TMP void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, ImPlotFormatter fmt, void* fmt_data=NULL, double angle0=90, ImPlotPieChartFlags flags=0);
 IMPLOT_TMP void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, const char* label_fmt="%.1f", double angle0=90, ImPlotPieChartFlags flags=0);
 
 // Plots a 2D heatmap chart. Values are expected to be in row-major order by default. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -610,10 +610,8 @@ void Demo_PieCharts() {
     static ImPlotPieChartFlags flags = 0;
     ImGui::SetNextItemWidth(250);
     ImGui::DragFloat4("Values", data1, 0.01f, 0, 1);
-    if ((data1[0] + data1[1] + data1[2] + data1[3]) < 1) {
-        ImGui::SameLine();
-        CHECKBOX_FLAG(flags,ImPlotPieChartFlags_Normalize);
-    }
+    CHECKBOX_FLAG(flags, ImPlotPieChartFlags_Normalize);
+    CHECKBOX_FLAG(flags, ImPlotPieChartFlags_IgnoreHidden);
 
     if (ImPlot::BeginPlot("##Pie1", ImVec2(250,250), ImPlotFlags_Equal | ImPlotFlags_NoMouseText)) {
         ImPlot::SetupAxes(NULL, NULL, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations);


### PR DESCRIPTION
- Added `ImPlotPieChartFlags_IgnoreHidden` flag
- Added `PlotPieChart` overload that accepts an `ImPlotFormatter`.

I especially needed the `IgnoreHidden` feature for my use case, so I figured why not share them. Let me know what you think.

![piechartenhance](https://user-images.githubusercontent.com/8263806/195114339-bb4eeb26-8fe1-44f5-adbc-481e03e1aee0.jpg)
