### PR TITLE
Reintroduce header guards for `IMGUI_DEFINE_MATH_OPERATORS` to fix compiler warnings

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -125,7 +125,9 @@ You can read releases logs https://github.com/epezent/implot/releases for more d
 
 */
 
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
+#endif
 #include "implot.h"
 #include "implot_internal.h"
 

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -22,7 +22,9 @@
 
 // ImPlot v0.17
 
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
+#endif
 #include "implot.h"
 #include "implot_internal.h"
 


### PR DESCRIPTION
The commit 33c5a965f55f80057f197257d1d1cdb06523e963 removed the definition for `IMGUI_DEFINE_MATH_OPERATORS` including a header guard from `implot_internal.h` and moved it into the unit files `implot.cpp` and `implot_items.cpp` but without a corresponding check whether `IMGUI_DEFINE_MATH_OPERATORS` was already defined.

When `IMGUI_DEFINE_MATH_OPERATORS` is set externally, e.g. via target compile definitions, this now leads to compiler warnings. The PR fixes these compiler warnings by reintroducing header guards for `IMGUI_DEFINE_MATH_OPERATORS`.