### PR TITLE
Fix indexing logic of GetterHeatmapColMaj::operator()

### DIFF
--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -2327,8 +2327,8 @@ struct GetterHeatmapColMaj {
     { }
     template <typename I> IMPLOT_INLINE RectC operator()(I idx) const {
         double val = (double)Values[idx];
-        const int r = idx % Cols;
-        const int c = idx / Cols;
+        const int r = idx % Rows;
+        const int c = idx / Rows;
         const ImPlotPoint p(XRef + HalfSize.x + c*Width, YRef + YDir * (HalfSize.y + r*Height));
         RectC rect;
         rect.Pos = p;


### PR DESCRIPTION
Change indexing mod from Cols to Rows to fix bounding point implementation error.