### PR TITLE
Feat: Different types of legend icon

### DIFF
--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -2596,7 +2596,7 @@ void PlotCandlestick(const char* label_id, const double* xs, const double* opens
     }
 
     // begin plot item
-    if (ImPlot::BeginItem(label_id)) {
+    if (ImPlot::BeginItem(label_id, ImPlotLegendIconType_FillLine)) {
         // override legend icon color
         ImPlot::GetCurrentItem()->Color = IM_COL32(64,64,64,255);
         // fit data if requested

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -967,26 +967,55 @@ struct ImPlotAlignmentData {
     void Reset() { PadA = PadB = PadAMax = PadBMax = 0; }
 };
 
+// Legend icon types
+enum ImPlotLegendIconType_ {
+    ImPlotLegendIconType_Line,          // Horizontal line (line plots)
+    ImPlotLegendIconType_LineMarkers,   // Horizontal line with marker (line plots with markers)
+    ImPlotLegendIconType_Markers,       // Single marker (scatter plots)
+    ImPlotLegendIconType_Fill,          // Filled square (shaded plots, pie charts)
+    ImPlotLegendIconType_FillLine       // Filled square with outline (bars, histograms)
+};
+
 // State information for Plot items
 struct ImPlotItem
 {
-    ImGuiID      ID;
-    ImU32        Color;
-    ImPlotMarker Marker;
-    ImRect       LegendHoverRect;
-    int          NameOffset;
-    bool         Show;
-    bool         LegendHovered;
-    bool         SeenThisFrame;
+    ImGuiID              ID;
+    ImU32                Color;
+    ImU32                LineColor;
+    ImU32                FillColor;
+    ImU32                MarkerLineColor;
+    ImU32                MarkerFillColor;
+    ImPlotMarker         Marker;
+    ImPlotItemFlags      LegendFlags;
+    ImPlotLegendIconType_ LegendIconType;
+    ImRect               LegendHoverRect;
+    int                  NameOffset;
+    bool                 Show;
+    bool                 LegendHovered;
+    bool                 SeenThisFrame;
+    bool                 LegendRenderLine;
+    bool                 LegendRenderFill;
+    bool                 LegendRenderMarkers;
+    float                LegendLineWeight;
 
     ImPlotItem() {
-        ID            = 0;
-        Color         = IM_COL32_WHITE;
-        Marker        = ImPlotMarker_None;
-        NameOffset    = -1;
-        Show          = true;
-        SeenThisFrame = false;
-        LegendHovered = false;
+        ID                   = 0;
+        Color                = IM_COL32_WHITE;
+        LineColor            = IM_COL32_WHITE;
+        FillColor            = IM_COL32_WHITE;
+        MarkerLineColor      = IM_COL32_WHITE;
+        MarkerFillColor      = IM_COL32_WHITE;
+        Marker               = ImPlotMarker_None;
+        LegendFlags          = ImPlotItemFlags_None;
+        LegendIconType       = ImPlotLegendIconType_Line;
+        NameOffset           = -1;
+        Show                 = true;
+        SeenThisFrame        = false;
+        LegendHovered        = false;
+        LegendRenderLine     = false;
+        LegendRenderFill     = false;
+        LegendRenderMarkers  = false;
+        LegendLineWeight     = 1.0f;
     }
 
     ~ImPlotItem() { ID = 0; }
@@ -1333,12 +1362,12 @@ IMPLOT_API void ShowSubplotsContextMenu(ImPlotSubplot& subplot);
 //-----------------------------------------------------------------------------
 
 // Begins a new item. Returns false if the item should not be plotted. Pushes PlotClipRect.
-IMPLOT_API bool BeginItem(const char* label_id, const ImPlotSpec& spec = ImPlotSpec(), const ImVec4& item_col = IMPLOT_AUTO_COL, ImPlotMarker item_mkr = ImPlotMarker_Invalid);
+IMPLOT_API bool BeginItem(const char* label_id, ImPlotLegendIconType_ icon_type, const ImPlotSpec& spec = ImPlotSpec(), const ImVec4& item_col = IMPLOT_AUTO_COL, ImPlotMarker item_mkr = ImPlotMarker_Invalid);
 
 // Same as above but with fitting functionality.
 template <typename _Fitter>
-bool BeginItemEx(const char* label_id, const _Fitter& fitter, const ImPlotSpec& spec, const ImVec4& item_col = IMPLOT_AUTO_COL, ImPlotMarker item_mkr = ImPlotMarker_Invalid) {
-    if (BeginItem(label_id, spec, item_col, item_mkr)) {
+bool BeginItemEx(const char* label_id, ImPlotLegendIconType_ icon_type, const _Fitter& fitter, const ImPlotSpec& spec, const ImVec4& item_col = IMPLOT_AUTO_COL, ImPlotMarker item_mkr = ImPlotMarker_Invalid) {
+    if (BeginItem(label_id, icon_type, spec, item_col, item_mkr)) {
         ImPlotPlot& plot = *GetCurrentPlot();
         if (plot.FitThisFrame && !ImHasFlag(spec.Flags, ImPlotItemFlags_NoFit))
             fitter.Fit(plot.Axes[plot.CurrentX], plot.Axes[plot.CurrentY]);


### PR DESCRIPTION
Closes #569
Closes #160

<p align="center">
<img width="350" alt="Image" src="https://github.com/user-attachments/assets/00f410a8-8037-446b-8631-90adec414e7f" />

<img width="350" alt="Image" src="https://github.com/user-attachments/assets/6446043a-5b4a-448f-95bf-0942873e0f71" />
</p>

<p align="center">
<img width="350"  alt="Image" src="https://github.com/user-attachments/assets/2e4d9957-16f7-421a-9988-a1a0c263282f" />

<img width="350" alt="Image" src="https://github.com/user-attachments/assets/dbb7f319-028b-402f-8a1a-af1b66173310" />
</p

# Improved Legend Icons

## Summary
Legend icons now accurately represent the plot type instead of always showing a solid square.

## Changes
- **Line plots**: Display as horizontal lines in legend
- **Line plots with markers**: Display as horizontal line with centered marker
- **Scatter plots**: Display as single marker (no line)
- **Filled plots** (shaded, pie, heatmap, digital): Display as filled square
- **Bar plots/histograms**: Display as filled square with outline

## Implementation
- Added `ImPlotLegendIconType_` enum with 5 icon types: Line, LineMarkers, Markers, Fill, FillLine
- Extended `ImPlotItem` to store legend rendering data (colors, marker type, line weight, icon type)
- Added `RenderLegendIcon()` to render icons based on type
- Each plot function explicitly sets its icon type when calling `BeginItem()`
- Markers in legend are consistently sized at 0.5× icon width

## Technical Details
- Icon type is determined per-plot-type
- Legend icons respect the same color properties as the plot (line color, fill color, marker colors)
- Icons respond to hover/held/disabled states with alpha modulation
- No breaking changes to public API