### PR TITLE
Feature: Implementation of Per Point Custom Color for Line, Scatter and nd Contour

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -4596,6 +4596,19 @@ ImVec4 SampleColormap(float t, ImPlotColormap cmap) {
     return ImGui::ColorConvertU32ToFloat4(SampleColormapU32(t,cmap));
 }
 
+ImU32 ConvertValueToColor(float value, float v_min, float v_max, ImPlotColormap colormap) {
+    return SampleColormapU32(ImClamp(ImRemap01(value, v_min, v_max), 0.f, 1.f), colormap);
+}
+
+template <typename T>
+void ConvertValueToColor(T* value, ImU32* cs, int count, float v_min, float v_max, ImPlotColormap colormap) {
+    for (int i = 0; i < count; i++)
+        cs[i] = SampleColormapU32(ImClamp(ImRemap01(static_cast<float>(value[i]), v_min, v_max), 0.f, 1.f), colormap);
+}
+template void ConvertValueToColor<double>(double* value, ImU32* cs, int count, float v_min, float v_max, ImPlotColormap colormap);
+template void ConvertValueToColor<float>(float* value, ImU32* cs, int count, float v_min, float v_max, ImPlotColormap colormap);
+template void ConvertValueToColor<int>(int* value, ImU32* cs, int count, float v_min, float v_max, ImPlotColormap colormap);
+
 void RenderColorBar(const ImU32* colors, int size, ImDrawList& DrawList, const ImRect& bounds, bool vert, bool reversed, bool continuous) {
     const int n = continuous ? size - 1 : size;
     ImU32 col1, col2;


### PR DESCRIPTION
This PR provides the function that users can add an array storing the value at each point (such as temperature, density, etc.) and assign the color to each point according to the selected colormap. The existing functionality and invoking methods are not influenced by this modification. The demo can be found in the figures below. We also made similar implementation for ImPlot3D (https://github.com/brenocq/implot3d/pull/162) .

<img width="774" height="798" alt="PerPointCustomColor_Lines" src="https://github.com/user-attachments/assets/8f847a6f-0198-4477-9ade-9bbf1921f028" />
<img width="770" height="585" alt="PerPointCustomColor_Scatters" src="https://github.com/user-attachments/assets/77c8f741-62b2-49ef-aa44-2873f23c907f" />
<img width="767" height="957" alt="PerPointCustomColor_Contour" src="https://github.com/user-attachments/assets/afdcfa60-eca7-4bbc-bdb3-151362e8633c" />
