### PR TITLE
Ability to query point, line and rect drags for their click, hovered and held states

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -4170,9 +4170,11 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
 
     const bool mouse_inside = rect_grab.Contains(ImGui::GetMousePos());
     const bool mouse_clicked = ImGui::IsMouseClicked(0);
+    const bool mouse_down = ImGui::IsMouseDown(0);
     if (input && mouse_inside) {
         if (out_clicked) *out_clicked = *out_clicked || mouse_clicked;
-        if (out_hovered) *out_hovered = true;        
+        if (out_hovered) *out_hovered = true;
+        if (out_held)    *out_held    = *out_held    || mouse_down;
     }
 
     PushPlotClipRect();

--- a/implot.cpp
+++ b/implot.cpp
@@ -3894,7 +3894,7 @@ IMPLOT_API void TagYV(double y, const ImVec4& color, const char* fmt, va_list ar
 
 static const float DRAG_GRAB_HALF_SIZE = 4.0f;
 
-bool DragPoint(int n_id, double* x, double* y, const ImVec4& col, float radius, ImPlotDragToolFlags flags, bool* is_clicked, bool* is_hovered, bool* is_held) {
+bool DragPoint(int n_id, double* x, double* y, const ImVec4& col, float radius, ImPlotDragToolFlags flags, bool* out_clicked, bool* out_hovered, bool* out_held) {
     ImGui::PushID("#IMPLOT_DRAG_POINT");
     IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != nullptr, "DragPoint() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
@@ -3918,12 +3918,12 @@ bool DragPoint(int n_id, double* x, double* y, const ImVec4& col, float radius, 
     ImGui::KeepAliveID(id);
     if (input) {
         bool clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
-        if (is_clicked)
-            *is_clicked = clicked;
-        if (is_hovered)
-            *is_hovered = hovered;
-        if (is_held)
-            *is_held = held;
+        if (out_clicked)
+            *out_clicked = clicked;
+        if (out_hovered)
+            *out_hovered = hovered;
+        if (out_held)
+            *out_held = held;
     }
 
     bool dragging = false;
@@ -3946,7 +3946,7 @@ bool DragPoint(int n_id, double* x, double* y, const ImVec4& col, float radius, 
     return dragging;
 }
 
-bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags, bool* is_clicked, bool* is_hovered, bool* is_held) {
+bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags, bool* out_clicked, bool* out_hovered, bool* out_held) {
     // ImGui::PushID("#IMPLOT_DRAG_LINE_X");
     ImPlotContext& gp = *GImPlot;
     IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "DragLineX() needs to be called between BeginPlot() and EndPlot()!");
@@ -3970,12 +3970,12 @@ bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     ImGui::KeepAliveID(id);
     if (input) {
         bool clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
-        if (is_clicked)
-            *is_clicked = clicked;
-        if (is_hovered)
-            *is_hovered = hovered;
-        if (is_held)
-            *is_held = held;
+        if (out_clicked)
+            *out_clicked = clicked;
+        if (out_hovered)
+            *out_hovered = hovered;
+        if (out_held)
+            *out_held = held;
     }
 
     if ((hovered || held) && show_curs)
@@ -4004,7 +4004,7 @@ bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     return dragging;
 }
 
-bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags, bool* is_clicked, bool* is_hovered, bool* is_held) {
+bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags, bool* out_clicked, bool* out_hovered, bool* out_held) {
     ImGui::PushID("#IMPLOT_DRAG_LINE_Y");
     ImPlotContext& gp = *GImPlot;
     IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "DragLineY() needs to be called between BeginPlot() and EndPlot()!");
@@ -4029,12 +4029,12 @@ bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     ImGui::KeepAliveID(id);
     if (input) {
         bool clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
-        if (is_clicked)
-            *is_clicked = clicked;
-        if (is_hovered)
-            *is_hovered = hovered;
-        if (is_held)
-            *is_held = held;
+        if (out_clicked)
+            *out_clicked = clicked;
+        if (out_hovered)
+            *out_hovered = hovered;
+        if (out_held)
+            *out_held = held;
     }
 
     if ((hovered || held) && show_curs)
@@ -4063,7 +4063,7 @@ bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     return dragging;
 }
 
-bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_max, const ImVec4& col, ImPlotDragToolFlags flags, bool* is_clicked, bool* is_hovered, bool* is_held) {
+bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_max, const ImVec4& col, ImPlotDragToolFlags flags, bool* out_clicked, bool* out_hovered, bool* out_held) {
     ImGui::PushID("#IMPLOT_DRAG_RECT");
     IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != nullptr, "DragRect() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
@@ -4106,13 +4106,8 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
 
     ImGui::KeepAliveID(id);
     if (input) {
-        bool clicked = ImGui::ButtonBehavior(b_rect,id,&hovered,&held);
-        if (is_clicked)
-            *is_clicked = clicked;
-        if (is_hovered)
-            *is_hovered = hovered;
-        if (is_held)
-            *is_held = held;
+        // middle point
+        ImGui::ButtonBehavior(b_rect,id,&hovered,&held); 
     }
 
     if ((hovered || held) && show_curs)
@@ -4171,6 +4166,20 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
         }
     }
 
+    if (input) {
+        // Entire rectangle
+        ImGuiID r_id = id + 5;
+        ImGui::KeepAliveID(r_id);
+        bool is_hovered = false;
+        bool is_held = false;
+        bool is_clicked = ImGui::ButtonBehavior(rect, r_id, &is_hovered, &is_held);
+        if (out_clicked)
+            *out_clicked = is_clicked;
+        if (out_hovered)
+            *out_hovered = is_hovered;
+        if (out_held)
+            *out_held = is_held;
+    }
 
     PushPlotClipRect();
     ImDrawList& DrawList = *GetPlotDrawList();
