### PR TITLE
Add Rapid Plot Legend Item Selection

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -670,9 +670,30 @@ bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool hov
                       ? false
                       : ImGui::ButtonBehavior(button_bb, item->ID, &item_hov, &item_hld);
 
-        if (item_clk)
-            item->Show = !item->Show;
-
+        if (item_clk) {
+            ImGuiIO& IO = ImGui::GetIO();
+            if (IO.KeyCtrl && IO.KeyShift) {
+                // select all items
+                for (int j = 0; j < num_items; ++j) {
+                    ImPlotItem* item_j = items.GetLegendItem(indices[j]);
+                    item_j->Show = true;
+                }
+            }
+            else if (IO.KeyCtrl) {
+                // select the item and deselect all others
+                for (int j = 0; j < num_items; ++j) {
+                    ImPlotItem* item_j = items.GetLegendItem(indices[j]);
+                    if (item_j->Show) {
+                        item_j->Show = false;
+                    }
+                }
+                item->Show = true;
+            }
+            else {
+                // select/deselect the item
+                item->Show = !item->Show;
+            }
+        }
 
         const bool can_hover = (item_hov)
                              && (!ImHasFlag(items.Legend.Flags, ImPlotLegendFlags_NoHighlightItem)

--- a/implot.cpp
+++ b/implot.cpp
@@ -694,6 +694,30 @@ bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool hov
                 item->Show = !item->Show;
             }
         }
+        else {
+            // multiple selection
+            static bool selecting_multiple_items = false;
+
+            if (item_hov) {
+                selecting_multiple_items = true;
+            }
+
+            if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
+                selecting_multiple_items = false;
+            }
+
+            if (selecting_multiple_items &&
+                ImGui::IsMouseDown(ImGuiMouseButton_Left) &&
+                ImGui::IsMouseHoveringRect(button_bb.Min, button_bb.Max)) {
+                ImGuiIO& IO = ImGui::GetIO();
+                if (IO.KeyCtrl) {
+                    item->Show = true;
+                }
+                else if (IO.KeyAlt) {
+                    item->Show = false;
+                }
+            }
+        }
 
         const bool can_hover = (item_hov)
                              && (!ImHasFlag(items.Legend.Flags, ImPlotLegendFlags_NoHighlightItem)


### PR DESCRIPTION
I propose a new method for selecting items in Plot Legend, addressing the following issue:

Currently, in the legend, users can use mouse click to show or hide individual items.
However, when there are many items and a user wants to view just one, they need to hide to the others, which requires numerous mouse clicks.
Repeating this process can be very tiring for users.

Now, there is a quicker and simpler way for users to select just one item, and I have also added a method for them to view all items again.

[New Actions]
* Selecting a single item in the plot legend and automatically deselecting all others
  * Ctrl + Mouse Left Button Click

* Selecting all items in the plot legend
  * Ctrl + Shift + Mouse Left Button Click

* Selecting multiple items
  * Ctrl + Mouse Left Button Drag

* Deselecting multiple items
  * Alt + Mouse Left Button Drag

[Demo: Selecting a single item and deselecting all others / Selecting all items]
![select_the_item_and_deselect_all_others](https://github.com/epezent/implot/assets/59576365/575d2c09-60f5-4a0f-a1da-f05b93e2810e)

[Demo: Selecting/Deselecting multiple items]
![multiple_selection](https://github.com/epezent/implot/assets/59576365/552caee2-19ff-4153-a516-bc9b65502bb6)
