### PR TITLE
Ability to treat point, line and rect drags as clicks

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -3914,15 +3914,19 @@ bool DragPoint(int n_id, double* x, double* y, const ImVec4& col, float radius, 
     const ImGuiID id = ImGui::GetCurrentWindow()->GetID(n_id);
     ImRect rect(pos.x-grab_half_size,pos.y-grab_half_size,pos.x+grab_half_size,pos.y+grab_half_size);
     bool hovered = false, held = false;
+    bool clicked = false;
 
     ImGui::KeepAliveID(id);
     if (input)
-        ImGui::ButtonBehavior(rect,id,&hovered,&held);
+        clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
 
     bool dragging = false;
     if (held && ImGui::IsMouseDragging(0)) {
         *x = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).x;
         *y = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).y;
+        dragging = true;
+    }
+    if (clicked && ImHasFlag(flags, ImPlotDragToolFlags_ClickIsDrag)) {
         dragging = true;
     }
 
@@ -3959,10 +3963,11 @@ bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     const ImGuiID id = ImGui::GetCurrentWindow()->GetID(n_id);
     ImRect rect(x-grab_half_size,yt,x+grab_half_size,yb);
     bool hovered = false, held = false;
+    bool clicked = false;
 
     ImGui::KeepAliveID(id);
     if (input)
-        ImGui::ButtonBehavior(rect,id,&hovered,&held);
+        clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
 
     if ((hovered || held) && show_curs)
         ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
@@ -3974,6 +3979,9 @@ bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     bool dragging = false;
     if (held && ImGui::IsMouseDragging(0)) {
         *value = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).x;
+        dragging = true;
+    }
+    if (clicked && ImHasFlag(flags, ImPlotDragToolFlags_ClickIsDrag)) {
         dragging = true;
     }
 
@@ -4011,10 +4019,11 @@ bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     const ImGuiID id = ImGui::GetCurrentWindow()->GetID(n_id);
     ImRect rect(xl,y-grab_half_size,xr,y+grab_half_size);
     bool hovered = false, held = false;
+    bool clicked = false;
 
     ImGui::KeepAliveID(id);
     if (input)
-        ImGui::ButtonBehavior(rect,id,&hovered,&held);
+        clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
 
     if ((hovered || held) && show_curs)
         ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
@@ -4026,6 +4035,9 @@ bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     bool dragging = false;
     if (held && ImGui::IsMouseDragging(0)) {
         *value = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).y;
+        dragging = true;
+    }
+    if (clicked && ImHasFlag(flags, ImPlotDragToolFlags_ClickIsDrag)) {
         dragging = true;
     }
 
@@ -4081,11 +4093,12 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
 
     bool dragging = false;
     bool hovered = false, held = false;
+    bool clicked = false;
     ImRect b_rect(pc.x-DRAG_GRAB_HALF_SIZE,pc.y-DRAG_GRAB_HALF_SIZE,pc.x+DRAG_GRAB_HALF_SIZE,pc.y+DRAG_GRAB_HALF_SIZE);
 
     ImGui::KeepAliveID(id);
     if (input)
-        ImGui::ButtonBehavior(b_rect,id,&hovered,&held);
+        clicked = ImGui::ButtonBehavior(b_rect,id,&hovered,&held);
 
     if ((hovered || held) && show_curs)
         ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeAll);
@@ -4095,6 +4108,9 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
             *y[i] = pp.y;
             *x[i] = pp.x;
         }
+        dragging = true;
+    }
+    if (clicked && ImHasFlag(flags, ImPlotDragToolFlags_ClickIsDrag)) {
         dragging = true;
     }
 

--- a/implot.h
+++ b/implot.h
@@ -208,7 +208,7 @@ enum ImPlotDragToolFlags_ {
     ImPlotDragToolFlags_NoFit     = 1 << 1, // the drag tool won't be considered for plot fits
     ImPlotDragToolFlags_NoInputs  = 1 << 2, // lock the tool from user inputs
     ImPlotDragToolFlags_Delayed   = 1 << 3, // tool rendering will be delayed one frame; useful when applying position-constraints
-    ImPlotDragToolFlags_ClickIsDrag = 1 << 4, // click is considered as dragging
+    ImPlotDragToolFlags_ClickIsDrag = 1 << 4, // click is treated same as dragging
 };
 
 // Flags for ColormapScale

--- a/implot.h
+++ b/implot.h
@@ -208,6 +208,7 @@ enum ImPlotDragToolFlags_ {
     ImPlotDragToolFlags_NoFit     = 1 << 1, // the drag tool won't be considered for plot fits
     ImPlotDragToolFlags_NoInputs  = 1 << 2, // lock the tool from user inputs
     ImPlotDragToolFlags_Delayed   = 1 << 3, // tool rendering will be delayed one frame; useful when applying position-constraints
+    ImPlotDragToolFlags_ClickIsDrag = 1 << 4, // click is considered as dragging
 };
 
 // Flags for ColormapScale


### PR DESCRIPTION
Currently it is not possible to know if draggable point was clicked.  `ImPlot::DragPoint` returns true only when point was dragged few pixels.
This is needed for example for the ability to remove existing points on Ctrl+clicks.

I've added new flag `ImPlotDragToolFlags_::ImPlotDragToolFlags_ClickIsDrag`.
If this flag is set `ImPlot::Drag..` functions will return true when element is clicked.

This is achieved by using return result of `ImGui::ButtonBehavior` function.

Hope this patch will be useful. 

If there is better way to detect clicks on draggable points please let me know.

Example code:
```cpp
if (ImPlot::DragPoint(id, &x, &y, ImVec4(1, 0, 1, 1), 4.0f, ImPlotDragToolFlags_ClickIsDrag)) {
    if (ImGui::GetIO().KeyCtrl) {
        // remove point
    }
}
```

https://github.com/epezent/implot/assets/1259724/4bd38a4f-2c81-4969-8e06-bfe426cb71ff


