### PR TITLE
Scroll can pan or zoom : useful for touchpad

### DIFF
--- a/implot.h
+++ b/implot.h
@@ -562,18 +562,21 @@ struct ImPlotStyle {
 
 // Input mapping structure. Default values listed. See also MapInputDefault, MapInputReverse.
 struct ImPlotInputMap {
-    ImGuiMouseButton Pan;           // LMB    enables panning when held,
-    int              PanMod;        // none   optional modifier that must be held for panning/fitting
-    ImGuiMouseButton Fit;           // LMB    initiates fit when double clicked
-    ImGuiMouseButton Select;        // RMB    begins box selection when pressed and confirms selection when released
-    ImGuiMouseButton SelectCancel;  // LMB    cancels active box selection when pressed; cannot be same as Select
-    int              SelectMod;     // none   optional modifier that must be held for box selection
-    int              SelectHorzMod; // Alt    expands active box selection horizontally to plot edge when held
-    int              SelectVertMod; // Shift  expands active box selection vertically to plot edge when held
-    ImGuiMouseButton Menu;          // RMB    opens context menus (if enabled) when clicked
-    int              OverrideMod;   // Ctrl   when held, all input is ignored; used to enable axis/plots as DND sources
-    int              ZoomMod;       // none   optional modifier that must be held for scroll wheel zooming
-    float            ZoomRate;      // 0.1f   zoom rate for scroll (e.g. 0.1f = 10% plot range every scroll click); make negative to invert
+    ImGuiMouseButton Pan;               // LMB    enables panning when held,
+    int              PanMod;            // none   optional modifier that must be held for panning/fitting
+    ImGuiMouseButton Fit;               // LMB    initiates fit when double clicked
+    ImGuiMouseButton Select;            // RMB    begins box selection when pressed and confirms selection when released
+    ImGuiMouseButton SelectCancel;      // LMB    cancels active box selection when pressed; cannot be same as Select
+    int              SelectMod;         // none   optional modifier that must be held for box selection
+    int              SelectHorzMod;     // Alt    expands active box selection horizontally to plot edge when held
+    int              SelectVertMod;     // Shift  expands active box selection vertically to plot edge when held
+    ImGuiMouseButton Menu;              // RMB    opens context menus (if enabled) when clicked
+    int              OverrideMod;       // Ctrl   when held, all input is ignored; used to enable axis/plots as DND sources
+    int              ZoomPanToggleMod;  // none   toggle between zoom and pan for scroll wheel behavior
+    bool             ZoomBothAxis;      // true   if true, both axis are zoomed by the scroll wheel, otherwise horizontal axis is zoomed by the horizontal wheel
+    float            ZoomRate;          // 0.1f   zoom rate for scroll (e.g. 0.1f = 10% plot range every scroll click); make negative to invert
+    float            ScrollPanRate;     // 100.f  zoom rate for scroll (e.g. 0.1f = 10% plot range every scroll click); make negative to invert
+    bool             ScrollWheelPans;   // false  if true, default behavior of scroll wheel will pan instead of zoom
     IMPLOT_API ImPlotInputMap();
 };
 

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -252,7 +252,8 @@ void ShowInputMapping() {
     InputMapping("SelectCancel",&map.SelectCancel,nullptr);
     InputMapping("Menu",&map.Menu,nullptr);
     InputMapping("OverrideMod",nullptr,&map.OverrideMod);
-    InputMapping("ZoomMod",nullptr,&map.ZoomMod);
+    InputMapping("ZoomPanToggleMod", nullptr, &map.ZoomPanToggleMod);
+    ImGui::SliderFloat("ScrollPanRate", &map.ScrollPanRate, -100, 100);
     ImGui::SliderFloat("ZoomRate",&map.ZoomRate,-1,1);
 }
 


### PR DESCRIPTION
First of all, thank you for writing this wonderful library!

I would like to propose this changes about the behavior of scrolling on plot.

Before, scrolling was exclusively for zooming.
But on modern touchpad (e.g. macbook) mouse wheel event is sometime a 2 dimensional vector (vertical and horinzonal) and hence can be use for more fine grained control.

This implements optional panning and zooming with the mouse wheel in a satisfying way for such touchpad. This adds a few options controlling:
- if the mouse wheel panning or zooming by default
- the modifier key toggling between the two behavior (none for behavior non togglable)
- the rate of panning and zooming
- if both axis should be controlled together with the vertical axis or separated with the horizontal and vertical component.


In particular, the default behavior does not change.

Would such a change makes sense in your opinion?