@@ -4192,8 +4201,8 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
     return dragging;
 }
 
-bool DragRect(int id, ImPlotRect* bounds, const ImVec4& col, ImPlotDragToolFlags flags, bool* is_clicked, bool* is_hovered, bool* is_held) {
-    return DragRect(id, &bounds->X.Min, &bounds->Y.Min,&bounds->X.Max, &bounds->Y.Max, col, flags, is_clicked, is_hovered, is_held);
+bool DragRect(int id, ImPlotRect* bounds, const ImVec4& col, ImPlotDragToolFlags flags, bool* out_clicked, bool* out_hovered, bool* out_held) {
+    return DragRect(id, &bounds->X.Min, &bounds->Y.Min,&bounds->X.Max, &bounds->Y.Max, col, flags, out_clicked, out_hovered, out_held);
 }
 
 //-----------------------------------------------------------------------------

--- a/implot.cpp
+++ b/implot.cpp
@@ -3894,7 +3894,7 @@ IMPLOT_API void TagYV(double y, const ImVec4& color, const char* fmt, va_list ar
 
 static const float DRAG_GRAB_HALF_SIZE = 4.0f;
 
-bool DragPoint(int n_id, double* x, double* y, const ImVec4& col, float radius, ImPlotDragToolFlags flags) {
+bool DragPoint(int n_id, double* x, double* y, const ImVec4& col, float radius, ImPlotDragToolFlags flags, bool* is_clicked, bool* is_hovered, bool* is_held) {
     ImGui::PushID("#IMPLOT_DRAG_POINT");
     IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != nullptr, "DragPoint() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
@@ -3916,8 +3916,15 @@ bool DragPoint(int n_id, double* x, double* y, const ImVec4& col, float radius, 
     bool hovered = false, held = false;
 
     ImGui::KeepAliveID(id);
-    if (input)
-        ImGui::ButtonBehavior(rect,id,&hovered,&held);
+    if (input) {
+        bool clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
+        if (is_clicked)
+            *is_clicked = clicked;
+        if (is_hovered)
+            *is_hovered = hovered;
+        if (is_held)
+            *is_held = held;
+    }
 
     bool dragging = false;
     if (held && ImGui::IsMouseDragging(0)) {
@@ -3939,7 +3946,7 @@ bool DragPoint(int n_id, double* x, double* y, const ImVec4& col, float radius, 
     return dragging;
 }
 
-bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags) {
+bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags, bool* is_clicked, bool* is_hovered, bool* is_held) {
     // ImGui::PushID("#IMPLOT_DRAG_LINE_X");
     ImPlotContext& gp = *GImPlot;
     IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "DragLineX() needs to be called between BeginPlot() and EndPlot()!");
@@ -3961,8 +3968,15 @@ bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     bool hovered = false, held = false;
 
     ImGui::KeepAliveID(id);
-    if (input)
-        ImGui::ButtonBehavior(rect,id,&hovered,&held);
+    if (input) {
+        bool clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
+        if (is_clicked)
+            *is_clicked = clicked;
+        if (is_hovered)
+            *is_hovered = hovered;
+        if (is_held)
+            *is_held = held;
+    }
 
     if ((hovered || held) && show_curs)
         ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
@@ -3990,7 +4004,7 @@ bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     return dragging;
 }
 
-bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags) {
+bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags, bool* is_clicked, bool* is_hovered, bool* is_held) {
     ImGui::PushID("#IMPLOT_DRAG_LINE_Y");
     ImPlotContext& gp = *GImPlot;
     IM_ASSERT_USER_ERROR(gp.CurrentPlot != nullptr, "DragLineY() needs to be called between BeginPlot() and EndPlot()!");
@@ -4013,8 +4027,15 @@ bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     bool hovered = false, held = false;
 
     ImGui::KeepAliveID(id);
-    if (input)
-        ImGui::ButtonBehavior(rect,id,&hovered,&held);
+    if (input) {
+        bool clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
+        if (is_clicked)
+            *is_clicked = clicked;
+        if (is_hovered)
+            *is_hovered = hovered;
+        if (is_held)
+            *is_held = held;
+    }
 
     if ((hovered || held) && show_curs)
         ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
@@ -4042,7 +4063,7 @@ bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     return dragging;
 }
 
-bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_max, const ImVec4& col, ImPlotDragToolFlags flags) {
+bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_max, const ImVec4& col, ImPlotDragToolFlags flags, bool* is_clicked, bool* is_hovered, bool* is_held) {
     ImGui::PushID("#IMPLOT_DRAG_RECT");
     IM_ASSERT_USER_ERROR(GImPlot->CurrentPlot != nullptr, "DragRect() needs to be called between BeginPlot() and EndPlot()!");
     SetupLock();
@@ -4084,8 +4105,15 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
     ImRect b_rect(pc.x-DRAG_GRAB_HALF_SIZE,pc.y-DRAG_GRAB_HALF_SIZE,pc.x+DRAG_GRAB_HALF_SIZE,pc.y+DRAG_GRAB_HALF_SIZE);
 
     ImGui::KeepAliveID(id);
-    if (input)
-        ImGui::ButtonBehavior(b_rect,id,&hovered,&held);
+    if (input) {
+        bool clicked = ImGui::ButtonBehavior(b_rect,id,&hovered,&held);
+        if (is_clicked)
+            *is_clicked = clicked;
+        if (is_hovered)
+            *is_hovered = hovered;
+        if (is_held)
+            *is_held = held;
+    }
 
     if ((hovered || held) && show_curs)
         ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeAll);
@@ -4164,8 +4192,8 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
     return dragging;
 }
 
-bool DragRect(int id, ImPlotRect* bounds, const ImVec4& col, ImPlotDragToolFlags flags) {
-    return DragRect(id, &bounds->X.Min, &bounds->Y.Min,&bounds->X.Max, &bounds->Y.Max, col, flags);
+bool DragRect(int id, ImPlotRect* bounds, const ImVec4& col, ImPlotDragToolFlags flags, bool* is_clicked, bool* is_hovered, bool* is_held) {
+    return DragRect(id, &bounds->X.Min, &bounds->Y.Min,&bounds->X.Max, &bounds->Y.Max, col, flags, is_clicked, is_hovered, is_held);
 }
 
 //-----------------------------------------------------------------------------

--- a/implot.cpp
+++ b/implot.cpp
@@ -3918,32 +3918,29 @@ bool DragPoint(int n_id, double* x, double* y, const ImVec4& col, float radius, 
     ImGui::KeepAliveID(id);
     if (input) {
         bool clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
-        if (out_clicked)
-            *out_clicked = clicked;
-        if (out_hovered)
-            *out_hovered = hovered;
-        if (out_held)
-            *out_held = held;
+        if (out_clicked) *out_clicked = clicked;
+        if (out_hovered) *out_hovered = hovered;
+        if (out_held)    *out_held    = held;
     }
 
-    bool dragging = false;
+    bool modified = false;
     if (held && ImGui::IsMouseDragging(0)) {
         *x = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).x;
         *y = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).y;
-        dragging = true;
+        modified = true;
     }
 
     PushPlotClipRect();
     ImDrawList& DrawList = *GetPlotDrawList();
     if ((hovered || held) && show_curs)
         ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
-    if (dragging && no_delay)
+    if (modified && no_delay)
         pos = PlotToPixels(*x,*y,IMPLOT_AUTO,IMPLOT_AUTO);
     DrawList.AddCircleFilled(pos, radius, col32);
     PopPlotClipRect();
 
     ImGui::PopID();
-    return dragging;
+    return modified;
 }
 
 bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags, bool* out_clicked, bool* out_hovered, bool* out_held) {
@@ -3970,12 +3967,9 @@ bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     ImGui::KeepAliveID(id);
     if (input) {
         bool clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
-        if (out_clicked)
-            *out_clicked = clicked;
-        if (out_hovered)
-            *out_hovered = hovered;
-        if (out_held)
-            *out_held = held;
+        if (out_clicked) *out_clicked = clicked;
+        if (out_hovered) *out_hovered = hovered;
+        if (out_held)    *out_held    = held;
     }
 
     if ((hovered || held) && show_curs)
@@ -3985,15 +3979,15 @@ bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     ImVec4 color = IsColorAuto(col) ? ImGui::GetStyleColorVec4(ImGuiCol_Text) : col;
     ImU32 col32 = ImGui::ColorConvertFloat4ToU32(color);
 
-    bool dragging = false;
+    bool modified = false;
     if (held && ImGui::IsMouseDragging(0)) {
         *value = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).x;
-        dragging = true;
+        modified = true;
     }
 
     PushPlotClipRect();
     ImDrawList& DrawList = *GetPlotDrawList();
