### PR TITLE
replace older time functions with more portable ones

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -909,7 +909,7 @@ ImPlotTime MkGmtTime(struct tm *ptm) {
 #ifdef _WIN32
     t.S = _mkgmtime(ptm);
 #else
-    t.S = timegm(ptm);
+    t.S = mktime(ptm);
 #endif
     if (t.S < 0)
         t.S = 0;
@@ -924,7 +924,7 @@ tm* GetGmtTime(const ImPlotTime& t, tm* ptm)
   else
     return nullptr;
 #else
-  return gmtime_r(&t.S, ptm);
+  return gmtime_s(&t.S, ptm);
 #endif
 }
 
@@ -943,7 +943,7 @@ tm* GetLocTime(const ImPlotTime& t, tm* ptm) {
   else
     return nullptr;
 #else
-    return localtime_r(&t.S, ptm);
+    return localtime_s(&t.S, ptm);
 #endif
 }
 


### PR DESCRIPTION
As per https://www.gnu.org/software/libc/manual/html_node/Broken_002ddown-Time.html