### PR TITLE
Feat: Per-Index Color/Size Support with ImPlotSpec

### DIFF
--- a/implot.h
+++ b/implot.h
@@ -137,8 +137,10 @@ enum ImAxis_ {
 // Plotting properties. These provide syntactic sugar for creating ImPlotSpecs from (ImPlotProp,value) pairs. See ImPlotSpec documentation.
 enum ImPlotProp_ {
     ImPlotProp_LineColor,       // line color (applies to lines, bar edges); IMPLOT_AUTO_COL will use next Colormap color or current item color
+    ImPlotProp_LineColors,      // array of colors for each line; if nullptr, use LineColor for all lines
     ImPlotProp_LineWeight,      // line weight in pixels (applies to lines, bar edges, marker edges)
     ImPlotProp_FillColor,       // fill color (applies to shaded regions, bar faces); IMPLOT_AUTO_COL will use next Colormap color or current item color
+    ImPlotProp_FillColors,      // array of colors for each fill; if nullptr, use FillColor for all fills
     ImPlotProp_FillAlpha,       // alpha multiplier (applies to FillColor and MarkerFillColor)
     ImPlotProp_Marker,          // marker type; specify ImPlotMarker_Auto to use the next unused marker
     ImPlotProp_MarkerSize,      // size of markers (radius) *in pixels*
@@ -501,8 +503,10 @@ enum ImPlotBin_ {
 //    });
 struct ImPlotSpec {
     ImVec4          LineColor       = IMPLOT_AUTO_COL;       // line color (applies to lines, bar edges); IMPLOT_AUTO_COL will use next Colormap color or current item color
+    ImU32*          LineColors      = nullptr;               // array of colors for each line; if nullptr, use LineColor for all lines
     float           LineWeight      = 1.0f;                  // line weight in pixels (applies to lines, bar edges, marker edges)
     ImVec4          FillColor       = IMPLOT_AUTO_COL;       // fill color (applies to shaded regions, bar faces); IMPLOT_AUTO_COL will use next Colormap color or current item color
+    ImU32*          FillColors      = nullptr;               // array of colors for each fill; if nullptr, use FillColor for all fills
     float           FillAlpha       = 1.0f;                  // alpha multiplier (applies to FillColor and MarkerFillColor)
     ImPlotMarker    Marker          = ImPlotMarker_None;     // marker type; specify ImPlotMarker_Auto to use the next unused marker
     float           MarkerSize      = 4;                     // size of markers (radius) *in pixels*
@@ -549,6 +553,16 @@ struct ImPlotSpec {
         default: break;
         }
         IM_ASSERT(0 && "User provided an ImPlotProp which cannot be set from scalar value!");
+    }
+
+    // Set a property from a pointer value.
+    void SetProp(ImPlotProp prop, ImU32* v) {
+        switch (prop) {
+        case ImPlotProp_LineColors      : LineColors      = v;  return;
+        case ImPlotProp_FillColors      : FillColors      = v;  return;
+        default: break;
+        }
+        IM_ASSERT(0 && "User provided an ImPlotProp which cannot be set from pointer value!");
     }
 
     // Set a property from an ImVec4 value.

--- a/implot.h
+++ b/implot.h
@@ -144,6 +144,7 @@ enum ImPlotProp_ {
     ImPlotProp_FillAlpha,       // alpha multiplier (applies to FillColor, FillColors, MarkerFillColor, and MarkerFillColors)
     ImPlotProp_Marker,          // marker type; specify ImPlotMarker_Auto to use the next unused marker
     ImPlotProp_MarkerSize,      // size of markers (radius) *in pixels*
+    ImPlotProp_MarkerSizes,     // array of sizes for each marker; if nullptr, use MarkerSize for all markers
     ImPlotProp_MarkerLineColor, // marker edge color; IMPLOT_AUTO_COL will use LineColor
     ImPlotProp_MarkerLineColors, // array of colors for each marker edge; if nullptr, use MarkerLineColor for all markers
     ImPlotProp_MarkerFillColor, // marker face color; IMPLOT_AUTO_COL will use LineColor
@@ -512,6 +513,7 @@ struct ImPlotSpec {
     float           FillAlpha       = 1.0f;                  // alpha multiplier (applies to FillColor, FillColors, MarkerFillColor, and MarkerFillColors)
     ImPlotMarker    Marker          = ImPlotMarker_None;     // marker type; specify ImPlotMarker_Auto to use the next unused marker
     float           MarkerSize      = 4;                     // size of markers (radius) *in pixels*
+    float*          MarkerSizes     = nullptr;               // array of sizes for each marker; if nullptr, use MarkerSize for all markers
     ImVec4          MarkerLineColor = IMPLOT_AUTO_COL;       // marker edge color; IMPLOT_AUTO_COL will use LineColor
     ImU32*          MarkerLineColors = nullptr;              // array of colors for each marker edge; if nullptr, use MarkerLineColor for all markers
     ImVec4          MarkerFillColor = IMPLOT_AUTO_COL;       // marker face color; IMPLOT_AUTO_COL will use LineColor
@@ -569,6 +571,15 @@ struct ImPlotSpec {
         default: break;
         }
         IM_ASSERT(0 && "User provided an ImPlotProp which cannot be set from pointer value!");
+    }
+
+    // Set a property from a float pointer value.
+    void SetProp(ImPlotProp prop, float* v) {
+        switch (prop) {
+        case ImPlotProp_MarkerSizes : MarkerSizes = v; return;
+        default: break;
+        }
+        IM_ASSERT(0 && "User provided an ImPlotProp which cannot be set from float pointer value!");
     }
 
     // Set a property from an ImVec4 value.

--- a/implot.h
+++ b/implot.h
@@ -141,11 +141,13 @@ enum ImPlotProp_ {
     ImPlotProp_LineWeight,      // line weight in pixels (applies to lines, bar edges, marker edges)
     ImPlotProp_FillColor,       // fill color (applies to shaded regions, bar faces); IMPLOT_AUTO_COL will use next Colormap color or current item color
     ImPlotProp_FillColors,      // array of colors for each fill; if nullptr, use FillColor for all fills
-    ImPlotProp_FillAlpha,       // alpha multiplier (applies to FillColor and MarkerFillColor)
+    ImPlotProp_FillAlpha,       // alpha multiplier (applies to FillColor, FillColors, MarkerFillColor, and MarkerFillColors)
     ImPlotProp_Marker,          // marker type; specify ImPlotMarker_Auto to use the next unused marker
     ImPlotProp_MarkerSize,      // size of markers (radius) *in pixels*
     ImPlotProp_MarkerLineColor, // marker edge color; IMPLOT_AUTO_COL will use LineColor
+    ImPlotProp_MarkerLineColors, // array of colors for each marker edge; if nullptr, use MarkerLineColor for all markers
     ImPlotProp_MarkerFillColor, // marker face color; IMPLOT_AUTO_COL will use LineColor
+    ImPlotProp_MarkerFillColors, // array of colors for each marker face; if nullptr, use MarkerFillColor for all markers
     ImPlotProp_Size,            // size of error bar whiskers (width or height), and digital bars (height) *in pixels*
     ImPlotProp_Offset,          // data index offset
     ImPlotProp_Stride,          // data stride in bytes; IMPLOT_AUTO will result in sizeof(T) where T is the type passed to PlotX
@@ -507,11 +509,13 @@ struct ImPlotSpec {
     float           LineWeight      = 1.0f;                  // line weight in pixels (applies to lines, bar edges, marker edges)
     ImVec4          FillColor       = IMPLOT_AUTO_COL;       // fill color (applies to shaded regions, bar faces); IMPLOT_AUTO_COL will use next Colormap color or current item color
     ImU32*          FillColors      = nullptr;               // array of colors for each fill; if nullptr, use FillColor for all fills
-    float           FillAlpha       = 1.0f;                  // alpha multiplier (applies to FillColor and MarkerFillColor)
+    float           FillAlpha       = 1.0f;                  // alpha multiplier (applies to FillColor, FillColors, MarkerFillColor, and MarkerFillColors)
     ImPlotMarker    Marker          = ImPlotMarker_None;     // marker type; specify ImPlotMarker_Auto to use the next unused marker
     float           MarkerSize      = 4;                     // size of markers (radius) *in pixels*
     ImVec4          MarkerLineColor = IMPLOT_AUTO_COL;       // marker edge color; IMPLOT_AUTO_COL will use LineColor
+    ImU32*          MarkerLineColors = nullptr;              // array of colors for each marker edge; if nullptr, use MarkerLineColor for all markers
     ImVec4          MarkerFillColor = IMPLOT_AUTO_COL;       // marker face color; IMPLOT_AUTO_COL will use LineColor
+    ImU32*          MarkerFillColors = nullptr;              // array of colors for each marker face; if nullptr, use MarkerFillColor for all markers
     float           Size            = 4;                     // size of error bar whiskers (width or height), and digital bars (height) *in pixels*
     int             Offset          = 0;                     // data index offset
     int             Stride          = IMPLOT_AUTO;           // data stride in bytes; IMPLOT_AUTO will result in sizeof(T) where T is the type passed to PlotX
@@ -558,8 +562,10 @@ struct ImPlotSpec {
     // Set a property from a pointer value.
     void SetProp(ImPlotProp prop, ImU32* v) {
         switch (prop) {
-        case ImPlotProp_LineColors      : LineColors      = v;  return;
-        case ImPlotProp_FillColors      : FillColors      = v;  return;
+        case ImPlotProp_LineColors       : LineColors       = v;  return;
+        case ImPlotProp_FillColors       : FillColors       = v;  return;
+        case ImPlotProp_MarkerLineColors : MarkerLineColors = v;  return;
+        case ImPlotProp_MarkerFillColors : MarkerFillColors = v;  return;
         default: break;
         }
         IM_ASSERT(0 && "User provided an ImPlotProp which cannot be set from pointer value!");

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1194,6 +1194,44 @@ void Demo_PerIndexColors() {
         ImPlot::EndPlot();
     }
 
+    // Colorful Scatter (matches Demo_ScatterPlots structure with per-marker colors)
+    srand(0);
+    static float xs_scatter1[100], ys_scatter1[100];
+    static ImU32 colors_scatter1_fill[100], colors_scatter1_line[100];
+    for (int i = 0; i < 100; ++i) {
+        xs_scatter1[i] = i * 0.01f;
+        ys_scatter1[i] = xs_scatter1[i] + 0.1f * ((float)rand() / (float)RAND_MAX);
+        // Rainbow hue colors
+        float hue = i / 99.0f;
+        colors_scatter1_fill[i] = ImColor::HSV(hue, 0.8f, 0.9f);
+        colors_scatter1_line[i] = ImColor::HSV(hue, 0.9f, 0.7f);
+    }
+    static float xs_scatter2[50], ys_scatter2[50];
+    static ImU32 colors_scatter2[50];
+    for (int i = 0; i < 50; i++) {
+        xs_scatter2[i] = 0.25f + 0.2f * ((float)rand() / (float)RAND_MAX);
+        ys_scatter2[i] = 0.75f + 0.2f * ((float)rand() / (float)RAND_MAX);
+        // Colormap colors (Viridis)
+        float t = i / 49.0f;
+        ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
+        colors_scatter2[i] = ImGui::GetColorU32(color);
+    }
+
+    if (ImPlot::BeginPlot("Colorful Scatter", ImVec2(-1,0))) {
+        ImPlot::PlotScatter("Data 1", xs_scatter1, ys_scatter1, 100, {
+            ImPlotProp_MarkerFillColors, colors_scatter1_fill,
+            ImPlotProp_MarkerLineColors, colors_scatter1_line,
+        });
+        ImPlot::PlotScatter("Data 2", xs_scatter2, ys_scatter2, 50, {
+            ImPlotProp_Marker, ImPlotMarker_Square,
+            ImPlotProp_MarkerSize, 6,
+            ImPlotProp_MarkerFillColors, colors_scatter2,
+            ImPlotProp_MarkerLineColors, colors_scatter2,
+            ImPlotProp_FillAlpha, 0.5f,
+        });
+        ImPlot::EndPlot();
+    }
+
     if (ImPlot::BeginPlot("Colorful Stairs", ImVec2(-1,0))) {
         ImPlot::SetupAxes("x","y");
         ImPlot::SetupAxesLimits(0, 1, -1.5, 1.5);

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1061,6 +1061,26 @@ void Demo_NaNValues() {
 
 //-----------------------------------------------------------------------------
 
+void Demo_PerPointColors() {
+    static float xs1[1001], ys1[1001];
+    static ImU32 colors1[1001];
+    for (int i = 0; i < 1001; ++i) {
+        xs1[i] = i * 0.001f;
+        ys1[i] = 0.5f + 0.5f * sinf(50 * (xs1[i] + (float)ImGui::GetTime() / 10));
+        colors1[i] = ImGui::GetColorU32(ImVec4(ys1[i], 0.5f, 1.0f - ys1[i], 1.0f));
+    }
+
+    if (ImPlot::BeginPlot("Colorful Line Plot", ImVec2(-1,0))) {
+        ImPlot::PlotLine("f(x)", xs1, ys1, 1001, {
+            ImPlotProp_LineColor, ImVec4(1,0,1,1),
+            ImPlotProp_LineColors, colors1,
+        });
+        ImPlot::EndPlot();
+    }
+}
+
+//-----------------------------------------------------------------------------
+
 void Demo_LogScale() {
     static double xs[1001], ys1[1001], ys2[1001], ys3[1001];
     for (int i = 0; i < 1001; ++i) {
@@ -2396,6 +2416,7 @@ void ShowDemoWindow(bool* p_open) {
             DemoHeader("Images", Demo_Images);
             DemoHeader("Markers and Text", Demo_MarkersAndText);
             DemoHeader("NaN Values", Demo_NaNValues);
+            DemoHeader("Per Point Colors", Demo_PerPointColors);
             ImGui::EndTabItem();
         }
         if (ImGui::BeginTabItem("Subplots")) {

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1180,7 +1180,6 @@ void Demo_PerIndexColors() {
         ImPlot::EndPlot();
     }
 
-
     // Colorful Bubbles
     srand(0);
     static float xs_bubble[20], ys1_bubble[20], ys2_bubble[20], szs1_bubble[20], szs2_bubble[20];
@@ -1218,50 +1217,53 @@ void Demo_PerIndexColors() {
         ImPlot::EndPlot();
     }
 
-    // Colorful Stairs
-    if (ImPlot::BeginPlot("Colorful Stairs", ImVec2(-1,0))) {
-        ImPlot::SetupAxes("x","y");
-        ImPlot::SetupAxesLimits(0, 1, -1.5, 1.5);
+    // Colorful Stairstep
+    static float ys1_stairs[21], ys2_stairs[21];
+    static ImU32 colors1_stairs[21], colors2_stairs[21];
+    for (int i = 0; i < 21; ++i) {
+        ys1_stairs[i] = 0.75f + 0.2f * sinf(10 * i * 0.05f);
+        ys2_stairs[i] = 0.25f + 0.2f * sinf(10 * i * 0.05f);
 
-        // 1. Constant color stairs
-        static double xs_stairs1[20], ys_stairs1[20];
-        for (int i = 0; i < 20; ++i) {
-            xs_stairs1[i] = i / 19.0;
-            ys_stairs1[i] = sin(xs_stairs1[i] * 6.0 * PI) * 0.5;
-        }
-        ImPlot::PlotStairs("Const Color", xs_stairs1, ys_stairs1, 20, {
-            ImPlotProp_LineColor, ImVec4(1.0f, 0.5f, 0.0f, 1.0f),
+        // Rainbow colors for Post Step
+        float hue = i / 20.0f;
+        colors1_stairs[i] = ImColor::HSV(hue, 0.8f, 0.9f);
+
+        // Colormap colors for Pre Step
+        float t = i / 20.0f;
+        ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
+        colors2_stairs[i] = ImGui::GetColorU32(color);
+    }
+    static ImPlotStairsFlags flags_stairs = 0;
+    CHECKBOX_FLAG(flags_stairs, ImPlotStairsFlags_Shaded);
+
+    if (ImPlot::BeginPlot("Colorful Stairstep Plot")) {
+        ImPlot::SetupAxes("x","f(x)");
+        ImPlot::SetupAxesLimits(0,1,0,1);
+        ImPlot::PlotLine("##1", ys1_stairs, 21, 0.05f, 0, {
+            ImPlotProp_LineColor, ImVec4(0.5f,0.5f,0.5f,1.0f)
+        });
+        ImPlot::PlotLine("##2", ys2_stairs, 21, 0.05f, 0, {
+            ImPlotProp_LineColor, ImVec4(0.5f,0.5f,0.5f,1.0f)
         });
 
-        // 2. Per-vertex rainbow colors
-        static double xs_stairs2[20], ys_stairs2[20];
-        static ImU32 colors_stairs_rainbow[20];
-        for (int i = 0; i < 20; ++i) {
-            xs_stairs2[i] = i / 19.0;
-            ys_stairs2[i] = cos(xs_stairs2[i] * 4.0 * PI) * 0.8;
-            float t = i / 19.0f;
-            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Jet);
-            colors_stairs_rainbow[i] = ImGui::GetColorU32(color);
-        }
-        ImPlot::PlotStairs("Rainbow Stairs", xs_stairs2, ys_stairs2, 20, {
-            ImPlotProp_LineColors, colors_stairs_rainbow,
+        ImPlot::PlotStairs("Post Step (default)", ys1_stairs, 21, 0.05f, 0, {
+            ImPlotProp_Flags, flags_stairs,
+            ImPlotProp_FillAlpha, 0.25f,
+            ImPlotProp_Marker, ImPlotMarker_Auto,
+            ImPlotProp_LineColors, colors1_stairs,
+            ImPlotProp_FillColors, colors1_stairs,
+            ImPlotProp_MarkerFillColors, colors1_stairs,
+            ImPlotProp_MarkerLineColors, colors1_stairs
         });
 
-        // 3. Per-vertex colormap with shaded
-        static double xs_stairs3[20], ys_stairs3[20];
-        static ImU32 colors_stairs_map[20];
-        for (int i = 0; i < 20; ++i) {
-            xs_stairs3[i] = i / 19.0;
-            ys_stairs3[i] = -0.5 + sin(xs_stairs3[i] * 8.0 * PI) * 0.3;
-            float t = i / 19.0f;
-            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
-            colors_stairs_map[i] = ImGui::GetColorU32(color);
-        }
-        ImPlot::PlotStairs("Colormap Stairs+Fill", xs_stairs3, ys_stairs3, 20, {
-            ImPlotProp_LineColors, colors_stairs_map,
-            ImPlotProp_FillColors, colors_stairs_map,
-            ImPlotProp_FillAlpha, 0.4f,
-            ImPlotProp_Flags, ImPlotStairsFlags_Shaded | ImPlotStairsFlags_PreStep
+        ImPlot::PlotStairs("Pre Step", ys2_stairs, 21, 0.05f, 0, {
+            ImPlotProp_Flags, flags_stairs | ImPlotStairsFlags_PreStep,
+            ImPlotProp_FillAlpha, 0.25f,
+            ImPlotProp_Marker, ImPlotMarker_Auto,
+            ImPlotProp_LineColors, colors2_stairs,
+            ImPlotProp_FillColors, colors2_stairs,
+            ImPlotProp_MarkerFillColors, colors2_stairs,
+            ImPlotProp_MarkerLineColors, colors2_stairs
         });
 
         ImPlot::EndPlot();

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1145,7 +1145,7 @@ void Demo_PerIndexColors() {
         static double xs_bubble1[20], ys_bubble1[20], sizes_bubble1[20];
         for (int i = 0; i < 20; ++i) {
             xs_bubble1[i] = i / 19.0;
-            ys_bubble1[i] = 0.7 * sinf(xs_bubble1[i] * 6.0 * M_PI);
+            ys_bubble1[i] = 0.7 * sinf(xs_bubble1[i] * 6.0 * PI);
             sizes_bubble1[i] = 0.02 + 0.01 * sinf(xs_bubble1[i] * 10.0);
         }
         ImPlot::PlotBubble("Const Color Bubbles", xs_bubble1, ys_bubble1, sizes_bubble1, 20, {
@@ -1160,7 +1160,7 @@ void Demo_PerIndexColors() {
         static ImU32 colors_bubble_rainbow[20];
         for (int i = 0; i < 20; ++i) {
             xs_bubble2[i] = i / 19.0;
-            ys_bubble2[i] = 0.3 * cosf(xs_bubble2[i] * 4.0 * M_PI);
+            ys_bubble2[i] = 0.3 * cosf(xs_bubble2[i] * 4.0 * PI);
             sizes_bubble2[i] = 0.025 + 0.015 * cosf(xs_bubble2[i] * 8.0);
             float t = i / 19.0f;
             ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Jet);
@@ -1178,7 +1178,7 @@ void Demo_PerIndexColors() {
         static ImU32 colors_bubble_colormap[20];
         for (int i = 0; i < 20; ++i) {
             xs_bubble3[i] = i / 19.0;
-            ys_bubble3[i] = -0.3 + 0.2 * sinf(xs_bubble3[i] * 8.0 * M_PI);
+            ys_bubble3[i] = -0.3 + 0.2 * sinf(xs_bubble3[i] * 8.0 * PI);
             sizes_bubble3[i] = 0.03 + 0.01 * sinf(xs_bubble3[i] * 12.0);
             float t = i / 19.0f;
             ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
@@ -1240,7 +1240,7 @@ void Demo_PerIndexColors() {
         static double xs_stairs1[20], ys_stairs1[20];
         for (int i = 0; i < 20; ++i) {
             xs_stairs1[i] = i / 19.0;
-            ys_stairs1[i] = sinf(xs_stairs1[i] * 6.0 * M_PI) * 0.5;
+            ys_stairs1[i] = sinf(xs_stairs1[i] * 6.0 * PI) * 0.5;
         }
         ImPlot::PlotStairs("Const Color", xs_stairs1, ys_stairs1, 20, {
             ImPlotProp_LineColor, ImVec4(1.0f, 0.5f, 0.0f, 1.0f),
@@ -1251,7 +1251,7 @@ void Demo_PerIndexColors() {
         static ImU32 colors_stairs_rainbow[20];
         for (int i = 0; i < 20; ++i) {
             xs_stairs2[i] = i / 19.0;
-            ys_stairs2[i] = cosf(xs_stairs2[i] * 4.0 * M_PI) * 0.8;
+            ys_stairs2[i] = cosf(xs_stairs2[i] * 4.0 * PI) * 0.8;
             float t = i / 19.0f;
             ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Jet);
             colors_stairs_rainbow[i] = ImGui::GetColorU32(color);
@@ -1265,7 +1265,7 @@ void Demo_PerIndexColors() {
         static ImU32 colors_stairs_map[20];
         for (int i = 0; i < 20; ++i) {
             xs_stairs3[i] = i / 19.0;
-            ys_stairs3[i] = -0.5 + sinf(xs_stairs3[i] * 8.0 * M_PI) * 0.3;
+            ys_stairs3[i] = -0.5 + sinf(xs_stairs3[i] * 8.0 * PI) * 0.3;
             float t = i / 19.0f;
             ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
             colors_stairs_map[i] = ImGui::GetColorU32(color);
@@ -1288,7 +1288,7 @@ void Demo_PerIndexColors() {
         static double data_v[10];
         static ImU32 colors_v[10];
         for (int i = 0; i < 10; ++i) {
-            data_v[i] = 3.0 + sinf(i * 0.8f * (float)M_PI) * 2.0;
+            data_v[i] = 3.0 + sinf(i * 0.8f * (float)PI) * 2.0;
             float t = i / 9.0f;
             ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Jet);
             colors_v[i] = ImGui::GetColorU32(color);
@@ -1303,7 +1303,7 @@ void Demo_PerIndexColors() {
         static double data_v2[10];
         static ImU32 colors_v2[10];
         for (int i = 0; i < 10; ++i) {
-            data_v2[i] = 5.0 + cosf(i * 0.6f * (float)M_PI) * 2.5;
+            data_v2[i] = 5.0 + cosf(i * 0.6f * (float)PI) * 2.5;
             float t = i / 9.0f;
             ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
             colors_v2[i] = ImGui::GetColorU32(color);
@@ -1326,7 +1326,7 @@ void Demo_PerIndexColors() {
         static double xs_stem1[20], ys_stem1[20];
         for (int i = 0; i < 20; ++i) {
             xs_stem1[i] = i;
-            ys_stem1[i] = sinf(i * 0.4f * (float)M_PI);
+            ys_stem1[i] = sinf(i * 0.4f * (float)PI);
         }
         ImPlot::PlotStems("Const Color", xs_stem1, ys_stem1, 20, 0.0, {
             ImPlotProp_LineColor, ImVec4(1.0f, 0.3f, 0.3f, 1.0f),
@@ -1339,7 +1339,7 @@ void Demo_PerIndexColors() {
         static ImU32 colors_stem_rainbow[20];
         for (int i = 0; i < 20; ++i) {
             xs_stem2[i] = i;
-            ys_stem2[i] = cosf(i * 0.5f * (float)M_PI) * 0.8f;
+            ys_stem2[i] = cosf(i * 0.5f * (float)PI) * 0.8f;
             float t = i / 19.0f;
             ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Jet);
             colors_stem_rainbow[i] = ImGui::GetColorU32(color);
@@ -1355,7 +1355,7 @@ void Demo_PerIndexColors() {
         static ImU32 colors_stem_viridis[20];
         for (int i = 0; i < 20; ++i) {
             xs_stem3[i] = i;
-            ys_stem3[i] = -0.5f + sinf(i * 0.3f * (float)M_PI) * 0.5f;
+            ys_stem3[i] = -0.5f + sinf(i * 0.3f * (float)PI) * 0.5f;
             float t = i / 19.0f;
             ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
             colors_stem_viridis[i] = ImGui::GetColorU32(color);

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1137,64 +1137,44 @@ void Demo_PerIndexColors() {
         ImPlot::EndPlot();
     }
 
-    if (ImPlot::BeginPlot("Colorful Bubbles", ImVec2(-1,0))) {
-        ImPlot::SetupAxes("x","y");
-        ImPlot::SetupAxesLimits(0, 1, -0.5, 1.0);
+    // Colorful Bubbles
+    srand(0);
+    static float xs_bubble[20], ys1_bubble[20], ys2_bubble[20], szs1_bubble[20], szs2_bubble[20];
+    static ImU32 colors1_bubble[20], colors2_bubble[20];
+    for (int i = 0; i < 20; ++i) {
+        xs_bubble[i] = i * 0.1f;
+        ys1_bubble[i] = (float)rand() / (float)RAND_MAX;
+        ys2_bubble[i] = (float)rand() / (float)RAND_MAX;
 
-        // 1. Constant color bubbles
-        static double xs_bubble1[20], ys_bubble1[20], sizes_bubble1[20];
-        for (int i = 0; i < 20; ++i) {
-            xs_bubble1[i] = i / 19.0;
-            ys_bubble1[i] = 0.7 * sinf(xs_bubble1[i] * 6.0 * PI);
-            sizes_bubble1[i] = 0.02 + 0.01 * sinf(xs_bubble1[i] * 10.0);
-        }
-        ImPlot::PlotBubble("Const Color Bubbles", xs_bubble1, ys_bubble1, sizes_bubble1, 20, {
-            ImPlotProp_FillColor, ImVec4(1.0f, 0.5f, 0.0f, 1.0f),
+        szs1_bubble[i] = 0.02f + 0.08f * ((float)rand() / (float)RAND_MAX);
+        szs2_bubble[i] = 0.02f + 0.08f * ((float)rand() / (float)RAND_MAX);
+
+        // Rainbow colors for Data 1
+        float hue = i / 19.0f;
+        colors1_bubble[i] = ImColor::HSV(hue, 0.8f, 0.9f);
+
+        // Colormap colors for Data 2
+        float t = i / 19.0f;
+        ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
+        colors2_bubble[i] = ImGui::GetColorU32(color);
+    }
+
+    if (ImPlot::BeginPlot("Colorful Bubbles", ImVec2(-1,0), ImPlotFlags_Equal)) {
+        ImPlot::PlotBubble("Data 1", xs_bubble, ys1_bubble, szs1_bubble, 20, {
             ImPlotProp_FillAlpha, 0.5f,
-            ImPlotProp_LineColor, ImVec4(1.0f, 0.2f, 0.0f, 1.0f),
-            ImPlotProp_LineWeight, 2.0f
+            ImPlotProp_FillColors, colors1_bubble,
+            ImPlotProp_LineColors, colors1_bubble
         });
-
-        // 2. Per-bubble rainbow colors
-        static double xs_bubble2[20], ys_bubble2[20], sizes_bubble2[20];
-        static ImU32 colors_bubble_rainbow[20];
-        for (int i = 0; i < 20; ++i) {
-            xs_bubble2[i] = i / 19.0;
-            ys_bubble2[i] = 0.3 * cosf(xs_bubble2[i] * 4.0 * PI);
-            sizes_bubble2[i] = 0.025 + 0.015 * cosf(xs_bubble2[i] * 8.0);
-            float t = i / 19.0f;
-            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Jet);
-            colors_bubble_rainbow[i] = ImGui::GetColorU32(color);
-        }
-        ImPlot::PlotBubble("Rainbow Bubbles", xs_bubble2, ys_bubble2, sizes_bubble2, 20, {
-            ImPlotProp_FillColors, colors_bubble_rainbow,
-            ImPlotProp_FillAlpha, 0.6f,
-            ImPlotProp_LineColors, colors_bubble_rainbow,
-            ImPlotProp_LineWeight, 1.5f
-        });
-
-        // 3. Per-bubble colormap colors (viridis)
-        static double xs_bubble3[20], ys_bubble3[20], sizes_bubble3[20];
-        static ImU32 colors_bubble_colormap[20];
-        for (int i = 0; i < 20; ++i) {
-            xs_bubble3[i] = i / 19.0;
-            ys_bubble3[i] = -0.3 + 0.2 * sinf(xs_bubble3[i] * 8.0 * PI);
-            sizes_bubble3[i] = 0.03 + 0.01 * sinf(xs_bubble3[i] * 12.0);
-            float t = i / 19.0f;
-            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
-            colors_bubble_colormap[i] = ImGui::GetColorU32(color);
-        }
-        ImPlot::PlotBubble("Colormap Bubbles", xs_bubble3, ys_bubble3, sizes_bubble3, 20, {
-            ImPlotProp_FillColors, colors_bubble_colormap,
-            ImPlotProp_FillAlpha, 0.7f,
-            ImPlotProp_LineColors, colors_bubble_colormap,
-            ImPlotProp_LineWeight, 1.0f
+        ImPlot::PlotBubble("Data 2", xs_bubble, ys2_bubble, szs2_bubble, 20, {
+            ImPlotProp_FillAlpha, 0.5f,
+            ImPlotProp_LineColor, ImVec4(0,0,0,0.0),
+            ImPlotProp_FillColors, colors2_bubble
         });
 
         ImPlot::EndPlot();
     }
 
-    // Colorful Scatter (matches Demo_ScatterPlots structure with per-marker colors)
+    // Colorful Scatter
     srand(0);
     static float xs_scatter1[100], ys_scatter1[100];
     static ImU32 colors_scatter1_fill[100], colors_scatter1_line[100];
@@ -1240,7 +1220,7 @@ void Demo_PerIndexColors() {
         static double xs_stairs1[20], ys_stairs1[20];
         for (int i = 0; i < 20; ++i) {
             xs_stairs1[i] = i / 19.0;
-            ys_stairs1[i] = sinf(xs_stairs1[i] * 6.0 * PI) * 0.5;
+            ys_stairs1[i] = sin(xs_stairs1[i] * 6.0 * PI) * 0.5;
         }
         ImPlot::PlotStairs("Const Color", xs_stairs1, ys_stairs1, 20, {
             ImPlotProp_LineColor, ImVec4(1.0f, 0.5f, 0.0f, 1.0f),
@@ -1251,7 +1231,7 @@ void Demo_PerIndexColors() {
         static ImU32 colors_stairs_rainbow[20];
         for (int i = 0; i < 20; ++i) {
             xs_stairs2[i] = i / 19.0;
-            ys_stairs2[i] = cosf(xs_stairs2[i] * 4.0 * PI) * 0.8;
+            ys_stairs2[i] = cos(xs_stairs2[i] * 4.0 * PI) * 0.8;
             float t = i / 19.0f;
             ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Jet);
             colors_stairs_rainbow[i] = ImGui::GetColorU32(color);
@@ -1265,7 +1245,7 @@ void Demo_PerIndexColors() {
         static ImU32 colors_stairs_map[20];
         for (int i = 0; i < 20; ++i) {
             xs_stairs3[i] = i / 19.0;
-            ys_stairs3[i] = -0.5 + sinf(xs_stairs3[i] * 8.0 * PI) * 0.3;
+            ys_stairs3[i] = -0.5 + sin(xs_stairs3[i] * 8.0 * PI) * 0.3;
             float t = i / 19.0f;
             ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
             colors_stairs_map[i] = ImGui::GetColorU32(color);

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1146,6 +1146,7 @@ void Demo_PerIndexColors() {
     srand(0);
     static float xs_scatter1[100], ys_scatter1[100];
     static ImU32 colors_scatter1_fill[100], colors_scatter1_line[100];
+    static float sizes_scatter1[100];
     for (int i = 0; i < 100; ++i) {
         xs_scatter1[i] = i * 0.01f;
         ys_scatter1[i] = xs_scatter1[i] + 0.1f * ((float)rand() / (float)RAND_MAX);
@@ -1153,9 +1154,12 @@ void Demo_PerIndexColors() {
         float hue = i / 99.0f;
         colors_scatter1_fill[i] = ImColor::HSV(hue, 0.8f, 0.9f);
         colors_scatter1_line[i] = ImColor::HSV(hue, 0.9f, 0.7f);
+        // Random sizes between 2 and 6
+        sizes_scatter1[i] = 2.0f + 4.0f * ((float)rand() / (float)RAND_MAX);
     }
     static float xs_scatter2[50], ys_scatter2[50];
     static ImU32 colors_scatter2[50];
+    static float sizes_scatter2[50];
     for (int i = 0; i < 50; i++) {
         xs_scatter2[i] = 0.25f + 0.2f * ((float)rand() / (float)RAND_MAX);
         ys_scatter2[i] = 0.75f + 0.2f * ((float)rand() / (float)RAND_MAX);
@@ -1163,19 +1167,22 @@ void Demo_PerIndexColors() {
         float t = i / 49.0f;
         ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
         colors_scatter2[i] = ImGui::GetColorU32(color);
+        // Random sizes between 2 and 6
+        sizes_scatter2[i] = 2.0f + 4.0f * ((float)rand() / (float)RAND_MAX);
     }
 
     if (ImPlot::BeginPlot("Colorful Scatter", ImVec2(-1,0))) {
         ImPlot::PlotScatter("Data 1", xs_scatter1, ys_scatter1, 100, {
             ImPlotProp_MarkerFillColors, colors_scatter1_fill,
             ImPlotProp_MarkerLineColors, colors_scatter1_line,
+            ImPlotProp_MarkerSizes, sizes_scatter1
         });
         ImPlot::PlotScatter("Data 2", xs_scatter2, ys_scatter2, 50, {
             ImPlotProp_Marker, ImPlotMarker_Square,
-            ImPlotProp_MarkerSize, 6,
             ImPlotProp_MarkerFillColors, colors_scatter2,
             ImPlotProp_MarkerLineColors, colors_scatter2,
-            ImPlotProp_FillAlpha, 0.5f,
+            ImPlotProp_MarkerSizes, sizes_scatter2,
+            ImPlotProp_FillAlpha, 0.5f
         });
         ImPlot::EndPlot();
     }

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1203,12 +1203,12 @@ void Demo_PerIndexColors() {
     }
 
     if (ImPlot::BeginPlot("Colorful Bubbles", ImVec2(-1,0), ImPlotFlags_Equal)) {
-        ImPlot::PlotBubble("Data 1", xs_bubble, ys1_bubble, szs1_bubble, 20, {
+        ImPlot::PlotBubbles("Data 1", xs_bubble, ys1_bubble, szs1_bubble, 20, {
             ImPlotProp_FillAlpha, 0.5f,
             ImPlotProp_FillColors, colors1_bubble,
             ImPlotProp_LineColors, colors1_bubble
         });
-        ImPlot::PlotBubble("Data 2", xs_bubble, ys2_bubble, szs2_bubble, 20, {
+        ImPlot::PlotBubbles("Data 2", xs_bubble, ys2_bubble, szs2_bubble, 20, {
             ImPlotProp_FillAlpha, 0.5f,
             ImPlotProp_LineColor, ImVec4(0,0,0,0.0),
             ImPlotProp_FillColors, colors2_bubble

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1062,115 +1062,38 @@ void Demo_NaNValues() {
 //-----------------------------------------------------------------------------
 
 void Demo_PerIndexColors() {
-    static float xs1[101], ys1[101], ys2[101], ys3[101];
-    static ImU32 colors_rainbow[101];
-    static ImU32 colors_colormap[101];
-
-    ImPlot::PushColormap(ImPlotColormap_Hot);
-    for (int i = 0; i < 101; ++i) {
-        xs1[i] = i * 0.01f;
-        ys1[i] = 0.5f + 0.3f * sinf(20 * xs1[i]);
-        ys2[i] = 0.2f + 0.3f * sinf(15 * xs1[i] + 1.0f);
-        ys3[i] = -0.1f + 0.3f * sinf(10 * xs1[i] + 2.0f);
-
-        // Rainbow colors (HSV sweep)
-        float hue = (float)i / 100.0f;
-        colors_rainbow[i] = ImColor::HSV(hue, 0.8f, 0.9f);
-
-        // Sample from current colormap
-        float t = (float)i / 100.0f;
-        colors_colormap[i] = ImColor(ImPlot::SampleColormap(t));
+    // Colorful Lines
+    static float xs1[1001], ys1[1001];
+    static ImU32 colors1[1001];
+    for (int i = 0; i < 1001; ++i) {
+        xs1[i] = i * 0.001f;
+        ys1[i] = 0.5f + 0.5f * sinf(50 * (xs1[i] + (float)ImGui::GetTime() / 10));
+        // Rainbow colors for f(x)
+        float hue = (float)i / 1000.0f;
+        colors1[i] = ImColor::HSV(hue, 0.8f, 0.9f);
     }
-    ImPlot::PopColormap();
-
-    if (ImPlot::BeginPlot("Colorful Lines", ImVec2(-1,0))) {
-        ImPlot::SetupAxes("x","y");
-        ImPlot::SetupAxesLimits(0, 1, -0.5, 1.0);
-
-        // 1. Constant color via LineColor (default behavior)
-        ImPlot::PlotLine("Const Color", xs1, ys1, 101, {
-            ImPlotProp_LineColor, ImVec4(1, 0.5f, 0, 1),
-            ImPlotProp_LineWeight, 1.0f
-        });
-
-        // 2. Per-vertex colors via LineColors (rainbow)
-        ImPlot::PlotLine("Rainbow Colors", xs1, ys2, 101, {
-            ImPlotProp_LineColors, colors_rainbow,
-            ImPlotProp_LineWeight, 2.0f
-        });
-
-        // 3. Per-vertex colors sampled from colormap
-        ImPlot::PlotLine("Colormap Colors", xs1, ys3, 101, {
-            ImPlotProp_LineColors, colors_colormap,
-            ImPlotProp_LineWeight, 3.0f
-        });
-
-        ImPlot::EndPlot();
-    }
-
-    if (ImPlot::BeginPlot("Colorful Shaded", ImVec2(-1,0))) {
-        ImPlot::SetupAxes("x","y");
-        ImPlot::SetupAxesLimits(0, 1, -0.5, 1.0);
-
-        // Constant color with FillAlpha
-        static double y_ref = 0.0;
-        ImPlot::PlotShaded("Const Color", xs1, ys3, 101, y_ref, {
-            ImPlotProp_FillColor, ImVec4(0.3f, 0.7f, 1.0f, 1.0f),
-            ImPlotProp_FillAlpha, 0.4f
-        });
-
-        // Per-vertex colors with FillAlpha (rainbow)
-        ImPlot::PlotShaded("Rainbow Shaded", xs1, ys1, 101, y_ref, {
-            ImPlotProp_FillColors, colors_rainbow,
-            ImPlotProp_FillAlpha, 0.5f
-        });
-
-        // Per-vertex colors with PlotLine (colormap)
-        ImPlot::PlotLine("Colormap Line+Fill", xs1, ys2, 101, {
-            ImPlotProp_LineColors, colors_colormap,
-            ImPlotProp_FillColors, colors_colormap,
-            ImPlotProp_LineWeight, 2.0f,
-            ImPlotProp_FillAlpha, 0.3f,
-            ImPlotProp_Flags, ImPlotLineFlags_Shaded
-        });
-
-        ImPlot::EndPlot();
-    }
-
-    // Colorful Bubbles
-    srand(0);
-    static float xs_bubble[20], ys1_bubble[20], ys2_bubble[20], szs1_bubble[20], szs2_bubble[20];
-    static ImU32 colors1_bubble[20], colors2_bubble[20];
+    static double xs2[20], ys2[20];
+    static ImU32 colors2[20];
     for (int i = 0; i < 20; ++i) {
-        xs_bubble[i] = i * 0.1f;
-        ys1_bubble[i] = (float)rand() / (float)RAND_MAX;
-        ys2_bubble[i] = (float)rand() / (float)RAND_MAX;
-
-        szs1_bubble[i] = 0.02f + 0.08f * ((float)rand() / (float)RAND_MAX);
-        szs2_bubble[i] = 0.02f + 0.08f * ((float)rand() / (float)RAND_MAX);
-
-        // Rainbow colors for Data 1
-        float hue = i / 19.0f;
-        colors1_bubble[i] = ImColor::HSV(hue, 0.8f, 0.9f);
-
-        // Colormap colors for Data 2
+        xs2[i] = i * 1/19.0f;
+        ys2[i] = xs2[i] * xs2[i];
+        // Colormap colors for g(x)
         float t = i / 19.0f;
         ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
-        colors2_bubble[i] = ImGui::GetColorU32(color);
+        colors2[i] = ImGui::GetColorU32(color);
     }
-
-    if (ImPlot::BeginPlot("Colorful Bubbles", ImVec2(-1,0), ImPlotFlags_Equal)) {
-        ImPlot::PlotBubble("Data 1", xs_bubble, ys1_bubble, szs1_bubble, 20, {
-            ImPlotProp_FillAlpha, 0.5f,
-            ImPlotProp_FillColors, colors1_bubble,
-            ImPlotProp_LineColors, colors1_bubble
+    if (ImPlot::BeginPlot("Colorful Lines")) {
+        ImPlot::SetupAxes("x","y");
+        ImPlot::PlotLine("f(x)", xs1, ys1, 1001, {
+            ImPlotProp_LineColors, colors1
         });
-        ImPlot::PlotBubble("Data 2", xs_bubble, ys2_bubble, szs2_bubble, 20, {
-            ImPlotProp_FillAlpha, 0.5f,
-            ImPlotProp_LineColor, ImVec4(0,0,0,0.0),
-            ImPlotProp_FillColors, colors2_bubble
+        ImPlot::PlotLine("g(x)", xs2, ys2, 20, {
+            ImPlotProp_Marker, ImPlotMarker_Circle,
+            ImPlotProp_Flags, ImPlotLineFlags_Segments,
+            ImPlotProp_LineColors, colors2,
+            ImPlotProp_MarkerFillColors, colors2,
+            ImPlotProp_MarkerLineColors, colors2
         });
-
         ImPlot::EndPlot();
     }
 
@@ -1212,6 +1135,44 @@ void Demo_PerIndexColors() {
         ImPlot::EndPlot();
     }
 
+    // Colorful Bubbles
+    srand(0);
+    static float xs_bubble[20], ys1_bubble[20], ys2_bubble[20], szs1_bubble[20], szs2_bubble[20];
+    static ImU32 colors1_bubble[20], colors2_bubble[20];
+    for (int i = 0; i < 20; ++i) {
+        xs_bubble[i] = i * 0.1f;
+        ys1_bubble[i] = (float)rand() / (float)RAND_MAX;
+        ys2_bubble[i] = (float)rand() / (float)RAND_MAX;
+
+        szs1_bubble[i] = 0.02f + 0.08f * ((float)rand() / (float)RAND_MAX);
+        szs2_bubble[i] = 0.02f + 0.08f * ((float)rand() / (float)RAND_MAX);
+
+        // Rainbow colors for Data 1
+        float hue = i / 19.0f;
+        colors1_bubble[i] = ImColor::HSV(hue, 0.8f, 0.9f);
+
+        // Colormap colors for Data 2
+        float t = i / 19.0f;
+        ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
+        colors2_bubble[i] = ImGui::GetColorU32(color);
+    }
+
+    if (ImPlot::BeginPlot("Colorful Bubbles", ImVec2(-1,0), ImPlotFlags_Equal)) {
+        ImPlot::PlotBubble("Data 1", xs_bubble, ys1_bubble, szs1_bubble, 20, {
+            ImPlotProp_FillAlpha, 0.5f,
+            ImPlotProp_FillColors, colors1_bubble,
+            ImPlotProp_LineColors, colors1_bubble
+        });
+        ImPlot::PlotBubble("Data 2", xs_bubble, ys2_bubble, szs2_bubble, 20, {
+            ImPlotProp_FillAlpha, 0.5f,
+            ImPlotProp_LineColor, ImVec4(0,0,0,0.0),
+            ImPlotProp_FillColors, colors2_bubble
+        });
+
+        ImPlot::EndPlot();
+    }
+
+    // Colorful Stairs
     if (ImPlot::BeginPlot("Colorful Stairs", ImVec2(-1,0))) {
         ImPlot::SetupAxes("x","y");
         ImPlot::SetupAxesLimits(0, 1, -1.5, 1.5);
@@ -1260,6 +1221,7 @@ void Demo_PerIndexColors() {
         ImPlot::EndPlot();
     }
 
+    // Colorful Bars
     if (ImPlot::BeginPlot("Colorful Bars", ImVec2(-1,0))) {
         ImPlot::SetupAxes("Category","Value");
         ImPlot::SetupAxesLimits(-0.5, 9.5, 0, 12);
@@ -1298,6 +1260,7 @@ void Demo_PerIndexColors() {
         ImPlot::EndPlot();
     }
 
+    // Colorful Stems
     if (ImPlot::BeginPlot("Colorful Stems", ImVec2(-1,0))) {
         ImPlot::SetupAxes("x","y");
         ImPlot::SetupAxesLimits(-0.5, 19.5, -1.2, 1.2);
@@ -1349,6 +1312,7 @@ void Demo_PerIndexColors() {
         ImPlot::EndPlot();
     }
 
+    // Colorful Infinite Lines
     if (ImPlot::BeginPlot("Colorful Infinite Lines", ImVec2(-1,0))) {
         ImPlot::SetupAxes("x","y");
         ImPlot::SetupAxesLimits(0, 10, -1, 10);

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1269,94 +1269,65 @@ void Demo_PerIndexColors() {
         ImPlot::EndPlot();
     }
 
-    // Colorful Bars
-    if (ImPlot::BeginPlot("Colorful Bars", ImVec2(-1,0))) {
-        ImPlot::SetupAxes("Category","Value");
-        ImPlot::SetupAxesLimits(-0.5, 9.5, 0, 12);
+    // Colorful Bar Plots
+    static ImS8 data_bars[10] = {1,2,3,4,5,6,7,8,9,10};
+    static ImU32 colors_bars_v[10], colors_bars_h[10];
+    for (int i = 0; i < 10; ++i) {
+        // Rainbow colors for Vertical
+        float hue = i / 9.0f;
+        colors_bars_v[i] = ImColor::HSV(hue, 0.8f, 0.9f);
 
-        // 1. Vertical bars with per-bar rainbow colors
-        static double data_v[10];
-        static ImU32 colors_v[10];
-        for (int i = 0; i < 10; ++i) {
-            data_v[i] = 3.0 + sinf(i * 0.8f * (float)PI) * 2.0;
-            float t = i / 9.0f;
-            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Jet);
-            colors_v[i] = ImGui::GetColorU32(color);
-        }
-        ImPlot::PlotBars("Vertical Rainbow", data_v, 10, 0.35, 0, {
-            ImPlotProp_FillColors, colors_v,
-            ImPlotProp_LineColors, colors_v,
-            ImPlotProp_FillAlpha, 0.5f
+        // Colormap colors for Horizontal
+        float t = i / 9.0f;
+        ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
+        colors_bars_h[i] = ImGui::GetColorU32(color);
+    }
+
+    if (ImPlot::BeginPlot("Colorful Bar Plot")) {
+        ImPlot::PlotBars("Vertical", data_bars, 10, 0.7, 1, {
+            ImPlotProp_FillColors, colors_bars_v,
+            ImPlotProp_LineColors, colors_bars_v
         });
-
-        // 2. Vertical bars with colormap colors
-        static double data_v2[10];
-        static ImU32 colors_v2[10];
-        for (int i = 0; i < 10; ++i) {
-            data_v2[i] = 5.0 + cosf(i * 0.6f * (float)PI) * 2.5;
-            float t = i / 9.0f;
-            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
-            colors_v2[i] = ImGui::GetColorU32(color);
-        }
-        ImPlot::PlotBars("Vertical Colormap", data_v2, 10, 0.35, 0.35, {
-            ImPlotProp_FillColors, colors_v2,
-            ImPlotProp_LineColors, colors_v2,
-            ImPlotProp_FillAlpha, 0.7f,
-            ImPlotProp_LineWeight, 2.0f
+        ImPlot::PlotBars("Horizontal", data_bars, 10, 0.4, 1, {
+            ImPlotProp_Flags, ImPlotBarsFlags_Horizontal,
+            ImPlotProp_FillColors, colors_bars_h,
+            ImPlotProp_LineColors, colors_bars_h
         });
-
         ImPlot::EndPlot();
     }
 
-    // Colorful Stems
-    if (ImPlot::BeginPlot("Colorful Stems", ImVec2(-1,0))) {
-        ImPlot::SetupAxes("x","y");
-        ImPlot::SetupAxesLimits(-0.5, 19.5, -1.2, 1.2);
+    // Colorful Stem Plots
+    static double xs_stems[51], ys1_stems[51], ys2_stems[51];
+    static ImU32 colors1_stems[51], colors2_stems[51];
+    for (int i = 0; i < 51; ++i) {
+        xs_stems[i] = i * 0.02;
+        ys1_stems[i] = 1.0 + 0.5 * sin(25*xs_stems[i])*cos(2*xs_stems[i]);
+        ys2_stems[i] = 0.5 + 0.25  * sin(10*xs_stems[i]) * sin(xs_stems[i]);
 
-        // 1. Constant color stems
-        static double xs_stem1[20], ys_stem1[20];
-        for (int i = 0; i < 20; ++i) {
-            xs_stem1[i] = i;
-            ys_stem1[i] = sinf(i * 0.4f * (float)PI);
-        }
-        ImPlot::PlotStems("Const Color", xs_stem1, ys_stem1, 20, 0.0, {
-            ImPlotProp_LineColor, ImVec4(1.0f, 0.3f, 0.3f, 1.0f),
+        // Rainbow colors for Stems 1
+        float hue = i / 50.0f;
+        colors1_stems[i] = ImColor::HSV(hue, 0.8f, 0.9f);
+
+        // Colormap colors for Stems 2
+        float t = i / 50.0f;
+        ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
+        colors2_stems[i] = ImGui::GetColorU32(color);
+    }
+
+    if (ImPlot::BeginPlot("Colorful Stem Plots")) {
+        ImPlot::SetupAxisLimits(ImAxis_X1,0,1.0);
+        ImPlot::SetupAxisLimits(ImAxis_Y1,0,1.6);
+        ImPlot::PlotStems("Stems 1", xs_stems, ys1_stems, 51, 0, {
+            ImPlotProp_LineColors, colors1_stems,
+            ImPlotProp_MarkerFillColors, colors1_stems,
+            ImPlotProp_MarkerLineColors, colors1_stems
+        });
+        ImPlot::PlotStems("Stems 2", xs_stems, ys2_stems, 51, 0, {
             ImPlotProp_Marker, ImPlotMarker_Circle,
-            ImPlotProp_MarkerSize, 2.0f
+            ImPlotProp_LineColors, colors2_stems,
+            ImPlotProp_MarkerFillColors, colors2_stems,
+            ImPlotProp_MarkerLineColors, colors2_stems
         });
-
-        // 2. Per-stem rainbow colors
-        static double xs_stem2[20], ys_stem2[20];
-        static ImU32 colors_stem_rainbow[20];
-        for (int i = 0; i < 20; ++i) {
-            xs_stem2[i] = i;
-            ys_stem2[i] = cosf(i * 0.5f * (float)PI) * 0.8f;
-            float t = i / 19.0f;
-            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Jet);
-            colors_stem_rainbow[i] = ImGui::GetColorU32(color);
-        }
-        ImPlot::PlotStems("Rainbow Stems", xs_stem2, ys_stem2, 20, 0.0, {
-            ImPlotProp_LineColors, colors_stem_rainbow,
-            ImPlotProp_Marker, ImPlotMarker_Square,
-            ImPlotProp_MarkerSize, 2.0f
-        });
-
-        // 3. Per-stem colormap colors (Viridis)
-        static double xs_stem3[20], ys_stem3[20];
-        static ImU32 colors_stem_viridis[20];
-        for (int i = 0; i < 20; ++i) {
-            xs_stem3[i] = i;
-            ys_stem3[i] = -0.5f + sinf(i * 0.3f * (float)PI) * 0.5f;
-            float t = i / 19.0f;
-            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
-            colors_stem_viridis[i] = ImGui::GetColorU32(color);
-        }
-        ImPlot::PlotStems("Colormap Stems", xs_stem3, ys_stem3, 20, 0.0, {
-            ImPlotProp_LineColors, colors_stem_viridis,
-            ImPlotProp_Marker, ImPlotMarker_Diamond,
-            ImPlotProp_MarkerSize, 2.0f
-        });
-
         ImPlot::EndPlot();
     }
 

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1097,6 +1097,51 @@ void Demo_PerIndexColors() {
         ImPlot::EndPlot();
     }
 
+    // Colorful Shaded Plots
+    static float xs_shaded[1001], ys_shaded[1001], ys1_shaded[1001], ys2_shaded[1001], ys3_shaded[1001], ys4_shaded[1001];
+    static ImU32 colors_shaded1[1001], colors_shaded2[1001];
+    srand(0);
+    for (int i = 0; i < 1001; ++i) {
+        xs_shaded[i]  = i * 0.001f;
+        ys_shaded[i]  = 0.25f + 0.25f * sinf(25 * xs_shaded[i]) * sinf(5 * xs_shaded[i]) + RandomRange(-0.01f, 0.01f);
+        ys1_shaded[i] = ys_shaded[i] + RandomRange(0.1f, 0.12f);
+        ys2_shaded[i] = ys_shaded[i] - RandomRange(0.1f, 0.12f);
+        ys3_shaded[i] = 0.75f + 0.2f * sinf(25 * xs_shaded[i]);
+        ys4_shaded[i] = 0.75f + 0.1f * cosf(25 * xs_shaded[i]);
+
+        // Rainbow colors for Uncertain Data
+        float hue = i / 1000.0f;
+        colors_shaded1[i] = ImColor::HSV(hue, 0.8f, 0.9f);
+
+        // Colormap colors for Overlapping
+        float t = i / 1000.0f;
+        ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
+        colors_shaded2[i] = ImGui::GetColorU32(color);
+    }
+    static ImPlotSpec spec_shaded(ImPlotProp_FillAlpha, 0.25f);
+
+    if (ImPlot::BeginPlot("Colorful Shaded Plots")) {
+        ImPlot::SetupLegend(ImPlotLocation_NorthWest, ImPlotLegendFlags_Reverse);
+        ImPlot::PlotShaded("Uncertain Data", xs_shaded, ys1_shaded, ys2_shaded, 1001, {
+            ImPlotProp_FillColors, colors_shaded1,
+            ImPlotProp_FillAlpha, spec_shaded.FillAlpha
+        });
+        ImPlot::PlotLine("Uncertain Data", xs_shaded, ys_shaded, 1001, {
+            ImPlotProp_LineColors, colors_shaded1
+        });
+        ImPlot::PlotShaded("Overlapping", xs_shaded, ys3_shaded, ys4_shaded, 1001, {
+            ImPlotProp_FillColors, colors_shaded2,
+            ImPlotProp_FillAlpha, spec_shaded.FillAlpha
+        });
+        ImPlot::PlotLine("Overlapping", xs_shaded, ys3_shaded, 1001, {
+            ImPlotProp_LineColors, colors_shaded2
+        });
+        ImPlot::PlotLine("Overlapping", xs_shaded, ys4_shaded, 1001, {
+            ImPlotProp_LineColors, colors_shaded2
+        });
+        ImPlot::EndPlot();
+    }
+
     // Colorful Scatter
     srand(0);
     static float xs_scatter1[100], ys_scatter1[100];
@@ -1134,6 +1179,7 @@ void Demo_PerIndexColors() {
         });
         ImPlot::EndPlot();
     }
+
 
     // Colorful Bubbles
     srand(0);

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1061,20 +1061,50 @@ void Demo_NaNValues() {
 
 //-----------------------------------------------------------------------------
 
-void Demo_PerPointColors() {
-    static float xs1[1001], ys1[1001];
-    static ImU32 colors1[1001];
-    for (int i = 0; i < 1001; ++i) {
-        xs1[i] = i * 0.001f;
-        ys1[i] = 0.5f + 0.5f * sinf(50 * (xs1[i] + (float)ImGui::GetTime() / 10));
-        colors1[i] = ImGui::GetColorU32(ImVec4(ys1[i], 0.5f, 1.0f - ys1[i], 1.0f));
-    }
+void Demo_PerIndexColors() {
+    static float xs1[101], ys1[101], ys2[101], ys3[101];
+    static ImU32 colors_rainbow[101];
+    static ImU32 colors_colormap[101];
 
-    if (ImPlot::BeginPlot("Colorful Line Plot", ImVec2(-1,0))) {
-        ImPlot::PlotLine("f(x)", xs1, ys1, 1001, {
-            ImPlotProp_LineColor, ImVec4(1,0,1,1),
-            ImPlotProp_LineColors, colors1,
+    ImPlot::PushColormap(ImPlotColormap_Hot);
+    for (int i = 0; i < 101; ++i) {
+        xs1[i] = i * 0.01f;
+        ys1[i] = 0.5f + 0.3f * sinf(20 * xs1[i]);
+        ys2[i] = 0.2f + 0.3f * sinf(15 * xs1[i] + 1.0f);
+        ys3[i] = -0.1f + 0.3f * sinf(10 * xs1[i] + 2.0f);
+
+        // Rainbow colors (HSV sweep)
+        float hue = (float)i / 100.0f;
+        colors_rainbow[i] = ImColor::HSV(hue, 0.8f, 0.9f);
+
+        // Sample from current colormap
+        float t = (float)i / 100.0f;
+        colors_colormap[i] = ImColor(ImPlot::SampleColormap(t));
+    }
+    ImPlot::PopColormap();
+
+    if (ImPlot::BeginPlot("Colorful Lines", ImVec2(-1,0))) {
+        ImPlot::SetupAxes("x","y");
+        ImPlot::SetupAxesLimits(0, 1, -0.5, 1.0);
+
+        // 1. Constant color via LineColor (default behavior)
+        ImPlot::PlotLine("Const Color", xs1, ys1, 101, {
+            ImPlotProp_LineColor, ImVec4(1, 0.5f, 0, 1),
+            ImPlotProp_LineWeight, 1.0f
         });
+
+        // 2. Per-vertex colors via LineColors (rainbow)
+        ImPlot::PlotLine("Rainbow Colors", xs1, ys2, 101, {
+            ImPlotProp_LineColors, colors_rainbow,
+            ImPlotProp_LineWeight, 2.0f
+        });
+
+        // 3. Per-vertex colors sampled from colormap
+        ImPlot::PlotLine("Colormap Colors", xs1, ys3, 101, {
+            ImPlotProp_LineColors, colors_colormap,
+            ImPlotProp_LineWeight, 3.0f
+        });
+
         ImPlot::EndPlot();
     }
 }
@@ -2416,7 +2446,7 @@ void ShowDemoWindow(bool* p_open) {
             DemoHeader("Images", Demo_Images);
             DemoHeader("Markers and Text", Demo_MarkersAndText);
             DemoHeader("NaN Values", Demo_NaNValues);
-            DemoHeader("Per Point Colors", Demo_PerPointColors);
+            DemoHeader("Per-Index Colors", Demo_PerIndexColors);
             ImGui::EndTabItem();
         }
         if (ImGui::BeginTabItem("Subplots")) {

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1107,6 +1107,35 @@ void Demo_PerIndexColors() {
 
         ImPlot::EndPlot();
     }
+
+    if (ImPlot::BeginPlot("Colorful Shaded", ImVec2(-1,0))) {
+        ImPlot::SetupAxes("x","y");
+        ImPlot::SetupAxesLimits(0, 1, -0.5, 1.0);
+
+        // Constant color with FillAlpha
+        static double y_ref = 0.0;
+        ImPlot::PlotShaded("Const Color", xs1, ys3, 101, y_ref, {
+            ImPlotProp_FillColor, ImVec4(0.3f, 0.7f, 1.0f, 1.0f),
+            ImPlotProp_FillAlpha, 0.4f
+        });
+
+        // Per-vertex colors with FillAlpha (rainbow)
+        ImPlot::PlotShaded("Rainbow Shaded", xs1, ys1, 101, y_ref, {
+            ImPlotProp_FillColors, colors_rainbow,
+            ImPlotProp_FillAlpha, 0.5f
+        });
+
+        // Per-vertex colors with PlotLine (colormap)
+        ImPlot::PlotLine("Colormap Line+Fill", xs1, ys2, 101, {
+            ImPlotProp_LineColors, colors_colormap,
+            ImPlotProp_FillColors, colors_colormap,
+            ImPlotProp_LineWeight, 2.0f,
+            ImPlotProp_FillAlpha, 0.3f,
+            ImPlotProp_Flags, ImPlotLineFlags_Shaded
+        });
+
+        ImPlot::EndPlot();
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1193,6 +1193,54 @@ void Demo_PerIndexColors() {
 
         ImPlot::EndPlot();
     }
+
+    if (ImPlot::BeginPlot("Colorful Stairs", ImVec2(-1,0))) {
+        ImPlot::SetupAxes("x","y");
+        ImPlot::SetupAxesLimits(0, 1, -1.5, 1.5);
+
+        // 1. Constant color stairs
+        static double xs_stairs1[20], ys_stairs1[20];
+        for (int i = 0; i < 20; ++i) {
+            xs_stairs1[i] = i / 19.0;
+            ys_stairs1[i] = sinf(xs_stairs1[i] * 6.0 * M_PI) * 0.5;
+        }
+        ImPlot::PlotStairs("Const Color", xs_stairs1, ys_stairs1, 20, {
+            ImPlotProp_LineColor, ImVec4(1.0f, 0.5f, 0.0f, 1.0f),
+        });
+
+        // 2. Per-vertex rainbow colors
+        static double xs_stairs2[20], ys_stairs2[20];
+        static ImU32 colors_stairs_rainbow[20];
+        for (int i = 0; i < 20; ++i) {
+            xs_stairs2[i] = i / 19.0;
+            ys_stairs2[i] = cosf(xs_stairs2[i] * 4.0 * M_PI) * 0.8;
+            float t = i / 19.0f;
+            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Jet);
+            colors_stairs_rainbow[i] = ImGui::GetColorU32(color);
+        }
+        ImPlot::PlotStairs("Rainbow Stairs", xs_stairs2, ys_stairs2, 20, {
+            ImPlotProp_LineColors, colors_stairs_rainbow,
+        });
+
+        // 3. Per-vertex colormap with shaded
+        static double xs_stairs3[20], ys_stairs3[20];
+        static ImU32 colors_stairs_map[20];
+        for (int i = 0; i < 20; ++i) {
+            xs_stairs3[i] = i / 19.0;
+            ys_stairs3[i] = -0.5 + sinf(xs_stairs3[i] * 8.0 * M_PI) * 0.3;
+            float t = i / 19.0f;
+            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
+            colors_stairs_map[i] = ImGui::GetColorU32(color);
+        }
+        ImPlot::PlotStairs("Colormap Stairs+Fill", xs_stairs3, ys_stairs3, 20, {
+            ImPlotProp_LineColors, colors_stairs_map,
+            ImPlotProp_FillColors, colors_stairs_map,
+            ImPlotProp_FillAlpha, 0.4f,
+            ImPlotProp_Flags, ImPlotStairsFlags_Shaded | ImPlotStairsFlags_PreStep
+        });
+
+        ImPlot::EndPlot();
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1241,6 +1241,42 @@ void Demo_PerIndexColors() {
 
         ImPlot::EndPlot();
     }
+
+    if (ImPlot::BeginPlot("Colorful Bars", ImVec2(-1,0))) {
+        ImPlot::SetupAxes("Category","Value");
+        ImPlot::SetupAxesLimits(-0.5, 9.5, 0, 12);
+
+        // 1. Vertical bars with per-bar rainbow colors
+        static double data_v[10];
+        static ImU32 colors_v[10];
+        for (int i = 0; i < 10; ++i) {
+            data_v[i] = 3.0 + sinf(i * 0.8f * (float)M_PI) * 2.0;
+            float t = i / 9.0f;
+            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Jet);
+            colors_v[i] = ImGui::GetColorU32(color);
+        }
+        ImPlot::PlotBars("Vertical Rainbow", data_v, 10, 0.35, 0, {
+            ImPlotProp_FillColors, colors_v,
+            ImPlotProp_LineColors, colors_v,
+            ImPlotProp_FillAlpha, 0.5f
+        });
+
+        // 2. Vertical bars with colormap colors
+        static double data_v2[10];
+        static ImU32 colors_v2[10];
+        for (int i = 0; i < 10; ++i) {
+            data_v2[i] = 5.0 + cosf(i * 0.6f * (float)M_PI) * 2.5;
+            float t = i / 9.0f;
+            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
+            colors_v2[i] = ImGui::GetColorU32(color);
+        }
+        ImPlot::PlotBars("Vertical Colormap", data_v2, 10, 0.35, 0.35, {
+            ImPlotProp_FillColors, colors_v2,
+            ImPlotProp_LineColors, colors_v2,
+        });
+
+        ImPlot::EndPlot();
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1136,6 +1136,63 @@ void Demo_PerIndexColors() {
 
         ImPlot::EndPlot();
     }
+
+    if (ImPlot::BeginPlot("Colorful Bubbles", ImVec2(-1,0))) {
+        ImPlot::SetupAxes("x","y");
+        ImPlot::SetupAxesLimits(0, 1, -0.5, 1.0);
+
+        // 1. Constant color bubbles
+        static double xs_bubble1[20], ys_bubble1[20], sizes_bubble1[20];
+        for (int i = 0; i < 20; ++i) {
+            xs_bubble1[i] = i / 19.0;
+            ys_bubble1[i] = 0.7 * sinf(xs_bubble1[i] * 6.0 * M_PI);
+            sizes_bubble1[i] = 0.02 + 0.01 * sinf(xs_bubble1[i] * 10.0);
+        }
+        ImPlot::PlotBubble("Const Color Bubbles", xs_bubble1, ys_bubble1, sizes_bubble1, 20, {
+            ImPlotProp_FillColor, ImVec4(1.0f, 0.5f, 0.0f, 1.0f),
+            ImPlotProp_FillAlpha, 0.5f,
+            ImPlotProp_LineColor, ImVec4(1.0f, 0.2f, 0.0f, 1.0f),
+            ImPlotProp_LineWeight, 2.0f
+        });
+
+        // 2. Per-bubble rainbow colors
+        static double xs_bubble2[20], ys_bubble2[20], sizes_bubble2[20];
+        static ImU32 colors_bubble_rainbow[20];
+        for (int i = 0; i < 20; ++i) {
+            xs_bubble2[i] = i / 19.0;
+            ys_bubble2[i] = 0.3 * cosf(xs_bubble2[i] * 4.0 * M_PI);
+            sizes_bubble2[i] = 0.025 + 0.015 * cosf(xs_bubble2[i] * 8.0);
+            float t = i / 19.0f;
+            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Jet);
+            colors_bubble_rainbow[i] = ImGui::GetColorU32(color);
+        }
+        ImPlot::PlotBubble("Rainbow Bubbles", xs_bubble2, ys_bubble2, sizes_bubble2, 20, {
+            ImPlotProp_FillColors, colors_bubble_rainbow,
+            ImPlotProp_FillAlpha, 0.6f,
+            ImPlotProp_LineColors, colors_bubble_rainbow,
+            ImPlotProp_LineWeight, 1.5f
+        });
+
+        // 3. Per-bubble colormap colors (viridis)
+        static double xs_bubble3[20], ys_bubble3[20], sizes_bubble3[20];
+        static ImU32 colors_bubble_colormap[20];
+        for (int i = 0; i < 20; ++i) {
+            xs_bubble3[i] = i / 19.0;
+            ys_bubble3[i] = -0.3 + 0.2 * sinf(xs_bubble3[i] * 8.0 * M_PI);
+            sizes_bubble3[i] = 0.03 + 0.01 * sinf(xs_bubble3[i] * 12.0);
+            float t = i / 19.0f;
+            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
+            colors_bubble_colormap[i] = ImGui::GetColorU32(color);
+        }
+        ImPlot::PlotBubble("Colormap Bubbles", xs_bubble3, ys_bubble3, sizes_bubble3, 20, {
+            ImPlotProp_FillColors, colors_bubble_colormap,
+            ImPlotProp_FillAlpha, 0.7f,
+            ImPlotProp_LineColors, colors_bubble_colormap,
+            ImPlotProp_LineWeight, 1.0f
+        });
+
+        ImPlot::EndPlot();
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1273,6 +1273,99 @@ void Demo_PerIndexColors() {
         ImPlot::PlotBars("Vertical Colormap", data_v2, 10, 0.35, 0.35, {
             ImPlotProp_FillColors, colors_v2,
             ImPlotProp_LineColors, colors_v2,
+            ImPlotProp_FillAlpha, 0.7f,
+            ImPlotProp_LineWeight, 2.0f
+        });
+
+        ImPlot::EndPlot();
+    }
+
+    if (ImPlot::BeginPlot("Colorful Stems", ImVec2(-1,0))) {
+        ImPlot::SetupAxes("x","y");
+        ImPlot::SetupAxesLimits(-0.5, 19.5, -1.2, 1.2);
+
+        // 1. Constant color stems
+        static double xs_stem1[20], ys_stem1[20];
+        for (int i = 0; i < 20; ++i) {
+            xs_stem1[i] = i;
+            ys_stem1[i] = sinf(i * 0.4f * (float)M_PI);
+        }
+        ImPlot::PlotStems("Const Color", xs_stem1, ys_stem1, 20, 0.0, {
+            ImPlotProp_LineColor, ImVec4(1.0f, 0.3f, 0.3f, 1.0f),
+            ImPlotProp_Marker, ImPlotMarker_Circle,
+            ImPlotProp_MarkerSize, 2.0f
+        });
+
+        // 2. Per-stem rainbow colors
+        static double xs_stem2[20], ys_stem2[20];
+        static ImU32 colors_stem_rainbow[20];
+        for (int i = 0; i < 20; ++i) {
+            xs_stem2[i] = i;
+            ys_stem2[i] = cosf(i * 0.5f * (float)M_PI) * 0.8f;
+            float t = i / 19.0f;
+            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Jet);
+            colors_stem_rainbow[i] = ImGui::GetColorU32(color);
+        }
+        ImPlot::PlotStems("Rainbow Stems", xs_stem2, ys_stem2, 20, 0.0, {
+            ImPlotProp_LineColors, colors_stem_rainbow,
+            ImPlotProp_Marker, ImPlotMarker_Square,
+            ImPlotProp_MarkerSize, 2.0f
+        });
+
+        // 3. Per-stem colormap colors (Viridis)
+        static double xs_stem3[20], ys_stem3[20];
+        static ImU32 colors_stem_viridis[20];
+        for (int i = 0; i < 20; ++i) {
+            xs_stem3[i] = i;
+            ys_stem3[i] = -0.5f + sinf(i * 0.3f * (float)M_PI) * 0.5f;
+            float t = i / 19.0f;
+            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
+            colors_stem_viridis[i] = ImGui::GetColorU32(color);
+        }
+        ImPlot::PlotStems("Colormap Stems", xs_stem3, ys_stem3, 20, 0.0, {
+            ImPlotProp_LineColors, colors_stem_viridis,
+            ImPlotProp_Marker, ImPlotMarker_Diamond,
+            ImPlotProp_MarkerSize, 2.0f
+        });
+
+        ImPlot::EndPlot();
+    }
+
+    if (ImPlot::BeginPlot("Colorful Infinite Lines", ImVec2(-1,0))) {
+        ImPlot::SetupAxes("x","y");
+        ImPlot::SetupAxesLimits(0, 10, -1, 10);
+
+        // 1. Constant color infinite lines
+        static double vals1[5] = {1.0, 2.5, 4.0, 5.5, 7.0};
+        ImPlot::PlotInfLines("Const Color", vals1, 5, {
+            ImPlotProp_LineColor, ImVec4(0.0f, 0.7f, 1.0f, 1.0f),
+        });
+
+        // 2. Per-line rainbow colors (horizontal)
+        static double vals2[8];
+        static ImU32 colors_infline_rainbow[8];
+        for (int i = 0; i < 8; ++i) {
+            vals2[i] = 1.0 + i * 1.0;
+            float t = i / 7.0f;
+            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Jet);
+            colors_infline_rainbow[i] = ImGui::GetColorU32(color);
+        }
+        ImPlot::PlotInfLines("Rainbow Horizontal", vals2, 8, {
+            ImPlotProp_LineColors, colors_infline_rainbow,
+            ImPlotProp_Flags, ImPlotInfLinesFlags_Horizontal
+        });
+
+        // 3. Per-line colormap colors (vertical)
+        static double vals3[6];
+        static ImU32 colors_infline_viridis[6];
+        for (int i = 0; i < 6; ++i) {
+            vals3[i] = 1.5 + i * 1.5;
+            float t = i / 5.0f;
+            ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Plasma);
+            colors_infline_viridis[i] = ImGui::GetColorU32(color);
+        }
+        ImPlot::PlotInfLines("Plasma Vertical", vals3, 6, {
+            ImPlotProp_LineColors, colors_infline_viridis,
         });
 
         ImPlot::EndPlot();

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -692,7 +692,7 @@ struct GetterConstColor {
     GetterConstColor(ImU32 color, float alpha = 1.0f) {
         ImU32 col = color;
         if (alpha < 1.0f) {
-            ImVec4 col_vec = ImGui::ColorConvertU32ToFloat4(Color);
+            ImVec4 col_vec = ImGui::ColorConvertU32ToFloat4(col);
             col_vec.w *= alpha;
             col = ImGui::GetColorU32(col_vec);
         }

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -565,6 +565,28 @@ struct IndexerConst {
 };
 
 //-----------------------------------------------------------------------------
+// [SECTION] Color Indexers
+//-----------------------------------------------------------------------------
+
+struct IndexerIdxColor {
+    IndexerIdxColor(const ImU32* data, int count) :
+        Data(data),
+        Count(count)
+    { }
+    template <typename I> IMPLOT_INLINE ImU32 operator[](I idx) const {
+        return Data[idx];
+    }
+    const ImU32* Data;
+    int Count;
+};
+
+struct IndexerConstColor {
+    IndexerConstColor(ImU32 color) : Color(color) { }
+    template <typename I> IMPLOT_INLINE ImU32 operator[](I) const { return Color; }
+    const ImU32 Color;
+};
+
+//-----------------------------------------------------------------------------
 // [SECTION] Getters
 //-----------------------------------------------------------------------------
 
@@ -682,6 +704,16 @@ struct GetterError {
     const int Offset;
     const int Stride;
     typedef ImPlotPointError value_type;
+};
+
+template <typename _IndexerColor>
+struct GetterColor {
+  GetterColor(_IndexerColor color, int count) : Indexer(color), Count(count) { }
+  template <typename I> IMPLOT_INLINE ImU32 operator()(I idx) const {
+    return ImU32(Indexer[idx]);
+  }
+  const _IndexerColor Indexer;
+  const int Count;
 };
 
 //-----------------------------------------------------------------------------

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -1829,6 +1829,30 @@ void RenderMarkers(const _Getter& getter, ImPlotMarker marker, float size, bool 
     }
 }
 
+template <typename _Getter>
+void RenderColoredMarkers(const _Getter& getter, const ImPlotNextItemData& s) {
+    const ImU32 col_line = ImGui::GetColorU32(s.Spec.MarkerLineColor);
+    const ImU32 col_fill = ImGui::GetColorU32(s.Spec.MarkerFillColor);
+
+    if (s.Spec.MarkerFillColors != nullptr && s.Spec.MarkerLineColors != nullptr) {
+        GetterIdxColor fill_getter(s.Spec.MarkerFillColors, getter.Count, s.Spec.FillAlpha);
+        GetterIdxColor line_getter(s.Spec.MarkerLineColors, getter.Count);
+        RenderMarkers<_Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
+    } else if (s.Spec.MarkerFillColors != nullptr) {
+        GetterIdxColor fill_getter(s.Spec.MarkerFillColors, getter.Count, s.Spec.FillAlpha);
+        GetterConstColor line_getter(col_line);
+        RenderMarkers<_Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
+    } else if (s.Spec.MarkerLineColors != nullptr) {
+        GetterConstColor fill_getter(col_fill);
+        GetterIdxColor line_getter(s.Spec.MarkerLineColors, getter.Count);
+        RenderMarkers<_Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
+    } else {
+        GetterConstColor fill_getter(col_fill);
+        GetterConstColor line_getter(col_line);
+        RenderMarkers<_Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
+    }
+}
+
 //-----------------------------------------------------------------------------
 // [SECTION] PlotLine
 //-----------------------------------------------------------------------------
@@ -1902,25 +1926,7 @@ void PlotLineEx(const char* label_id, const _Getter& getter, const ImPlotSpec& s
                 PopPlotClipRect();
                 PushPlotClipRect(s.Spec.MarkerSize);
             }
-            const ImU32 col_line = ImGui::GetColorU32(s.Spec.MarkerLineColor);
-            const ImU32 col_fill = ImGui::GetColorU32(s.Spec.MarkerFillColor);
-            if (s.Spec.MarkerFillColors != nullptr && s.Spec.MarkerLineColors != nullptr) {
-                GetterIdxColor fill_getter(s.Spec.MarkerFillColors, getter.Count, s.Spec.FillAlpha);
-                GetterIdxColor line_getter(s.Spec.MarkerLineColors, getter.Count);
-                RenderMarkers<_Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            } else if (s.Spec.MarkerFillColors != nullptr) {
-                GetterIdxColor fill_getter(s.Spec.MarkerFillColors, getter.Count, s.Spec.FillAlpha);
-                GetterConstColor line_getter(col_line);
-                RenderMarkers<_Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            } else if (s.Spec.MarkerLineColors != nullptr) {
-                GetterConstColor fill_getter(col_fill);
-                GetterIdxColor line_getter(s.Spec.MarkerLineColors, getter.Count);
-                RenderMarkers<_Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            } else {
-                GetterConstColor fill_getter(col_fill);
-                GetterConstColor line_getter(col_line);
-                RenderMarkers<_Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            }
+            RenderColoredMarkers(getter, s);
         }
         EndItem();
     }
@@ -1969,25 +1975,7 @@ void PlotScatterEx(const char* label_id, const Getter& getter, const ImPlotSpec&
                 PopPlotClipRect();
                 PushPlotClipRect(s.Spec.MarkerSize);
             }
-            const ImU32 col_line = ImGui::GetColorU32(s.Spec.MarkerLineColor);
-            const ImU32 col_fill = ImGui::GetColorU32(s.Spec.MarkerFillColor);
-            if (s.Spec.MarkerFillColors != nullptr && s.Spec.MarkerLineColors != nullptr) {
-                GetterIdxColor fill_getter(s.Spec.MarkerFillColors, getter.Count, s.Spec.FillAlpha);
-                GetterIdxColor line_getter(s.Spec.MarkerLineColors, getter.Count);
-                RenderMarkers<Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            } else if (s.Spec.MarkerFillColors != nullptr) {
-                GetterIdxColor fill_getter(s.Spec.MarkerFillColors, getter.Count, s.Spec.FillAlpha);
-                GetterConstColor line_getter(col_line);
-                RenderMarkers<Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            } else if (s.Spec.MarkerLineColors != nullptr) {
-                GetterConstColor fill_getter(col_fill);
-                GetterIdxColor line_getter(s.Spec.MarkerLineColors, getter.Count);
-                RenderMarkers<Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            } else {
-                GetterConstColor fill_getter(col_fill);
-                GetterConstColor line_getter(col_line);
-                RenderMarkers<Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            }
+            RenderColoredMarkers(getter, s);
         }
         EndItem();
     }
@@ -2131,25 +2119,7 @@ void PlotStairsEx(const char* label_id, const Getter& getter, const ImPlotSpec& 
         if (s.RenderMarkers) {
             PopPlotClipRect();
             PushPlotClipRect(s.Spec.MarkerSize);
-            const ImU32 col_line = ImGui::GetColorU32(s.Spec.MarkerLineColor);
-            const ImU32 col_fill = ImGui::GetColorU32(s.Spec.MarkerFillColor);
-            if (s.Spec.MarkerFillColors != nullptr && s.Spec.MarkerLineColors != nullptr) {
-                GetterIdxColor fill_getter(s.Spec.MarkerFillColors, getter.Count, s.Spec.FillAlpha);
-                GetterIdxColor line_getter(s.Spec.MarkerLineColors, getter.Count);
-                RenderMarkers<Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            } else if (s.Spec.MarkerFillColors != nullptr) {
-                GetterIdxColor fill_getter(s.Spec.MarkerFillColors, getter.Count, s.Spec.FillAlpha);
-                GetterConstColor line_getter(col_line);
-                RenderMarkers<Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            } else if (s.Spec.MarkerLineColors != nullptr) {
-                GetterConstColor fill_getter(col_fill);
-                GetterIdxColor line_getter(s.Spec.MarkerLineColors, getter.Count);
-                RenderMarkers<Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            } else {
-                GetterConstColor fill_getter(col_fill);
-                GetterConstColor line_getter(col_line);
-                RenderMarkers<Getter>(getter, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            }
+            RenderColoredMarkers(getter, s);
         }
         EndItem();
     }
@@ -2576,25 +2546,7 @@ void PlotStemsEx(const char* label_id, const _GetterM& getter_mark, const _Gette
         if (s.RenderMarkers) {
             PopPlotClipRect();
             PushPlotClipRect(s.Spec.MarkerSize);
-            const ImU32 col_line = ImGui::GetColorU32(s.Spec.MarkerLineColor);
-            const ImU32 col_fill = ImGui::GetColorU32(s.Spec.MarkerFillColor);
-            if (s.Spec.MarkerFillColors != nullptr && s.Spec.MarkerLineColors != nullptr) {
-                GetterIdxColor fill_getter(s.Spec.MarkerFillColors, getter_mark.Count);
-                GetterIdxColor line_getter(s.Spec.MarkerLineColors, getter_mark.Count);
-                RenderMarkers<_GetterM>(getter_mark, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            } else if (s.Spec.MarkerFillColors != nullptr) {
-                GetterIdxColor fill_getter(s.Spec.MarkerFillColors, getter_mark.Count);
-                GetterConstColor line_getter(col_line);
-                RenderMarkers<_GetterM>(getter_mark, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            } else if (s.Spec.MarkerLineColors != nullptr) {
-                GetterConstColor fill_getter(col_fill);
-                GetterIdxColor line_getter(s.Spec.MarkerLineColors, getter_mark.Count);
-                RenderMarkers<_GetterM>(getter_mark, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            } else {
-                GetterConstColor fill_getter(col_fill);
-                GetterConstColor line_getter(col_line);
-                RenderMarkers<_GetterM>(getter_mark, s.Spec.Marker, s.Spec.MarkerSize, s.RenderMarkerFill, fill_getter, s.RenderMarkerLine, line_getter, s.Spec.LineWeight);
-            }
+            RenderColoredMarkers(getter_mark, s);
         }
         EndItem();
     }

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -2377,7 +2377,7 @@ void PlotBarsHEx(const char* label_id, const Getter1& getter1, const Getter2& ge
                 GetterIdxColor fill_getter(s.Spec.FillColors, getter1.Count, s.Spec.FillAlpha);
                 RenderPrimitives3<RendererBarsFillH>(getter1, getter2, fill_getter, height);
             } else {
-                GetterConstColor fill_getter(col_fill);
+                GetterConstColor fill_getter(col_fill, s.Spec.FillAlpha);
                 RenderPrimitives3<RendererBarsFillH>(getter1, getter2, fill_getter, height);
             }
             if (rend_line && col_fill == col_line)

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -705,6 +705,7 @@ struct GetterConstColor {
 struct GetterIdxColor {
     GetterIdxColor(const ImU32* data, int count, float alpha = 1.0f) : Data(data), Count(count), Alpha(alpha) { }
     template <typename I> IMPLOT_INLINE ImU32 operator[](I idx) const {
+        IM_ASSERT(idx >= 0 && idx < Count);
         ImU32 col = Data[idx];
         if (Alpha < 1.0f) {
             ImVec4 col_vec = ImGui::ColorConvertU32ToFloat4(col);
@@ -731,6 +732,7 @@ struct GetterConstSize {
 struct GetterIdxSize {
     GetterIdxSize(const float* data, int count) : Data(data), Count(count) { }
     template <typename I> IMPLOT_INLINE float operator[](I idx) const {
+        IM_ASSERT(idx >= 0 && idx < Count);
         return Data[idx];
     }
     const float* Data;

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -1917,7 +1917,7 @@ void PlotLineEx(const char* label_id, const _Getter& getter, const ImPlotSpec& s
                     RenderPrimitives3<RendererShaded>(getter,getter2,color_getter);
                 } else {
                     const ImU32 col_fill = ImGui::GetColorU32(s.Spec.FillColor);
-                    GetterConstColor color_getter(col_fill);
+                    GetterConstColor color_getter(col_fill, s.Spec.FillAlpha);
                     RenderPrimitives3<RendererShaded>(getter,getter2,color_getter);
                 }
             }
@@ -2270,7 +2270,7 @@ void PlotShadedEx(const char* label_id, const Getter1& getter1, const Getter2& g
                 RenderPrimitives3<RendererShaded>(getter1,getter2,color_getter);
             } else {
                 const ImU32 col = ImGui::GetColorU32(s.Spec.FillColor);
-                GetterConstColor color_getter(col);
+                GetterConstColor color_getter(col, s.Spec.FillAlpha);
                 RenderPrimitives3<RendererShaded>(getter1,getter2,color_getter);
             }
         }


### PR DESCRIPTION
Closes #485
Closes #298

# Per-Index Color/Size Support with ImPlotSpec

<p align="center">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/85414f8d-03dc-4064-8b9c-325eccc4a16d" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/fdd61d1e-9621-4c1f-b9e8-5bd2d7cd2d45" />
</p>

<p align="center">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/62333f2d-9938-44c9-91a5-af746660ebf2" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/413d9ffd-a191-4156-9cd6-f60e37d6aea1" />
</p>

## Summary

This PR introduces comprehensive per-index color support across all ImPlot plot types. Users can now specify an array of colors to apply different colors to each vertex, segment, bar, marker, or other primitive in their plots, enabling rich data visualizations with color-coded information.

This implementation is based on previous work #332 by @niavok, #665 by @vincentjzy, and #608 by @mihaly-sisak.

## Features

### New Properties

Four new `ImPlotSpec` properties have been added to enable per-index coloring:

- **`ImPlotProp_LineColors`** - Array of `ImU32` colors for line segments/vertices
- **`ImPlotProp_FillColors`** - Array of `ImU32` colors for filled regions
- **`ImPlotProp_MarkerLineColors`** - Array of `ImU32` colors for marker outlines
- **`ImPlotProp_MarkerFillColors`** - Array of `ImU32` colors for marker fills
- **`ImPlotProp_MarkerSizes`** - Array of `float` for marker sizes

### Supported Plot Types

Per-index colors are now supported in:
- Line plots (`PlotLine`)
- Shaded plots (`PlotShaded`)
- Scatter plots (`PlotScatter`)
- Bubble plots (`PlotBubbles`)
- Bar plots (`PlotBars`)
- Stairstep plots (`PlotStairs`)
- Stem plots (`PlotStems`)
- Infinite line plots (`PlotInfLines`)

## Usage Example

### Constant Color (Existing Behavior)

The existing single-color properties continue to work as before:

```cpp
static float xs[100], ys[100];
for (int i = 0; i < 100; ++i) {
    xs[i] = i * 0.01f;
    ys[i] = sinf(xs[i] * 20.0f);
}

if (ImPlot::BeginPlot("Single Color Line")) {
    ImPlot::PlotLine("Data", xs, ys, 100, {
        ImPlotProp_LineColor, ImVec4(1.0f, 0.5f, 0.0f, 1.0f),
        ImPlotProp_LineWeight, 2.0f
    });
    ImPlot::EndPlot();
}
```

### Per-Index Colors (New Feature)

To use per-index colors, provide an array of `ImU32` colors:

```cpp
static float xs[100], ys[100];
static ImU32 colors[100];

for (int i = 0; i < 100; ++i) {
    xs[i] = i * 0.01f;
    ys[i] = sinf(xs[i] * 20.0f);
    
    // Generate rainbow colors
    float hue = i / 99.0f;
    colors[i] = ImColor::HSV(hue, 0.8f, 0.9f);
}

if (ImPlot::BeginPlot("Rainbow Line")) {
    ImPlot::PlotLine("Data", xs, ys, 100, {
        ImPlotProp_LineColors, colors,  // Per-vertex colors
        ImPlotProp_LineWeight, 2.0f
    });
    ImPlot::EndPlot();
}
```

### Scatter Plot with Per-Marker Colors/Sizes

```cpp
static float xs[50], ys[50];
static ImU32 fill_colors[50], line_colors[50], marker_sizes[50]

for (int i = 0; i < 50; ++i) {
    xs[i] = i * 0.02f;
    ys[i] = xs[i] + 0.1f * ((float)rand() / (float)RAND_MAX);
    
    // Sample from a colormap
    float t = i / 49.0f;
    ImVec4 color = ImPlot::SampleColormap(t, ImPlotColormap_Viridis);
    fill_colors[i] = ImGui::GetColorU32(color);
    line_colors[i] = ImGui::GetColorU32(ImVec4(color.x * 0.7f, color.y * 0.7f, color.z * 0.7f, 1.0f));
    marker_sizes[i] = 6 * i / 49.0f;
}

if (ImPlot::BeginPlot("Colorful Scatter")) {
    ImPlot::PlotScatter("Data", xs, ys, 50, {
        ImPlotProp_Marker, ImPlotMarker_Circle,
        ImPlotProp_MarkerSize, 8.0f,
        ImPlotProp_MarkerFillColors, fill_colors,
        ImPlotProp_MarkerLineColors, line_colors,
        ImPlotProp_MarkerSizes, marker_sizes
    });
    ImPlot::EndPlot();
}
```

### Bar Plot with Per-Bar Colors

```cpp
static double data[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
static ImU32 colors[10];

for (int i = 0; i < 10; ++i) {
    float hue = i / 9.0f;
    colors[i] = ImColor::HSV(hue, 0.8f, 0.9f);
}

if (ImPlot::BeginPlot("Colorful Bars")) {
    ImPlot::PlotBars("Data", data, 10, 0.7, 1, {
        ImPlotProp_FillColors, colors,
        ImPlotProp_LineColors, colors
    });
    ImPlot::EndPlot();
}
```

## Implementation Details

### Color Getter Architecture

The implementation uses a template-based color getter system:

- **`GetterConstColor`** - Returns a constant color for all indices (used when single color is specified)
- **`GetterIdxColor`** - Returns per-index colors from an array (used when color array is specified)

Both getters support alpha blending via a constructor parameter.

### Backward Compatibility

All existing code continues to work without modification. The new per-index color properties are optional and only used when explicitly provided. When not specified, plots use the existing single-color properties (`ImPlotProp_LineColor`, `ImPlotProp_FillColor`, etc.).

## Demo

A comprehensive "Per-Index Colors" demo has been added to `implot_demo.cpp` showcasing:

- Colorful Lines (animated rainbow line and discrete colormap line)
- Colorful Scatter (rainbow and colormap markers)
- Colorful Shaded Plots (per-vertex colors with shading)
- Colorful Bubbles (per-bubble rainbow and colormap colors)
- Colorful Stairstep Plots (pre-step and post-step with colors)
- Colorful Bar Plots (vertical and horizontal colored bars)
- Colorful Stem Plots (colored stems with markers)
- Colorful Infinite Lines (colored vertical and horizontal lines)

Run the demo to see all the colorful plot examples in action!

## Testing

- Verified compilation on Linux, Windows (MSVC), and macOS
- All existing demos continue to work correctly
- New colorful demos showcase the feature across all plot types
- Backward compatibility maintained - no breaking changes

## Notes

- Color arrays must have at least as many elements as data points in the plot
- Colors are specified as `ImU32` (use `ImGui::GetColorU32()` or `ImColor` to convert from `ImVec4`)
- Alpha values in per-index colors are multiplied by `FillAlpha` property when applicable
- The feature integrates seamlessly with existing ImPlot styling and theming