-    if (dragging && no_delay)
+    if (modified && no_delay)
         x  = IM_ROUND(PlotToPixels(*value,0,IMPLOT_AUTO,IMPLOT_AUTO).x);
     DrawList.AddLine(ImVec2(x,yt), ImVec2(x,yb),     col32,   thickness);
     DrawList.AddLine(ImVec2(x,yt), ImVec2(x,yt+len), col32, 3*thickness);
@@ -4001,7 +3995,7 @@ bool DragLineX(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     PopPlotClipRect();
 
     // ImGui::PopID();
-    return dragging;
+    return modified;
 }
 
 bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPlotDragToolFlags flags, bool* out_clicked, bool* out_hovered, bool* out_held) {
@@ -4029,12 +4023,9 @@ bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     ImGui::KeepAliveID(id);
     if (input) {
         bool clicked = ImGui::ButtonBehavior(rect,id,&hovered,&held);
-        if (out_clicked)
-            *out_clicked = clicked;
-        if (out_hovered)
-            *out_hovered = hovered;
-        if (out_held)
-            *out_held = held;
+        if (out_clicked) *out_clicked = clicked;
+        if (out_hovered) *out_hovered = hovered;
+        if (out_held)    *out_held    = held;
     }
 
     if ((hovered || held) && show_curs)
@@ -4044,15 +4035,15 @@ bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     ImVec4 color = IsColorAuto(col) ? ImGui::GetStyleColorVec4(ImGuiCol_Text) : col;
     ImU32 col32 = ImGui::ColorConvertFloat4ToU32(color);
 
-    bool dragging = false;
+    bool modified = false;
     if (held && ImGui::IsMouseDragging(0)) {
         *value = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).y;
-        dragging = true;
+        modified = true;
     }
 
     PushPlotClipRect();
     ImDrawList& DrawList = *GetPlotDrawList();
-    if (dragging && no_delay)
+    if (modified && no_delay)
         y  = IM_ROUND(PlotToPixels(0, *value,IMPLOT_AUTO,IMPLOT_AUTO).y);
     DrawList.AddLine(ImVec2(xl,y), ImVec2(xr,y),     col32,   thickness);
     DrawList.AddLine(ImVec2(xl,y), ImVec2(xl+len,y), col32, 3*thickness);
