### PR TITLE
Use `%g` for the min/max sliders in the plot axis context menu

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -1296,12 +1296,12 @@ bool DragFloat(const char*, F*, float, F, F) {
 
 template <>
 bool DragFloat<double>(const char* label, double* v, float v_speed, double v_min, double v_max) {
-    return ImGui::DragScalar(label, ImGuiDataType_Double, v, v_speed, &v_min, &v_max, "%.3f", 1);
+    return ImGui::DragScalar(label, ImGuiDataType_Double, v, v_speed, &v_min, &v_max, "%.3g", 1);
 }
 
 template <>
 bool DragFloat<float>(const char* label, float* v, float v_speed, float v_min, float v_max) {
-    return ImGui::DragScalar(label, ImGuiDataType_Float, v, v_speed, &v_min, &v_max, "%.3f", 1);
+    return ImGui::DragScalar(label, ImGuiDataType_Float, v, v_speed, &v_min, &v_max, "%.3g", 1);
 }
 
 inline void BeginDisabledControls(bool cond) {


### PR DESCRIPTION
Hi,

The custom `ImGui::DragScalar` widgets used to set the min/max axis limits from the right-click context menu use a simple `%.3f` format specifier. This works well for large scales but as soon as you're plotting data in the range below `1e-3` these widgets display `0.000` but otherwise work as expected. Another problem is that large values, e.g. `5.9e9`, overflow the bounding box when they are rendered.

I changed the format specifier to `%.3g` for a practical compromise. Would that be all right to merge?