### PR TITLE
Display mouse coordinates when dragging/selecting

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -2922,7 +2922,7 @@ void EndPlot() {
     }
 
     // render mouse pos
-    if (!ImHasFlag(plot.Flags, ImPlotFlags_NoMouseText) && (plot.Hovered || ImHasFlag(plot.MouseTextFlags, ImPlotMouseTextFlags_ShowAlways))) {
+    if (!ImHasFlag(plot.Flags, ImPlotFlags_NoMouseText) && (plot.Hovered || plot.Held || plot.Selecting || ImHasFlag(plot.MouseTextFlags, ImPlotMouseTextFlags_ShowAlways))) {
 
         const bool no_aux = ImHasFlag(plot.MouseTextFlags, ImPlotMouseTextFlags_NoAuxAxes);
         const bool no_fmt = ImHasFlag(plot.MouseTextFlags, ImPlotMouseTextFlags_NoFormat);


### PR DESCRIPTION
When dragging a plot, or when doing a box-selection, the mouse is "captured" by Implot, i.e. the plot remains affected even when the mouse is moved outside the plot area. As such, the mouse coordinates should remain visible.