### PR TITLE
Fixes for requirement to define IMGUI_DEFINE_MATH_OPERATORS before imgui.h

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -122,6 +122,7 @@ You can read releases logs https://github.com/epezent/implot/releases for more d
 
 */
 
+#define IMGUI_DEFINE_MATH_OPERATORS
 #include "implot.h"
 #include "implot_internal.h"
 

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -31,10 +31,6 @@
 
 #pragma once
 
-#ifndef IMGUI_DEFINE_MATH_OPERATORS
-#define IMGUI_DEFINE_MATH_OPERATORS
-#endif
-
 #include <time.h>
 #include "imgui_internal.h"
 

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -22,6 +22,7 @@
 
 // ImPlot v0.14
 
+#define IMGUI_DEFINE_MATH_OPERATORS
 #include "implot.h"
 #include "implot_internal.h"
 
@@ -81,7 +82,7 @@ static IMPLOT_INLINE float  ImInvSqrt(float x) { return 1.0f / sqrtf(x); }
 //     unsigned long long  ImU64;  // 64-bit unsigned integer
 // (note: this list does *not* include `long`, `unsigned long` and `long double`)
 //
-// You can customize the supported types by defining IMPLOT_CUSTOM_NUMERIC_TYPES at compile time to define your own type list. 
+// You can customize the supported types by defining IMPLOT_CUSTOM_NUMERIC_TYPES at compile time to define your own type list.
 //    As an example, you could use the compile time define given by the line below in order to support only float and double.
 //        -DIMPLOT_CUSTOM_NUMERIC_TYPES="(float)(double)"
 //    In order to support all known C++ types, use:


### PR DESCRIPTION
Changed by
https://github.com/ocornut/imgui/commit/a1b8457cb5c9238f47fc7616e84c0775412ce556

The implot side fix should work with older imgui version, unless someone includes implot_internal.h directly without having the math operators defined (which I presume will be rare and easy to discover and fix).