### PR TITLE
Custom per-item colors for line and scatter plot

### DIFF
--- a/implot.h
+++ b/implot.h
@@ -861,6 +861,7 @@ IMPLOT_API void SetNextAxesToFit();
 IMPLOT_TMP void PlotLine(const char* label_id, const T* values, int count, double xscale=1, double xstart=0, ImPlotLineFlags flags=0, int offset=0, int stride=sizeof(T));
 IMPLOT_TMP void PlotLine(const char* label_id, const T* xs, const T* ys, int count, ImPlotLineFlags flags=0, int offset=0, int stride=sizeof(T));
 IMPLOT_API void PlotLineG(const char* label_id, ImPlotGetter getter, void* data, int count, ImPlotLineFlags flags=0);
+IMPLOT_API void PlotLineCG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotColorGetter color_func, void* color_data, ImPlotLineFlags flags=0);
 
 // Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
 IMPLOT_TMP void PlotScatter(const char* label_id, const T* values, int count, double xscale=1, double xstart=0, ImPlotScatterFlags flags=0, int offset=0, int stride=sizeof(T));

--- a/implot.h
+++ b/implot.h
@@ -937,13 +937,13 @@ IMPLOT_API void PlotDummy(const char* label_id, ImPlotDummyFlags flags=0);
 // user interactions can be retrieved through the optional output parameters.
 
 // Shows a draggable point at x,y. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragPoint(int id, double* x, double* y, const ImVec4& col, float size = 4, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
+IMPLOT_API bool DragPoint(int id, double* x, double* y, const ImVec4& col, float size = 4, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* out_held = nullptr);
 // Shows a draggable vertical guide line at an x-value. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragLineX(int id, double* x, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
+IMPLOT_API bool DragLineX(int id, double* x, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* out_held = nullptr);
 // Shows a draggable horizontal guide line at a y-value. #col defaults to ImGuiCol_Text.