@@ -4060,7 +4051,7 @@ bool DragLineY(int n_id, double* value, const ImVec4& col, float thickness, ImPl
     PopPlotClipRect();
 
     ImGui::PopID();
-    return dragging;
+    return modified;
 }
 
 bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_max, const ImVec4& col, ImPlotDragToolFlags flags, bool* out_clicked, bool* out_hovered, bool* out_held) {
@@ -4100,14 +4091,17 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
     ImU32 col32_a = ImGui::ColorConvertFloat4ToU32(color);
     const ImGuiID id = ImGui::GetCurrentWindow()->GetID(n_id);
 
-    bool dragging = false;
-    bool hovered = false, held = false;
+    bool modified = false;
+    bool clicked = false, hovered = false, held = false;
     ImRect b_rect(pc.x-DRAG_GRAB_HALF_SIZE,pc.y-DRAG_GRAB_HALF_SIZE,pc.x+DRAG_GRAB_HALF_SIZE,pc.y+DRAG_GRAB_HALF_SIZE);
 
     ImGui::KeepAliveID(id);
     if (input) {
         // middle point
-        ImGui::ButtonBehavior(b_rect,id,&hovered,&held); 
+        clicked = ImGui::ButtonBehavior(b_rect,id,&hovered,&held);
+        if (out_clicked) *out_clicked = clicked;
+        if (out_hovered) *out_hovered = hovered;
+        if (out_held)    *out_held    = held;
     }
 
     if ((hovered || held) && show_curs)
@@ -4118,7 +4112,7 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
             *y[i] = pp.y;
             *x[i] = pp.x;
         }
-        dragging = true;
+        modified = true;
     }
 
     for (int i = 0; i < 4; ++i) {
@@ -4126,15 +4120,19 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
         b_rect = ImRect(p[i].x-DRAG_GRAB_HALF_SIZE,p[i].y-DRAG_GRAB_HALF_SIZE,p[i].x+DRAG_GRAB_HALF_SIZE,p[i].y+DRAG_GRAB_HALF_SIZE);
         ImGuiID p_id = id + i + 1;
         ImGui::KeepAliveID(p_id);
-        if (input)
-            ImGui::ButtonBehavior(b_rect,p_id,&hovered,&held);
+        if (input) {
+            clicked = ImGui::ButtonBehavior(b_rect,p_id,&hovered,&held);
+            if (out_clicked) *out_clicked = *out_clicked || clicked;
+            if (out_hovered) *out_hovered = *out_hovered || hovered;
+            if (out_held)    *out_held    = *out_held    || held;
+        }
         if ((hovered || held) && show_curs)
             ImGui::SetMouseCursor(cur[i]);
 
         if (held && ImGui::IsMouseDragging(0)) {
             *x[i] = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).x;
             *y[i] = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).y;
-            dragging = true;
+            modified = true;
         }
 
         // edges
@@ -4144,8 +4142,12 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
                     : ImRect(e_min.x - DRAG_GRAB_HALF_SIZE, e_min.y + DRAG_GRAB_HALF_SIZE, e_max.x + DRAG_GRAB_HALF_SIZE, e_max.y - DRAG_GRAB_HALF_SIZE);
         ImGuiID e_id = id + i + 5;
         ImGui::KeepAliveID(e_id);
-        if (input)
-            ImGui::ButtonBehavior(b_rect,e_id,&hovered,&held);
+        if (input) {
+            clicked = ImGui::ButtonBehavior(b_rect,e_id,&hovered,&held);
+            if (out_clicked) *out_clicked = *out_clicked || clicked;
+            if (out_hovered) *out_hovered = *out_hovered || hovered;
+            if (out_held)    *out_held    = *out_held    || held;
+        }
         if ((hovered || held) && show_curs)
             h[i] ? ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS) : ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
         if (held && ImGui::IsMouseDragging(0)) {
@@ -4153,7 +4155,7 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
                 *y[i] = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).y;
             else
                 *x[i] = ImPlot::GetPlotMousePos(IMPLOT_AUTO,IMPLOT_AUTO).x;
-            dragging = true;
+            modified = true;
         }
         if (hovered && ImGui::IsMouseDoubleClicked(0))
         {
@@ -4162,28 +4164,20 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
                 *y[i] = ((y[i] == y_min && *y_min < *y_max) || (y[i] == y_max && *y_max < *y_min)) ? b.Y.Min : b.Y.Max;
             else
                 *x[i] = ((x[i] == x_min && *x_min < *x_max) || (x[i] == x_max && *x_max < *x_min)) ? b.X.Min : b.X.Max;
-            dragging = true;
+            modified = true;
         }
     }
 
