### PR TITLE
Make ImPlotPoint equal compatible

### DIFF
--- a/implot.h
+++ b/implot.h
@@ -466,11 +466,12 @@ enum ImPlotBin_ {
 // Double precision version of ImVec2 used by ImPlot. Extensible by end users.
 struct ImPlotPoint {
     double x, y;
-    ImPlotPoint()                         { x = y = 0.0;      }
-    ImPlotPoint(double _x, double _y)     { x = _x; y = _y;   }
-    ImPlotPoint(const ImVec2& p)          { x = p.x; y = p.y; }
-    double  operator[] (size_t idx) const { return (&x)[idx]; }
-    double& operator[] (size_t idx)       { return (&x)[idx]; }
+    ImPlotPoint()                                   { x = y = 0.0;                         }
+    ImPlotPoint(double _x, double _y)               { x = _x; y = _y;                      }
+    ImPlotPoint(const ImVec2& p)                    { x = p.x; y = p.y;                    }
+    double  operator[] (size_t idx) const           { return (&x)[idx];                    }
+    double& operator[] (size_t idx)                 { return (&x)[idx];                    }
+    bool operator==(const ImPlotPoint& point) const { return x == point.x && y == point.y; }
 #ifdef IMPLOT_POINT_CLASS_EXTRA
     IMPLOT_POINT_CLASS_EXTRA     // Define additional constructors and implicit cast operators in imconfig.h
                                  // to convert back and forth between your math types and ImPlotPoint.


### PR DESCRIPTION
## Problem
Once I wanted to `find_erase()`  from `ImVector<ImPlotPoint>` but then I got this:

Severity |	Code |	Description
-------- | ----------- | ------------
Error  |	C2676  |	binary '==': 'T' does not define this operator or a conversion to a type acceptable to the predefined


## Solution
Implement `bool operator==` by comparing equality of coordinates values

---

There are probably a lot more improvements `ImPlotPoint` needs to have, but I found just this use-case so far (implot is the great library, thank you)