### PR TITLE
qualify isnan() with std namespace

### DIFF
--- a/implot_internal.h
+++ b/implot_internal.h
@@ -120,7 +120,7 @@ static inline T ImRemap01(T x, T x0, T x1) { return (x - x0) / (x1 - x0); }
 // Returns always positive modulo (assumes r != 0)
 static inline int ImPosMod(int l, int r) { return (l % r + r) % r; }
 // Returns true if val is NAN
-static inline bool ImNan(double val) { return isnan(val); }
+static inline bool ImNan(double val) { return std::isnan(val); }
 // Returns true if val is NAN or INFINITY
 static inline bool ImNanOrInf(double val) { return !(val >= -DBL_MAX && val <= DBL_MAX) || ImNan(val); }
 // Turns NANs to 0s


### PR DESCRIPTION
See the commit message for details. I've tested this change on NetBSD only.

Found while porting [dolphin-emu/dolphin](https://github.com/dolphin-emu/dolphin) to NetBSD:
```console
[159/402] Building CXX object Externals/implot/CMakeFiles/implot.dir/implot/implot_items.cpp.o
samu: job failed: /usr/bin/c++ -DAUTOUPDATE=1 -DDATA_DIR=\"/usr/local/share/dolphin-emu/\" -DHAVE_EGL=1 -DHAVE_X11=1 -DHAVE_XRANDR=1 -DUSE_ANALYTICS=1 -DUSE_MEMORYWATCHER=1 -DUSE_PIPES=1 -D_A
RCH_32=1 -D_DEBUG -D_DEFAULT_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_M_GENERIC=1 -I/home/jan/Work/dolphin/Source/Core -I/home/jan/Work/dolphin/Externals/implot/implot -I/home/jan
/Work/dolphin/Externals/implot/imgui -I/home/jan/Work/dolphin/Externals/imgui -I/home/jan/Work/dolphin/Externals/fmt/fmt/include -g -std=c++2a -fdiagnostics-color -fno-strict-aliasing -fno-ex
ceptions -fvisibility-inlines-hidden -fvisibility=hidden -ggdb -w -MD -MT Externals/implot/CMakeFiles/implot.dir/implot/implot_items.cpp.o -MF Externals/implot/CMakeFiles/implot.dir/implot/im
plot_items.cpp.o.d -o Externals/implot/CMakeFiles/implot.dir/implot/implot_items.cpp.o -c /home/jan/Work/dolphin/Externals/implot/implot/implot_items.cpp
In file included from /home/jan/Work/dolphin/Externals/implot/implot/implot_items.cpp:27:
/home/jan/Work/dolphin/Externals/implot/implot/implot_internal.h: In function 'bool ImNan(double)':
/home/jan/Work/dolphin/Externals/implot/implot/implot_internal.h:123:47: error: 'isnan' was not declared in this scope; did you mean 'std::isnan'?
  123 | static inline bool ImNan(double val) { return isnan(val); }
      |                                               ^~~~~
      |                                               std::isnan
In file included from /home/jan/Work/dolphin/Externals/fmt/fmt/include/fmt/format.h:36,
                 from /home/jan/Work/dolphin/Source/Core/Common/Logging/Log.h:7,
                 from /home/jan/Work/dolphin/Source/Core/Common/Assert.h:8,
                 from /home/jan/Work/dolphin/Externals/imgui/imconfig.h:17,
                 from /home/jan/Work/dolphin/Externals/imgui/imgui.h:58,
                 from /home/jan/Work/dolphin/Externals/implot/implot/implot.h:48,
                 from /home/jan/Work/dolphin/Externals/implot/implot/implot_items.cpp:26:
/usr/include/g++/cmath:632:5: note: 'std::isnan' declared here
  632 |     isnan(_Tp __x)
      |     ^~~~~
samu: subcommand failed
```