### PR TITLE
Added  IMGUI_DISABLE_DEMO_WINDOWS support

### DIFF
--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -44,6 +44,8 @@
 
 #define CHECKBOX_FLAG(flags, flag) ImGui::CheckboxFlags(#flag, (unsigned int*)&flags, flag)
 
+#if !defined(IMGUI_DISABLE_DEMO_WINDOWS)
+
 // Encapsulates examples for customizing ImPlot.
 namespace MyImPlot {
 
@@ -2478,5 +2480,11 @@ void PlotCandlestick(const char* label_id, const double* xs, const double* opens
 }
 
 } // namespace MyImplot
+
+#else
+
+void ImPlot::ShowDemoWindow(bool* p_open) {}
+
+#endif
 
 #endif // #ifndef IMGUI_DISABLE


### PR DESCRIPTION
Unlike ImGui only ShowDemoWindow of the public implot.h api is actually defined in implot_demo.cpp.

Refrained from moving ShowStyleEditor, ShowStyleSelector, ShowUserGuide, ShowMetricsWindow to implot_demo.cpp like ImGui. But looks like it would be fairly painless to move if wanted.