-    if (input) {
-        // Entire rectangle
-        ImGuiID r_id = id + 5;
-        ImGui::KeepAliveID(r_id);
-        bool is_hovered = false;
-        bool is_held = false;
-        bool is_clicked = ImGui::ButtonBehavior(rect, r_id, &is_hovered, &is_held);
-        if (out_clicked)
-            *out_clicked = is_clicked;
-        if (out_hovered)
-            *out_hovered = is_hovered;
-        if (out_held)
-            *out_held = is_held;
+    const bool mouse_inside = rect_grab.Contains(ImGui::GetMousePos());
+    const bool mouse_clicked = ImGui::IsMouseClicked(0);
+    if (input && mouse_inside) {
+        if (out_clicked) *out_clicked = *out_clicked || mouse_clicked;
+        if (out_hovered) *out_hovered = true;        
     }
 
     PushPlotClipRect();
     ImDrawList& DrawList = *GetPlotDrawList();
-    if (dragging && no_delay) {
+    if (modified && no_delay) {
         for (int i = 0; i < 4; ++i)
             p[i] = PlotToPixels(*x[i],*y[i],IMPLOT_AUTO,IMPLOT_AUTO);
         pc = PlotToPixels((*x_min+*x_max)/2,(*y_min+*y_max)/2,IMPLOT_AUTO,IMPLOT_AUTO);
@@ -4191,14 +4185,14 @@ bool DragRect(int n_id, double* x_min, double* y_min, double* x_max, double* y_m
     }
     DrawList.AddRectFilled(rect.Min, rect.Max, col32_a);
     DrawList.AddRect(rect.Min, rect.Max, col32);
-    if (input && (dragging || rect_grab.Contains(ImGui::GetMousePos()))) {
+    if (input && (modified || mouse_inside)) {
         DrawList.AddCircleFilled(pc,DRAG_GRAB_HALF_SIZE,col32);
         for (int i = 0; i < 4; ++i)
             DrawList.AddCircleFilled(p[i],DRAG_GRAB_HALF_SIZE,col32);
     }
     PopPlotClipRect();
     ImGui::PopID();
-    return dragging;
+    return modified;
 }
 
 bool DragRect(int id, ImPlotRect* bounds, const ImVec4& col, ImPlotDragToolFlags flags, bool* out_clicked, bool* out_hovered, bool* out_held) {

--- a/implot.h
+++ b/implot.h
@@ -924,19 +924,17 @@ IMPLOT_API void PlotDummy(const char* label_id, ImPlotDummyFlags flags=0);
 
 // The following can be used to render interactive elements and/or annotations.
 // Like the item plotting functions above, they apply to the current x and y
-// axes, which can be changed with `SetAxis/SetAxes`.
+// axes, which can be changed with `SetAxis/SetAxes`. These functions return true
+// when user interaction causes the provided coordinates to change. Additional
+// user interactions can be retrieved through the optional output parameters.
 
 // Shows a draggable point at x,y. #col defaults to ImGuiCol_Text.
-// This function returns true when user interaction causes the provided coordinates to change. Additional user interactions can be retrieved through the optional output parameters.
 IMPLOT_API bool DragPoint(int id, double* x, double* y, const ImVec4& col, float size = 4, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
 // Shows a draggable vertical guide line at an x-value. #col defaults to ImGuiCol_Text.
-// This function returns true when user interaction causes the provided coordinates to change. Additional user interactions can be retrieved through the optional output parameters.
 IMPLOT_API bool DragLineX(int id, double* x, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
 // Shows a draggable horizontal guide line at a y-value. #col defaults to ImGuiCol_Text.
-// This function returns true when user interaction causes the provided coordinates to change. Additional user interactions can be retrieved through the optional output parameters.
 IMPLOT_API bool DragLineY(int id, double* y, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
 // Shows a draggable and resizeable rectangle.
-// This function returns true when user interaction causes the provided coordinates to change. Additional user interactions can be retrieved through the optional output parameters.
 IMPLOT_API bool DragRect(int id, double* x1, double* y1, double* x2, double* y2, const ImVec4& col, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
 
 // Shows an annotation callout at a chosen point. Clamping keeps annotations in the plot area. Annotations are always rendered on top.

--- a/implot.h
+++ b/implot.h
@@ -926,14 +926,15 @@ IMPLOT_API void PlotDummy(const char* label_id, ImPlotDummyFlags flags=0);
 // Like the item plotting functions above, they apply to the current x and y
 // axes, which can be changed with `SetAxis/SetAxes`.
 
+// When provided #clicked, #hovered, #held will be set to true if draggable item is clicked, hovered or held.
 // Shows a draggable point at x,y. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragPoint(int id, double* x, double* y, const ImVec4& col, float size = 4, ImPlotDragToolFlags flags=0);
+IMPLOT_API bool DragPoint(int id, double* x, double* y, const ImVec4& col, float size = 4, ImPlotDragToolFlags flags = 0, bool* clicked = nullptr, bool* hovered = nullptr, bool* held = nullptr);
 // Shows a draggable vertical guide line at an x-value. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragLineX(int id, double* x, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags=0);
+IMPLOT_API bool DragLineX(int id, double* x, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* clicked = nullptr, bool* hovered = nullptr, bool* held = nullptr);
 // Shows a draggable horizontal guide line at a y-value. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragLineY(int id, double* y, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags=0);
+IMPLOT_API bool DragLineY(int id, double* y, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* clicked = nullptr, bool* hovered = nullptr, bool* held = nullptr);
 // Shows a draggable and resizeable rectangle.
-IMPLOT_API bool DragRect(int id, double* x1, double* y1, double* x2, double* y2, const ImVec4& col, ImPlotDragToolFlags flags=0);
+IMPLOT_API bool DragRect(int id, double* x1, double* y1, double* x2, double* y2, const ImVec4& col, ImPlotDragToolFlags flags = 0, bool* clicked = nullptr, bool* hovered = nullptr, bool* held = nullptr);
 
 // Shows an annotation callout at a chosen point. Clamping keeps annotations in the plot area. Annotations are always rendered on top.
 IMPLOT_API void Annotation(double x, double y, const ImVec4& col, const ImVec2& pix_offset, bool clamp, bool round = false);

--- a/implot.h
+++ b/implot.h
@@ -926,15 +926,18 @@ IMPLOT_API void PlotDummy(const char* label_id, ImPlotDummyFlags flags=0);
 // Like the item plotting functions above, they apply to the current x and y
 // axes, which can be changed with `SetAxis/SetAxes`.
 
-// When provided #clicked, #hovered, #held will be set to true if draggable item is clicked, hovered or held.
 // Shows a draggable point at x,y. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragPoint(int id, double* x, double* y, const ImVec4& col, float size = 4, ImPlotDragToolFlags flags = 0, bool* clicked = nullptr, bool* hovered = nullptr, bool* held = nullptr);
+// This function returns true when user interaction causes the provided coordinates to change. Additional user interactions can be retrieved through the optional output parameters.
+IMPLOT_API bool DragPoint(int id, double* x, double* y, const ImVec4& col, float size = 4, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
 // Shows a draggable vertical guide line at an x-value. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragLineX(int id, double* x, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* clicked = nullptr, bool* hovered = nullptr, bool* held = nullptr);
+// This function returns true when user interaction causes the provided coordinates to change. Additional user interactions can be retrieved through the optional output parameters.
+IMPLOT_API bool DragLineX(int id, double* x, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
 // Shows a draggable horizontal guide line at a y-value. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragLineY(int id, double* y, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* clicked = nullptr, bool* hovered = nullptr, bool* held = nullptr);
+// This function returns true when user interaction causes the provided coordinates to change. Additional user interactions can be retrieved through the optional output parameters.
+IMPLOT_API bool DragLineY(int id, double* y, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
 // Shows a draggable and resizeable rectangle.
-IMPLOT_API bool DragRect(int id, double* x1, double* y1, double* x2, double* y2, const ImVec4& col, ImPlotDragToolFlags flags = 0, bool* clicked = nullptr, bool* hovered = nullptr, bool* held = nullptr);
+// This function returns true when user interaction causes the provided coordinates to change. Additional user interactions can be retrieved through the optional output parameters.
+IMPLOT_API bool DragRect(int id, double* x1, double* y1, double* x2, double* y2, const ImVec4& col, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
 
 // Shows an annotation callout at a chosen point. Clamping keeps annotations in the plot area. Annotations are always rendered on top.
 IMPLOT_API void Annotation(double x, double y, const ImVec4& col, const ImVec2& pix_offset, bool clamp, bool round = false);

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1421,18 +1421,18 @@ void Demo_DragPoints() {
     ImGui::CheckboxFlags("NoFit", (unsigned int*)&flags, ImPlotDragToolFlags_NoFit); ImGui::SameLine();
     ImGui::CheckboxFlags("NoInput", (unsigned int*)&flags, ImPlotDragToolFlags_NoInputs);
     ImPlotAxisFlags ax_flags = ImPlotAxisFlags_NoTickLabels | ImPlotAxisFlags_NoTickMarks;
-    bool clicked = false;
-    bool hovered = false;
-    bool held = false;
+    bool clicked[4] = {false, false, false, false};
+    bool hovered[4] = {false, false, false, false};
+    bool held[4]    = {false, false, false, false};
     if (ImPlot::BeginPlot("##Bezier",ImVec2(-1,0),ImPlotFlags_CanvasOnly)) {
         ImPlot::SetupAxes(nullptr,nullptr,ax_flags,ax_flags);
         ImPlot::SetupAxesLimits(0,1,0,1);
         static ImPlotPoint P[] = {ImPlotPoint(.05f,.05f), ImPlotPoint(0.2,0.4),  ImPlotPoint(0.8,0.6),  ImPlotPoint(.95f,.95f)};
 
-        ImPlot::DragPoint(0,&P[0].x,&P[0].y, ImVec4(0,0.9f,0,1),4,flags, &clicked, &hovered, &held);
-        ImPlot::DragPoint(1,&P[1].x,&P[1].y, ImVec4(1,0.5f,1,1),4,flags);
-        ImPlot::DragPoint(2,&P[2].x,&P[2].y, ImVec4(0,0.5f,1,1),4,flags);
-        ImPlot::DragPoint(3,&P[3].x,&P[3].y, ImVec4(0,0.9f,0,1),4,flags);
+        ImPlot::DragPoint(0,&P[0].x,&P[0].y, ImVec4(0,0.9f,0,1),4,flags, &clicked[0], &hovered[0], &held[0]);
+        ImPlot::DragPoint(1,&P[1].x,&P[1].y, ImVec4(1,0.5f,1,1),4,flags, &clicked[1], &hovered[1], &held[1]);
+        ImPlot::DragPoint(2,&P[2].x,&P[2].y, ImVec4(0,0.5f,1,1),4,flags, &clicked[2], &hovered[2], &held[2]);
+        ImPlot::DragPoint(3,&P[3].x,&P[3].y, ImVec4(0,0.9f,0,1),4,flags, &clicked[3], &hovered[3], &held[3]);
 
         static ImPlotPoint B[100];
         for (int i = 0; i < 100; ++i) {
@@ -1445,17 +1445,14 @@ void Demo_DragPoints() {
             B[i] = ImPlotPoint(w1*P[0].x + w2*P[1].x + w3*P[2].x + w4*P[3].x, w1*P[0].y + w2*P[1].y + w3*P[2].y + w4*P[3].y);
         }
 
-
-        ImPlot::SetNextLineStyle(ImVec4(1,0.5f,1,1));
+        ImPlot::SetNextLineStyle(ImVec4(1,0.5f,1,1),hovered[1]||held[1] ? 2.0f : 1.0f);
         ImPlot::PlotLine("##h1",&P[0].x, &P[0].y, 2, 0, 0, sizeof(ImPlotPoint));
-        ImPlot::SetNextLineStyle(ImVec4(0,0.5f,1,1));
+        ImPlot::SetNextLineStyle(ImVec4(0,0.5f,1,1), hovered[2]||held[2] ? 2.0f : 1.0f);
         ImPlot::PlotLine("##h2",&P[2].x, &P[2].y, 2, 0, 0, sizeof(ImPlotPoint));
-        ImPlot::SetNextLineStyle(ImVec4(0,0.9f,0,1), 2);
+        ImPlot::SetNextLineStyle(ImVec4(0,0.9f,0,1), hovered[0]||held[0]||hovered[3]||held[3] ? 3.0f : 2.0f);
         ImPlot::PlotLine("##bez",&B[0].x, &B[0].y, 100, 0, 0, sizeof(ImPlotPoint));
-
         ImPlot::EndPlot();
     }
-    ImGui::Text("First point is %sclicked, %shovered, %sheld", clicked ? "" : "not ", hovered ? "" : "not ", held ? "" : "not ");
 }
 
 //-----------------------------------------------------------------------------
@@ -1476,7 +1473,7 @@ void Demo_DragLines() {
     ImGui::CheckboxFlags("NoInput", (unsigned int*)&flags, ImPlotDragToolFlags_NoInputs);
     if (ImPlot::BeginPlot("##lines",ImVec2(-1,0))) {
         ImPlot::SetupAxesLimits(0,1,0,1);
-        ImPlot::DragLineX(0,&x1,ImVec4(1,1,1,1),1,flags, &clicked, &hovered, &held);
+        ImPlot::DragLineX(0,&x1,ImVec4(1,1,1,1),1,flags);
         ImPlot::DragLineX(1,&x2,ImVec4(1,1,1,1),1,flags);
         ImPlot::DragLineY(2,&y1,ImVec4(1,1,1,1),1,flags);
         ImPlot::DragLineY(3,&y2,ImVec4(1,1,1,1),1,flags);
@@ -1485,11 +1482,11 @@ void Demo_DragLines() {
             xs[i] = (x2+x1)/2+fabs(x2-x1)*(i/1000.0f - 0.5f);
             ys[i] = (y1+y2)/2+fabs(y2-y1)/2*sin(f*i/10);
         }
+        ImPlot::DragLineY(120482,&f,ImVec4(1,0.5f,1,1),1,flags, &clicked, &hovered, &held);
+        ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, hovered||held ? 2.0f : 1.0f);
         ImPlot::PlotLine("Interactive Data", xs, ys, 1000);
-        ImPlot::DragLineY(120482,&f,ImVec4(1,0.5f,1,1),1,flags);
         ImPlot::EndPlot();
     }
-    ImGui::Text("First vertical line is %sclicked, %shovered, %sheld", clicked ? "" : "not ", hovered ? "" : "not ", held ? "" : "not ");
 }
 
 //-----------------------------------------------------------------------------
@@ -1514,6 +1511,7 @@ void Demo_DragRects() {
         y_data3[i] = y_data2[i] * -0.6f + sinf(3 * arg) * 0.4f;
     }
     ImGui::BulletText("Click and drag the edges, corners, and center of the rect.");
+    ImGui::BulletText("Double click edges to expand rect to plot extents.");
     static ImPlotRect rect(0.0025,0.0045,0,0.5);
     static ImPlotDragToolFlags flags = ImPlotDragToolFlags_None;
     ImGui::CheckboxFlags("NoCursors", (unsigned int*)&flags, ImPlotDragToolFlags_NoCursors); ImGui::SameLine();
@@ -1529,6 +1527,8 @@ void Demo_DragRects() {
         ImPlot::DragRect(0,&rect.X.Min,&rect.Y.Min,&rect.X.Max,&rect.Y.Max,ImVec4(1,0,1,1),flags, &clicked, &hovered, &held);
         ImPlot::EndPlot();
     }
+    ImVec4 bg_col = held ? ImVec4(0.5f,0,0.5f,1) : (hovered ? ImVec4(0.25f,0,0.25f,1) : ImPlot::GetStyle().Colors[ImPlotCol_PlotBg]);
+    ImPlot::PushStyleColor(ImPlotCol_PlotBg, bg_col);
     if (ImPlot::BeginPlot("##rect",ImVec2(-1,150), ImPlotFlags_CanvasOnly)) {
         ImPlot::SetupAxes(nullptr,nullptr,ImPlotAxisFlags_NoDecorations,ImPlotAxisFlags_NoDecorations);
         ImPlot::SetupAxesLimits(rect.X.Min, rect.X.Max, rect.Y.Min, rect.Y.Max, ImGuiCond_Always);
@@ -1537,6 +1537,7 @@ void Demo_DragRects() {
         ImPlot::PlotLine("Signal 3", x_data, y_data3, 512);
         ImPlot::EndPlot();
     }
+    ImPlot::PopStyleColor();
     ImGui::Text("Rect is %sclicked, %shovered, %sheld", clicked ? "" : "not ", hovered ? "" : "not ", held ? "" : "not ");
 }
 

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1421,12 +1421,15 @@ void Demo_DragPoints() {
     ImGui::CheckboxFlags("NoFit", (unsigned int*)&flags, ImPlotDragToolFlags_NoFit); ImGui::SameLine();
     ImGui::CheckboxFlags("NoInput", (unsigned int*)&flags, ImPlotDragToolFlags_NoInputs);
     ImPlotAxisFlags ax_flags = ImPlotAxisFlags_NoTickLabels | ImPlotAxisFlags_NoTickMarks;
+    bool clicked = false;
+    bool hovered = false;
+    bool held = false;
     if (ImPlot::BeginPlot("##Bezier",ImVec2(-1,0),ImPlotFlags_CanvasOnly)) {
         ImPlot::SetupAxes(nullptr,nullptr,ax_flags,ax_flags);
         ImPlot::SetupAxesLimits(0,1,0,1);
         static ImPlotPoint P[] = {ImPlotPoint(.05f,.05f), ImPlotPoint(0.2,0.4),  ImPlotPoint(0.8,0.6),  ImPlotPoint(.95f,.95f)};
 
-        ImPlot::DragPoint(0,&P[0].x,&P[0].y, ImVec4(0,0.9f,0,1),4,flags);
+        ImPlot::DragPoint(0,&P[0].x,&P[0].y, ImVec4(0,0.9f,0,1),4,flags, &clicked, &hovered, &held);
         ImPlot::DragPoint(1,&P[1].x,&P[1].y, ImVec4(1,0.5f,1,1),4,flags);
         ImPlot::DragPoint(2,&P[2].x,&P[2].y, ImVec4(0,0.5f,1,1),4,flags);
         ImPlot::DragPoint(3,&P[3].x,&P[3].y, ImVec4(0,0.9f,0,1),4,flags);
@@ -1452,6 +1455,7 @@ void Demo_DragPoints() {
 
         ImPlot::EndPlot();
     }
+    ImGui::Text("First point is %sclicked, %shovered, %sheld", clicked ? "" : "not ", hovered ? "" : "not ", held ? "" : "not ");
 }
 
 //-----------------------------------------------------------------------------
@@ -1463,13 +1467,16 @@ void Demo_DragLines() {
     static double y1 = 0.25;
     static double y2 = 0.75;
     static double f = 0.1;
+    bool clicked = false;
+    bool hovered = false;
+    bool held = false;
     static ImPlotDragToolFlags flags = ImPlotDragToolFlags_None;
     ImGui::CheckboxFlags("NoCursors", (unsigned int*)&flags, ImPlotDragToolFlags_NoCursors); ImGui::SameLine();
     ImGui::CheckboxFlags("NoFit", (unsigned int*)&flags, ImPlotDragToolFlags_NoFit); ImGui::SameLine();
     ImGui::CheckboxFlags("NoInput", (unsigned int*)&flags, ImPlotDragToolFlags_NoInputs);
     if (ImPlot::BeginPlot("##lines",ImVec2(-1,0))) {
         ImPlot::SetupAxesLimits(0,1,0,1);
-        ImPlot::DragLineX(0,&x1,ImVec4(1,1,1,1),1,flags);
+        ImPlot::DragLineX(0,&x1,ImVec4(1,1,1,1),1,flags, &clicked, &hovered, &held);
         ImPlot::DragLineX(1,&x2,ImVec4(1,1,1,1),1,flags);
         ImPlot::DragLineY(2,&y1,ImVec4(1,1,1,1),1,flags);
         ImPlot::DragLineY(3,&y2,ImVec4(1,1,1,1),1,flags);
@@ -1482,6 +1489,7 @@ void Demo_DragLines() {
         ImPlot::DragLineY(120482,&f,ImVec4(1,0.5f,1,1),1,flags);
         ImPlot::EndPlot();
     }
+    ImGui::Text("First vertical line is %sclicked, %shovered, %sheld", clicked ? "" : "not ", hovered ? "" : "not ", held ? "" : "not ");
 }
 
 //-----------------------------------------------------------------------------
@@ -1494,6 +1502,9 @@ void Demo_DragRects() {
     static float y_data3[512];
     static float sampling_freq = 44100;
     static float freq = 500;
+    bool clicked = false;
+    bool hovered = false;
+    bool held = false;
     for (size_t i = 0; i < 512; ++i) {
         const float t = i / sampling_freq;
         x_data[i] = t;
@@ -1515,7 +1526,7 @@ void Demo_DragRects() {
         ImPlot::PlotLine("Signal 1", x_data, y_data1, 512);
         ImPlot::PlotLine("Signal 2", x_data, y_data2, 512);
         ImPlot::PlotLine("Signal 3", x_data, y_data3, 512);
-        ImPlot::DragRect(0,&rect.X.Min,&rect.Y.Min,&rect.X.Max,&rect.Y.Max,ImVec4(1,0,1,1),flags);
+        ImPlot::DragRect(0,&rect.X.Min,&rect.Y.Min,&rect.X.Max,&rect.Y.Max,ImVec4(1,0,1,1),flags, &clicked, &hovered, &held);
         ImPlot::EndPlot();
     }
     if (ImPlot::BeginPlot("##rect",ImVec2(-1,150), ImPlotFlags_CanvasOnly)) {
@@ -1526,6 +1537,7 @@ void Demo_DragRects() {
         ImPlot::PlotLine("Signal 3", x_data, y_data3, 512);
         ImPlot::EndPlot();
     }
+    ImGui::Text("Rect is %sclicked, %shovered, %sheld", clicked ? "" : "not ", hovered ? "" : "not ", held ? "" : "not ");
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Hello again! Following #506 PR.

To be able to query states of draggable items I've added new optional arguments:
```cpp
IMPLOT_API bool DragPoint(int id, double* x, double* y, const ImVec4& col, float size = 4, ImPlotDragToolFlags flags = 0, 
    bool* clicked = nullptr, bool* hovered = nullptr, bool* held = nullptr);
```
When `clicked`, `hovered` or `held` provided it will be set to results of `ImGui::ButtonBehavior` function.

Example code:
```cpp
bool is_clicked = false;
ImPlot::DragPoint(key.id, &x, &y, ImVec4(1.0f, 0.0f, 1.0f, 1.0f), line_weight, 0, &is_clicked);
if (is_clicked)
{
  //process click
}
```