### PR TITLE
Feat: Add flag to draw axis tick labels inside the plot area

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -1642,14 +1642,27 @@ void PadAndDatumAxesX(ImPlotPlot& plot, float& pad_T, float& pad_B, ImPlotAlignm
     float last_T  = plot.AxesRect.Min.y;
     float last_B  = plot.AxesRect.Max.y;
 
+    int first_axis_index = -1;
+    int first_opp_axis_index = -1;
+    for (int i = 0; i < IMPLOT_NUM_X_AXES; i++) {
+        ImPlotAxis& axis = plot.XAxis(i);
+        if (!axis.Enabled)
+            continue;
+        const bool opp = axis.IsOpposite();
+        if (opp && first_opp_axis_index == -1)
+            first_opp_axis_index = i;
+        if (!opp && first_axis_index == -1)
+            first_axis_index = i;
+    }
+
     for (int i = IMPLOT_NUM_X_AXES; i-- > 0;) { // FYI: can iterate forward
         ImPlotAxis& axis = plot.XAxis(i);
         if (!axis.Enabled)
             continue;
         const bool label = axis.HasLabel();
         const bool ticks = axis.HasTickLabels();
-        const bool ins   = axis.HasTickLabelsInside();
         const bool opp   = axis.IsOpposite();
+        const bool ins   = axis.HasTickLabelsInside() && (i == (opp ? first_opp_axis_index : first_axis_index));
         const bool time  = axis.Scale == ImPlotScale_Time;
         if (opp) {
             if (count_T++ > 0)
@@ -1723,14 +1736,27 @@ void PadAndDatumAxesY(ImPlotPlot& plot, float& pad_L, float& pad_R, ImPlotAlignm
     float last_L  = plot.AxesRect.Min.x;
     float last_R  = plot.AxesRect.Max.x;
 
+    int first_axis_index = -1;
+    int first_opp_axis_index = -1;
+    for (int i = 0; i < IMPLOT_NUM_Y_AXES; i++) {
+        ImPlotAxis& axis = plot.YAxis(i);
+        if (!axis.Enabled)
+            continue;
+        const bool opp = axis.IsOpposite();
+        if (opp && first_opp_axis_index == -1)
+            first_opp_axis_index = i;
+        if (!opp && first_axis_index == -1)
+            first_axis_index = i;
+    }
+
     for (int i = IMPLOT_NUM_Y_AXES; i-- > 0;) { // FYI: can iterate forward
         ImPlotAxis& axis = plot.YAxis(i);
         if (!axis.Enabled)
             continue;
         const bool label = axis.HasLabel();
         const bool ticks = axis.HasTickLabels();
-        const bool ins   = axis.HasTickLabelsInside();
         const bool opp   = axis.IsOpposite();
+        const bool ins   = axis.HasTickLabelsInside() && (i == (opp ? first_opp_axis_index : first_axis_index));
         if (opp) {
             if (count_R++ > 0)
                 pad_R += K + P;
@@ -2682,6 +2708,8 @@ void SetupFinish() {
     }
 
     // render x axis button, label, tick labels
+    bool is_first_x_axis = true;
+    bool is_first_opp_x_axis = true;
     for (int i = 0; i < IMPLOT_NUM_X_AXES; i++) {
         ImPlotAxis& ax = plot.XAxis(i);
         if (!ax.Enabled)
@@ -2697,7 +2725,7 @@ void SetupFinish() {
         }
         const ImPlotTicker& tkr = ax.Ticker;
         const bool opp = ax.IsOpposite();
-        const bool ins = ax.HasTickLabelsInside();
+        const bool ins = ax.HasTickLabelsInside() && (opp ? is_first_opp_x_axis : is_first_x_axis);
         if (ax.HasLabel()) {
             const char* label        = plot.GetAxisLabel(ax);
             const ImVec2 label_size  = ImGui::CalcTextSize(label);
@@ -2720,9 +2748,12 @@ void SetupFinish() {
                 }
             }
         }
+        (opp ? is_first_opp_x_axis : is_first_x_axis) = false;
     }
 
     // render y axis button, label, tick labels
+    bool is_first_y_axis = true;
+    bool is_first_opp_y_axis = true;
     for (int i = 0; i < IMPLOT_NUM_Y_AXES; i++) {
         ImPlotAxis& ax = plot.YAxis(i);
         if (!ax.Enabled)
@@ -2738,7 +2769,7 @@ void SetupFinish() {
         }
         const ImPlotTicker& tkr = ax.Ticker;
         const bool opp = ax.IsOpposite();
-        const bool ins = ax.HasTickLabelsInside();
+        const bool ins = ax.HasTickLabelsInside() && (opp ? is_first_opp_y_axis : is_first_y_axis);
         if (ax.HasLabel()) {
             const char* label        = plot.GetAxisLabel(ax);
             const ImVec2 label_size  = CalcTextSizeVertical(label);
@@ -2759,6 +2790,7 @@ void SetupFinish() {
                 }
             }
         }
+        (opp ? is_first_opp_y_axis : is_first_y_axis) = false;
     }
 
 

--- a/implot.cpp
+++ b/implot.cpp
@@ -2820,7 +2820,6 @@ void EndPlot() {
             continue;
         const ImPlotTicker& tkr = ax.Ticker;
         const bool opp = ax.IsOpposite();
-        const bool ins = ax.HasTickLabelsInside();
         const bool aux = ((opp && count_T > 0)||(!opp && count_B > 0));
         if (ax.HasTickMarks()) {
             const float direction = opp ? 1.0f : -1.0f;
@@ -2848,7 +2847,6 @@ void EndPlot() {
             continue;
         const ImPlotTicker& tkr = ax.Ticker;
         const bool opp = ax.IsOpposite();
-        const bool ins = ax.HasTickLabelsInside();
         const bool aux = ((opp && count_R > 0)||(!opp && count_L > 0));
         if (ax.HasTickMarks()) {
             const float direction = opp ? -1.0f : 1.0f;

--- a/implot.cpp
+++ b/implot.cpp
@@ -1730,6 +1730,9 @@ void PadAndDatumAxesX(ImPlotPlot& plot, float& pad_T, float& pad_B, int innermos
             }
             if (ticks && !ins)
                 pad_T += ImMax(T, axis.Ticker.MaxSize.y) + P + (time ? T + P : 0);
+            // fix ins axis rect overlapping plot title if no label is present and there are no other axes above
+            if (ins && !label && count_T == 1 && plot.HasTitle())
+                pad_T += K + P;
             axis.Datum1 = plot.CanvasRect.Min.y + pad_T;
             axis.Datum2 = last_T;
             last_T = axis.Datum1;

--- a/implot.cpp
+++ b/implot.cpp
@@ -2805,11 +2805,14 @@ void SetupFinish() {
             DrawList.AddText(label_pos, ax.ColorTxt, label);
         }
         if (ax.HasTickLabels()) {
+            const bool has_labels_above_axis = opp ^ ins;
+            const float label_pad_dir        = has_labels_above_axis ? -1.0f : 1.0f;
+            const float label_pad            = label_pad_dir * ((ins ? gp.Style.MajorTickLen.y : gp.Style.LabelPadding.y)
+                                                                + (has_labels_above_axis ? tkr.MaxSize.y : 0));
+            const float label_pad_per_level  = label_pad_dir * (txt_height + gp.Style.LabelPadding.y);
             for (int j = 0; j < tkr.TickCount(); ++j) {
                 const ImPlotTick& tk = tkr.Ticks[j];
-                const float datum = ax.Datum1 + ((opp ^ ins) ? (-gp.Style.LabelPadding.y -txt_height -tk.Level * (txt_height + gp.Style.LabelPadding.y))
-                                                             : gp.Style.LabelPadding.y + tk.Level * (txt_height + gp.Style.LabelPadding.y))
-                                  - ((ins ? gp.Style.LabelPadding.y : 0.0f) * (opp ? -1.0f : 1.0f));
+                const float datum = ax.Datum1 + label_pad + tk.Level * label_pad_per_level;
                 if (tk.ShowLabel && tk.PixelPos >= plot.PlotRect.Min.x - 1 && tk.PixelPos <= plot.PlotRect.Max.x + 1) {
                     ImVec2 start(tk.PixelPos - 0.5f * tk.LabelSize.x, datum);
                     DrawList.AddText(start, ax.ColorTxt, tkr.GetText(j));

--- a/implot.cpp
+++ b/implot.cpp
@@ -2805,14 +2805,13 @@ void SetupFinish() {
             DrawList.AddText(label_pos, ax.ColorTxt, label);
         }
         if (ax.HasTickLabels()) {
-            const bool has_labels_above_axis = opp ^ ins;
-            const float label_pad_dir        = has_labels_above_axis ? -1.0f : 1.0f;
-            const float label_pad            = label_pad_dir * ((ins ? gp.Style.MajorTickLen.y : gp.Style.LabelPadding.y)
-                                                                + (has_labels_above_axis ? tkr.MaxSize.y : 0));
-            const float label_pad_per_level  = label_pad_dir * (txt_height + gp.Style.LabelPadding.y);
+            const bool labels_opp = opp ^ ins;
+            const float label_pad = ins ? gp.Style.MajorTickLen.y : gp.Style.LabelPadding.y;
+            const float level_pad = txt_height + gp.Style.LabelPadding.y;
             for (int j = 0; j < tkr.TickCount(); ++j) {
                 const ImPlotTick& tk = tkr.Ticks[j];
-                const float datum = ax.Datum1 + label_pad + tk.Level * label_pad_per_level;
+                const float pad   = label_pad + (labels_opp ? tk.LabelSize.y : 0) + (tk.Level * level_pad);
+                const float datum = ax.Datum1 + pad * (labels_opp ? -1.0f : 1.0f);
                 if (tk.ShowLabel && tk.PixelPos >= plot.PlotRect.Min.x - 1 && tk.PixelPos <= plot.PlotRect.Max.x + 1) {
                     ImVec2 start(tk.PixelPos - 0.5f * tk.LabelSize.x, datum);
                     DrawList.AddText(start, ax.ColorTxt, tkr.GetText(j));
@@ -2848,10 +2847,12 @@ void SetupFinish() {
             AddTextVertical(&DrawList, label_pos, ax.ColorTxt, label);
         }
         if (ax.HasTickLabels()) {
+            const bool labels_opp = opp ^ ins;
+            const float label_pad = ins ? gp.Style.MajorTickLen.x : gp.Style.LabelPadding.x;
             for (int j = 0; j < tkr.TickCount(); ++j) {
                 const ImPlotTick& tk = tkr.Ticks[j];
-                const float datum = ax.Datum1 + ((opp ^ ins) ? gp.Style.LabelPadding.x : (-gp.Style.LabelPadding.x - tk.LabelSize.x))
-                                  + ((ins ? gp.Style.LabelPadding.x : 0.0f) * (opp ? -1.0f : 1.0f));
+                const float pad   = label_pad + (labels_opp ? 0 : tk.LabelSize.x);
+                const float datum = ax.Datum1 + pad * (labels_opp ? 1.0f : -1.0f);
                 if (tk.ShowLabel && tk.PixelPos >= plot.PlotRect.Min.y - 1 && tk.PixelPos <= plot.PlotRect.Max.y + 1) {
                     ImVec2 start(datum, tk.PixelPos - 0.5f * tk.LabelSize.y);
                     DrawList.AddText(start, ax.ColorTxt, tkr.GetText(j));

--- a/implot.h
+++ b/implot.h
@@ -147,27 +147,27 @@ enum ImPlotFlags_ {
 
 // Options for plot axes (see SetupAxis).
 enum ImPlotAxisFlags_ {
-    ImPlotAxisFlags_None          = 0,       // default
-    ImPlotAxisFlags_NoLabel       = 1 << 0,  // the axis label will not be displayed (axis labels are also hidden if the supplied string name is nullptr)
-    ImPlotAxisFlags_NoGridLines   = 1 << 1,  // no grid lines will be displayed
-    ImPlotAxisFlags_NoTickMarks   = 1 << 2,  // no tick marks will be displayed
-    ImPlotAxisFlags_NoTickLabels  = 1 << 3,  // no text labels will be displayed
-    ImPlotAxisFlags_NoInitialFit  = 1 << 4,  // axis will not be initially fit to data extents on the first rendered frame
-    ImPlotAxisFlags_NoMenus       = 1 << 5,  // the user will not be able to open context menus with right-click
-    ImPlotAxisFlags_NoSideSwitch  = 1 << 6,  // the user will not be able to switch the axis side by dragging it
-    ImPlotAxisFlags_NoHighlight   = 1 << 7,  // the axis will not have its background highlighted when hovered or held
-    ImPlotAxisFlags_Opposite      = 1 << 8,  // axis ticks and labels will be rendered on the conventionally opposite side (i.e, right or top)
-    ImPlotAxisFlags_Foreground    = 1 << 9,  // grid lines will be displayed in the foreground (i.e. on top of data) instead of the background
-    ImPlotAxisFlags_Invert        = 1 << 10, // the axis will be inverted
-    ImPlotAxisFlags_AutoFit       = 1 << 11, // axis will be auto-fitting to data extents
-    ImPlotAxisFlags_RangeFit      = 1 << 12, // axis will only fit points if the point is in the visible range of the **orthogonal** axis
-    ImPlotAxisFlags_PanStretch    = 1 << 13, // panning in a locked or constrained state will cause the axis to stretch if possible
-    ImPlotAxisFlags_LockMin       = 1 << 14, // the axis minimum value will be locked when panning/zooming
-    ImPlotAxisFlags_LockMax       = 1 << 15, // the axis maximum value will be locked when panning/zooming
+    ImPlotAxisFlags_None             = 0,       // default
+    ImPlotAxisFlags_NoLabel          = 1 << 0,  // the axis label will not be displayed (axis labels are also hidden if the supplied string name is nullptr)
+    ImPlotAxisFlags_NoGridLines      = 1 << 1,  // no grid lines will be displayed
+    ImPlotAxisFlags_NoTickMarks      = 1 << 2,  // no tick marks will be displayed
+    ImPlotAxisFlags_NoTickLabels     = 1 << 3,  // no text labels will be displayed
+    ImPlotAxisFlags_NoInitialFit     = 1 << 4,  // axis will not be initially fit to data extents on the first rendered frame
+    ImPlotAxisFlags_NoMenus          = 1 << 5,  // the user will not be able to open context menus with right-click
+    ImPlotAxisFlags_NoSideSwitch     = 1 << 6,  // the user will not be able to switch the axis side by dragging it
+    ImPlotAxisFlags_NoHighlight      = 1 << 7,  // the axis will not have its background highlighted when hovered or held
+    ImPlotAxisFlags_Opposite         = 1 << 8,  // axis ticks and labels will be rendered on the conventionally opposite side (i.e, right or top)
+    ImPlotAxisFlags_Foreground       = 1 << 9,  // grid lines will be displayed in the foreground (i.e. on top of data) instead of the background
+    ImPlotAxisFlags_Invert           = 1 << 10, // the axis will be inverted
+    ImPlotAxisFlags_AutoFit          = 1 << 11, // axis will be auto-fitting to data extents
+    ImPlotAxisFlags_RangeFit         = 1 << 12, // axis will only fit points if the point is in the visible range of the **orthogonal** axis
+    ImPlotAxisFlags_PanStretch       = 1 << 13, // panning in a locked or constrained state will cause the axis to stretch if possible
+    ImPlotAxisFlags_LockMin          = 1 << 14, // the axis minimum value will be locked when panning/zooming
+    ImPlotAxisFlags_LockMax          = 1 << 15, // the axis maximum value will be locked when panning/zooming
     ImPlotAxisFlags_TickLabelsInside = 1 << 16, // text labels will be drawn inside the plot area
-    ImPlotAxisFlags_Lock          = ImPlotAxisFlags_LockMin | ImPlotAxisFlags_LockMax,
-    ImPlotAxisFlags_NoDecorations = ImPlotAxisFlags_NoLabel | ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_NoTickMarks | ImPlotAxisFlags_NoTickLabels,
-    ImPlotAxisFlags_AuxDefault    = ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_Opposite
+    ImPlotAxisFlags_Lock             = ImPlotAxisFlags_LockMin | ImPlotAxisFlags_LockMax,
+    ImPlotAxisFlags_NoDecorations    = ImPlotAxisFlags_NoLabel | ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_NoTickMarks | ImPlotAxisFlags_NoTickLabels,
+    ImPlotAxisFlags_AuxDefault       = ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_Opposite
 };
 
 // Options for subplots (see BeginSubplot)

--- a/implot.h
+++ b/implot.h
@@ -164,7 +164,7 @@ enum ImPlotAxisFlags_ {
     ImPlotAxisFlags_PanStretch       = 1 << 13, // panning in a locked or constrained state will cause the axis to stretch if possible
     ImPlotAxisFlags_LockMin          = 1 << 14, // the axis minimum value will be locked when panning/zooming
     ImPlotAxisFlags_LockMax          = 1 << 15, // the axis maximum value will be locked when panning/zooming
-    ImPlotAxisFlags_TickLabelsInside = 1 << 16, // text labels will be drawn inside the plot area
+    ImPlotAxisFlags_TickLabelsInside = 1 << 16, // axis tick labels will be drawn inside the plot area (applies only to the innermost axes)
     ImPlotAxisFlags_Lock             = ImPlotAxisFlags_LockMin | ImPlotAxisFlags_LockMax,
     ImPlotAxisFlags_NoDecorations    = ImPlotAxisFlags_NoLabel | ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_NoTickMarks | ImPlotAxisFlags_NoTickLabels,
     ImPlotAxisFlags_AuxDefault       = ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_Opposite

--- a/implot.h
+++ b/implot.h
@@ -164,6 +164,7 @@ enum ImPlotAxisFlags_ {
     ImPlotAxisFlags_PanStretch    = 1 << 13, // panning in a locked or constrained state will cause the axis to stretch if possible
     ImPlotAxisFlags_LockMin       = 1 << 14, // the axis minimum value will be locked when panning/zooming
     ImPlotAxisFlags_LockMax       = 1 << 15, // the axis maximum value will be locked when panning/zooming
+    ImPlotAxisFlags_TickLabelsInside = 1 << 16, // text labels will be drawn inside the plot area
     ImPlotAxisFlags_Lock          = ImPlotAxisFlags_LockMin | ImPlotAxisFlags_LockMax,
     ImPlotAxisFlags_NoDecorations = ImPlotAxisFlags_NoLabel | ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_NoTickMarks | ImPlotAxisFlags_NoTickLabels,
     ImPlotAxisFlags_AuxDefault    = ImPlotAxisFlags_NoGridLines | ImPlotAxisFlags_Opposite

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -892,6 +892,7 @@ struct ImPlotAxis
     inline bool HasLabel()          const { return LabelOffset != -1 && !ImHasFlag(Flags, ImPlotAxisFlags_NoLabel);                          }
     inline bool HasGridLines()      const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoGridLines);                                           }
     inline bool HasTickLabels()     const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoTickLabels);                                          }
+    inline bool HasTickLabelsInside() const { return ImHasFlag(Flags, ImPlotAxisFlags_TickLabelsInside);                                     }
     inline bool HasTickMarks()      const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoTickMarks);                                           }
     inline bool WillRender()        const { return Enabled && (HasGridLines() || HasTickLabels() || HasTickMarks());                         }
     inline bool IsOpposite()        const { return ImHasFlag(Flags, ImPlotAxisFlags_Opposite);                                               }

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -889,25 +889,25 @@ struct ImPlotAxis
         UpdateTransformCache();
     }
 
-    inline bool HasLabel()          const { return LabelOffset != -1 && !ImHasFlag(Flags, ImPlotAxisFlags_NoLabel);                          }
-    inline bool HasGridLines()      const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoGridLines);                                           }
-    inline bool HasTickLabels()     const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoTickLabels);                                          }
-    inline bool HasTickLabelsInside() const { return ImHasFlag(Flags, ImPlotAxisFlags_TickLabelsInside);                                     }
-    inline bool HasTickMarks()      const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoTickMarks);                                           }
-    inline bool WillRender()        const { return Enabled && (HasGridLines() || HasTickLabels() || HasTickMarks());                         }
-    inline bool IsOpposite()        const { return ImHasFlag(Flags, ImPlotAxisFlags_Opposite);                                               }
-    inline bool IsInverted()        const { return ImHasFlag(Flags, ImPlotAxisFlags_Invert);                                                 }
-    inline bool IsForeground()      const { return ImHasFlag(Flags, ImPlotAxisFlags_Foreground);                                             }
-    inline bool IsAutoFitting()     const { return ImHasFlag(Flags, ImPlotAxisFlags_AutoFit);                                                }
-    inline bool CanInitFit()        const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoInitialFit) && !HasRange && !LinkedMin && !LinkedMax; }
-    inline bool IsRangeLocked()     const { return HasRange && RangeCond == ImPlotCond_Always;                                               }
-    inline bool IsLockedMin()       const { return !Enabled || IsRangeLocked() || ImHasFlag(Flags, ImPlotAxisFlags_LockMin);                 }
-    inline bool IsLockedMax()       const { return !Enabled || IsRangeLocked() || ImHasFlag(Flags, ImPlotAxisFlags_LockMax);                 }
-    inline bool IsLocked()          const { return IsLockedMin() && IsLockedMax();                                                           }
-    inline bool IsInputLockedMin()  const { return IsLockedMin() || IsAutoFitting();                                                         }
-    inline bool IsInputLockedMax()  const { return IsLockedMax() || IsAutoFitting();                                                         }
-    inline bool IsInputLocked()     const { return IsLocked()    || IsAutoFitting();                                                         }
-    inline bool HasMenus()          const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoMenus);                                               }
+    inline bool HasLabel()            const { return LabelOffset != -1 && !ImHasFlag(Flags, ImPlotAxisFlags_NoLabel);                          }
+    inline bool HasGridLines()        const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoGridLines);                                           }
+    inline bool HasTickLabels()       const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoTickLabels);                                          }
+    inline bool HasTickLabelsInside() const { return ImHasFlag(Flags, ImPlotAxisFlags_TickLabelsInside);                                       }
+    inline bool HasTickMarks()        const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoTickMarks);                                           }
+    inline bool WillRender()          const { return Enabled && (HasGridLines() || HasTickLabels() || HasTickMarks());                         }
+    inline bool IsOpposite()          const { return ImHasFlag(Flags, ImPlotAxisFlags_Opposite);                                               }
+    inline bool IsInverted()          const { return ImHasFlag(Flags, ImPlotAxisFlags_Invert);                                                 }
+    inline bool IsForeground()        const { return ImHasFlag(Flags, ImPlotAxisFlags_Foreground);                                             }
+    inline bool IsAutoFitting()       const { return ImHasFlag(Flags, ImPlotAxisFlags_AutoFit);                                                }
+    inline bool CanInitFit()          const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoInitialFit) && !HasRange && !LinkedMin && !LinkedMax; }
+    inline bool IsRangeLocked()       const { return HasRange && RangeCond == ImPlotCond_Always;                                               }
+    inline bool IsLockedMin()         const { return !Enabled || IsRangeLocked() || ImHasFlag(Flags, ImPlotAxisFlags_LockMin);                 }
+    inline bool IsLockedMax()         const { return !Enabled || IsRangeLocked() || ImHasFlag(Flags, ImPlotAxisFlags_LockMax);                 }
+    inline bool IsLocked()            const { return IsLockedMin() && IsLockedMax();                                                           }
+    inline bool IsInputLockedMin()    const { return IsLockedMin() || IsAutoFitting();                                                         }
+    inline bool IsInputLockedMax()    const { return IsLockedMax() || IsAutoFitting();                                                         }
+    inline bool IsInputLocked()       const { return IsLocked()    || IsAutoFitting();                                                         }
+    inline bool HasMenus()            const { return !ImHasFlag(Flags, ImPlotAxisFlags_NoMenus);                                               }
 
     inline bool IsPanLocked(bool increasing) {
         if (ImHasFlag(Flags, ImPlotAxisFlags_PanStretch)) {


### PR DESCRIPTION
Closes #607

The PR adds a ImPlotAxisFlags_TickLabelsInside flag that moves the tick labels into the plot area, saving space around the plot and making the plot area larger. It applies only to the innermost axes - at most 4 a time (X + Y and default + opposite).

It's useful when multiple plots have to be aligned, but some of them have much longer labels than the others and the final padding becomes significant.

<img width="807" height="723" alt="2026-01-17-151454" src="https://github.com/user-attachments/assets/f1ee8de6-c49d-41bd-8d4c-123fcab769ec" />
