### PR TITLE
implot: enable framed annotations

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -2853,9 +2853,15 @@ void EndPlot() {
                     min_len = len;
                 }
             }
-            DrawList.AddLine(an.Pos, corners[min_corner], an.ColorBg);
+            if (an.ColorBg == 0)
+              DrawList.AddLine(an.Pos, corners[min_corner], an.ColorFg * .8);
+            else
+              DrawList.AddLine(an.Pos, corners[min_corner], an.ColorBg);
         }
-        DrawList.AddRectFilled(rect.Min, rect.Max, an.ColorBg);
+        if (an.ColorBg == 0)
+          DrawList.AddRect(rect.Min, rect.Max, an.ColorFg * .6);
+        else
+          DrawList.AddRectFilled(rect.Min, rect.Max, an.ColorBg);
         DrawList.AddText(pos + gp.Style.AnnotationPadding, an.ColorFg, txt);
     }
 


### PR DESCRIPTION
Render frame around annotation box when its background color is set to 0. Frame's color is chosen to be 60% of foreground color and background is transparent.

P.S. You're welcome to decide better color values however ;)

![image](https://user-images.githubusercontent.com/2125293/198894547-3eefb3a7-9cea-41d2-8116-3f8d17097ea5.png)