-IMPLOT_API bool DragLineY(int id, double* y, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
+IMPLOT_API bool DragLineY(int id, double* y, const ImVec4& col, float thickness = 1, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* out_held = nullptr);
 // Shows a draggable and resizeable rectangle.
-IMPLOT_API bool DragRect(int id, double* x1, double* y1, double* x2, double* y2, const ImVec4& col, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* held = nullptr);
+IMPLOT_API bool DragRect(int id, double* x1, double* y1, double* x2, double* y2, const ImVec4& col, ImPlotDragToolFlags flags = 0, bool* out_clicked = nullptr, bool* out_hovered = nullptr, bool* out_held = nullptr);
 
 // Shows an annotation callout at a chosen point. Clamping keeps annotations in the plot area. Annotations are always rendered on top.
 IMPLOT_API void Annotation(double x, double y, const ImVec4& col, const ImVec2& pix_offset, bool clamp, bool round = false);

--- a/implot.h
+++ b/implot.h
@@ -589,6 +589,9 @@ typedef int (*ImPlotFormatter)(double value, char* buff, int size, void* user_da
 // Callback signature for data getter.
 typedef ImPlotPoint (*ImPlotGetter)(int idx, void* user_data);
 
+// Callback signature for color getter.
+typedef ImU32 (*ImPlotColorGetter)(ImPlotCol col, int idx, void* user_data);
+
 // Callback signature for axis transform.
 typedef double (*ImPlotTransform)(double value, void* user_data);
 

--- a/implot.h
+++ b/implot.h
@@ -867,6 +867,7 @@ IMPLOT_API void PlotLineCG(const char* label_id, ImPlotGetter getter_func, void*
 IMPLOT_TMP void PlotScatter(const char* label_id, const T* values, int count, double xscale=1, double xstart=0, ImPlotScatterFlags flags=0, int offset=0, int stride=sizeof(T));
 IMPLOT_TMP void PlotScatter(const char* label_id, const T* xs, const T* ys, int count, ImPlotScatterFlags flags=0, int offset=0, int stride=sizeof(T));
 IMPLOT_API void PlotScatterG(const char* label_id, ImPlotGetter getter, void* data, int count, ImPlotScatterFlags flags=0);
+IMPLOT_API void PlotScatterCG(const char* label_id, ImPlotGetter getter, void* data, int count, ImPlotColorGetter color_func, void* color_data, ImPlotScatterFlags flags=0);
 
 // Plots a a stairstep graph. The y value is continued constantly to the right from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i]
 IMPLOT_TMP void PlotStairs(const char* label_id, const T* values, int count, double xscale=1, double xstart=0, ImPlotStairsFlags flags=0, int offset=0, int stride=sizeof(T));

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -2163,10 +2163,23 @@ void Demo_CustomPlottersAndTooltips()  {
 void Demo_CustomColors() {
 
     if (ImPlot::BeginPlot("Custom Colors")){
-        ImPlot::PlotLineCG("Custom Colors Plot", 
+        ImPlot::PlotLineCG("Line Plot", 
             [](int idx, void* user_data){ 
                 return ImPlotPoint(0.1*idx, sin(0.1*idx)); 
             }, nullptr, 100, 
+            [](ImPlotCol col, int idx, void* user_data){ 
+                switch (idx % 3){
+                case 0 : return 0xFF0000FFu;
+                case 1 : return 0xFF00FF00u;
+                case 2 : return 0xFFFF0000u;
+                default: return 0u;
+                }
+            }, nullptr);
+        ImPlot::PlotScatterCG("Scatter Plot", 
+            [](int idx, void* user_data){ 
+                srand(idx);
+                return ImPlotPoint(10.0*float(rand())/float(RAND_MAX), -1.0+2.0*float(rand())/float(RAND_MAX));
+            }, nullptr, 20, 
             [](ImPlotCol col, int idx, void* user_data){ 
                 switch (idx % 3){
                 case 0 : return 0xFF0000FFu;

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -2158,7 +2158,26 @@ void Demo_CustomPlottersAndTooltips()  {
         MyImPlot::PlotCandlestick("GOOGL",dates, opens, closes, lows, highs, 218, tooltip, 0.25f, bullCol, bearCol);
         ImPlot::EndPlot();
     }
+}
+
+void Demo_CustomColors() {
+
+    if (ImPlot::BeginPlot("Custom Colors")){
+        ImPlot::PlotLineCG("Custom Colors Plot", 
+            [](int idx, void* user_data){ 
+                return ImPlotPoint(0.1*idx, sin(0.1*idx)); 
+            }, nullptr, 100, 
+            [](ImPlotCol col, int idx, void* user_data){ 
+                switch (idx % 3){
+                case 0 : return 0xFF0000FFu;
+                case 1 : return 0xFF00FF00u;
+                case 2 : return 0xFFFF0000u;
+                default: return 0u;
+                }
+            }, nullptr);
+        ImPlot::EndPlot();
     }
+}
 
 //-----------------------------------------------------------------------------
 // DEMO WINDOW
@@ -2247,6 +2266,7 @@ void ShowDemoWindow(bool* p_open) {
             DemoHeader("Images", Demo_Images);
             DemoHeader("Markers and Text", Demo_MarkersAndText);
             DemoHeader("NaN Values", Demo_NaNValues);
+            DemoHeader("Custom Colors", Demo_CustomColors);
             ImGui::EndTabItem();
         }
         if (ImGui::BeginTabItem("Subplots")) {

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -1773,6 +1773,12 @@ void PlotScatterG(const char* label_id, ImPlotGetter getter_func, void* data, in
     return PlotScatterEx(label_id, getter, color, flags);
 }
 
+void PlotScatterCG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotColorGetter color_func, void* color_data, ImPlotScatterFlags flags) {
+    GetterFuncPtr getter(getter_func,data, count);
+    ColorGetterFuncPtr color(color_func, color_data);
+    return PlotScatterEx(label_id, getter, color, flags);
+}
+
 //-----------------------------------------------------------------------------
 // [SECTION] PlotStairs
 //-----------------------------------------------------------------------------

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -649,7 +649,7 @@ struct GetterError {
 
 struct ColorGetter {
     ColorGetter() { }
-    IMPLOT_INLINE void fill_colors() {
+    IMPLOT_INLINE void FillColors() {
         for (int i = 0; i < 5; i++) Colors[i] = ImGui::GetColorU32(GetItemData().Colors[i]);
     }
     template <typename I> IMPLOT_INLINE ImU32 operator()(ImPlotCol col, I idx) const {
@@ -657,7 +657,7 @@ struct ColorGetter {
         IM_ASSERT(col < 5);
         return Colors[col];
     }
-    IMPLOT_INLINE bool is_fill_eq_line() const {
+    IMPLOT_INLINE bool IsFillEqLine() const {
         return Colors[ImPlotCol_Fill] == Colors[ImPlotCol_Line];
     }
     ImU32 Colors[5] = {};
@@ -669,12 +669,12 @@ struct ColorGetterFuncPtr {
         Color(color),
         Data(data)
     { }
-    IMPLOT_INLINE void fill_colors() { }
+    IMPLOT_INLINE void FillColors() { }
     template <typename I> IMPLOT_INLINE ImU32 operator()(ImPlotCol col, I idx) const {
         IM_ASSERT(col < 5);
         return Color(col, idx, Data);
     }
-    IMPLOT_INLINE bool is_fill_eq_line() const { return false; }
+    IMPLOT_INLINE bool IsFillEqLine() const { return false; }
     ImPlotColorGetter Color;
     void* const Data;
 };
@@ -1659,7 +1659,7 @@ void PlotLineEx(const char* label_id, const _Getter& getter, _ColorGetter& color
             EndItem();
             return;
         }
-        color.fill_colors();
+        color.FillColors();
         const ImPlotNextItemData& s = GetItemData();
         if (getter.Count > 1) {
             if (ImHasFlag(flags, ImPlotLineFlags_Shaded) && s.RenderFill) {
@@ -1740,7 +1740,7 @@ void PlotScatterEx(const char* label_id, const Getter& getter, ColorGetter& colo
             EndItem();
             return;
         }
-        color.fill_colors();
+        color.FillColors();
         const ImPlotNextItemData& s = GetItemData();
         ImPlotMarker marker = s.Marker == ImPlotMarker_None ? ImPlotMarker_Circle: s.Marker;
         if (marker != ImPlotMarker_None) {
@@ -1798,7 +1798,7 @@ void PlotStairsEx(const char* label_id, const Getter& getter, ColorGetter& color
             EndItem();
             return;
         }
-        color.fill_colors();
+        color.FillColors();
         const ImPlotNextItemData& s = GetItemData();
         if (getter.Count > 1) {
             if (s.RenderFill && ImHasFlag(flags,ImPlotStairsFlags_Shaded)) {
@@ -1862,7 +1862,7 @@ void PlotShadedEx(const char* label_id, const Getter1& getter1, const Getter2& g
             EndItem();
             return;
         }
-        color.fill_colors();
+        color.FillColors();
         const ImPlotNextItemData& s = GetItemData();
         if (s.RenderFill) {
             RenderPrimitives2<RendererShaded>(getter1,getter2,color);
@@ -1930,13 +1930,13 @@ void PlotBarsVEx(const char* label_id, const Getter1& getter1, const Getter2& ge
             EndItem();
             return;
         }
-        color.fill_colors();
+        color.FillColors();
         const ImPlotNextItemData& s = GetItemData();
         bool rend_fill = s.RenderFill;
         bool rend_line = s.RenderLine;
         if (rend_fill) {
             RenderPrimitives2<RendererBarsFillV>(getter1,getter2,color,width);
-            if (rend_line && color.is_fill_eq_line())
+            if (rend_line && color.IsFillEqLine())
                 rend_line = false;
         }
         if (rend_line) {
@@ -1953,13 +1953,13 @@ void PlotBarsHEx(const char* label_id, const Getter1& getter1, const Getter2& ge
             EndItem();
             return;
         }
-        color.fill_colors();
+        color.FillColors();
         const ImPlotNextItemData& s = GetItemData();
         bool rend_fill = s.RenderFill;
         bool rend_line = s.RenderLine;
         if (rend_fill) {
             RenderPrimitives2<RendererBarsFillH>(getter1,getter2,color,height);
-            if (rend_line && color.is_fill_eq_line())
+            if (rend_line && color.IsFillEqLine())
                 rend_line = false;
         }
         if (rend_line) {
@@ -2120,7 +2120,7 @@ void PlotErrorBarsVEx(const char* label_id, const _GetterPos& getter_pos, const 
             EndItem();
             return;
         }
-        color.fill_colors();
+        color.FillColors();
         const ImPlotNextItemData& s = GetItemData();
         ImDrawList& draw_list = *GetPlotDrawList();
         const bool rend_whisker  = s.ErrorBarSize > 0;
@@ -2146,7 +2146,7 @@ void PlotErrorBarsHEx(const char* label_id, const _GetterPos& getter_pos, const 
             EndItem();
             return;
         }
-        color.fill_colors();
+        color.FillColors();
         const ImPlotNextItemData& s = GetItemData();
         ImDrawList& draw_list = *GetPlotDrawList();
         const bool rend_whisker  = s.ErrorBarSize > 0;
@@ -2210,7 +2210,7 @@ void PlotStemsEx(const char* label_id, const _GetterM& getter_mark, const _Gette
             EndItem();
             return;
         }
-        color.fill_colors();
+        color.FillColors();
         const ImPlotNextItemData& s = GetItemData();
         // render stems
         if (s.RenderLine) {
@@ -2279,7 +2279,7 @@ void PlotInfLines(const char* label_id, const T* values, int count, ImPlotInfLin
                 EndItem();
                 return;
             }
-            color.fill_colors();
+            color.FillColors();
             const ImPlotNextItemData& s = GetItemData();
             if (s.RenderLine)
                 RenderPrimitives2<RendererLineSegments2>(getter_min, getter_max, color, s.LineWeight);
@@ -2294,7 +2294,7 @@ void PlotInfLines(const char* label_id, const T* values, int count, ImPlotInfLin
                 EndItem();
                 return;
             }
-            color.fill_colors();
+            color.FillColors();
             const ImPlotNextItemData& s = GetItemData();
             if (s.RenderLine)
                 RenderPrimitives2<RendererLineSegments2>(get_min, get_max, color, s.LineWeight);


### PR DESCRIPTION
Hello!
I've implemented user-settable per-item colors for line and scatter plots.
I've tried to match your coding style as close as I was able.
Please consider merging this pull request, or provide feedback how can I improve the implementation so it can be merged.
All previously available public plot APIs are unchanged.
I've added two new plot types:
```
typedef ImU32 (*ImPlotColorGetter)(ImPlotCol col, int idx, void* user_data);
IMPLOT_API void PlotLineCG(const char* label_id, ImPlotGetter getter_func, void* data, int count, ImPlotColorGetter color_func, void* color_data, ImPlotLineFlags flags=0);
IMPLOT_API void PlotScatterCG(const char* label_id, ImPlotGetter getter, void* data, int count, ImPlotColorGetter color_func, void* color_data, ImPlotScatterFlags flags=0);
``` 
The user can write a callback to set the item color based on the index.
I've added to the demo to showcase the new APIs.
The single-color plots are drawn with a new `struct ColorGetter` that is basically just a wrapper around `ImGui::GetColorU32(GetItemData().Colors[col])`.
I wanted to cache the plot colors so the ImVec4->ImU32 conversion happens only once. If you can give me any direction how can I achieve this more elegantly (than the current `fill_colors()`) please point me to the right direction. With this setup the ImVec4->ImU32 conversion happens only once, just as before with the single-color only version.
The per-item-colored plots are drawn with `struct ColorGetterFuncPtr`, implemented in the same style as `struct GetterXY` and `struct GetterFuncPtr`.
