### PR TITLE
Fix EndPlot() not deducing auto color for ImPlotCol_PlotBorder

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -2778,7 +2778,7 @@ void EndPlot() {
 
     // FINAL RENDER -----------------------------------------------------------
 
-    const bool render_border  = gp.Style.PlotBorderSize > 0 && gp.Style.Colors[ImPlotCol_PlotBorder].w > 0;
+    const bool render_border  = gp.Style.PlotBorderSize > 0 && GetStyleColorVec4(ImPlotCol_PlotBorder).w > 0;
     const bool any_x_held = plot.Held    || AnyAxesHeld(&plot.Axes[ImAxis_X1], IMPLOT_NUM_X_AXES);
     const bool any_y_held = plot.Held    || AnyAxesHeld(&plot.Axes[ImAxis_Y1], IMPLOT_NUM_Y_AXES);
 


### PR DESCRIPTION
EndPlot() currently accesses the style color field directly when deciding whether to render the border and behaves wrongly if ImPlotCol_PlotBorder is set to IMPLOT_AUTO_COL, never rendering it. Despite being documented to defaulting to ImGuiCol_Border's value.

Of course the easy fix on the application end is to set ImPlotCol_PlotBorder explicitly. This change may also be considered as a breaking change as it will start adding borders to plots that previously had none with default styling.
Changing the documentation to reflect the current behavior could be an alternative if preferred.