### PR TITLE
Feat: Line styles (dashed lines)

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -4556,6 +4556,77 @@ ImPlotMarker NextMarker() {
     ++gp.CurrentItems->MarkerIdx;
     return idx;
 }
+
+void LoadDefaultLineStyles() {
+    const ImU32 Dash[] = {10, 6};
+    const ImU32 Dot[]  = {2, 6};
+    const ImU32 DashDot[] = {10, 6, 2, 6};
+    const ImU32 DashDotDot[] = {10, 6, 2, 6, 2, 6};
+
+    AddLineStyle(Dash, sizeof(Dash)/sizeof(ImU32));
+    AddLineStyle(Dot, sizeof(Dot)/sizeof(ImU32));
+    AddLineStyle(DashDot, sizeof(DashDot)/sizeof(ImU32));
+    AddLineStyle(DashDotDot, sizeof(DashDotDot)/sizeof(ImU32));
+}
+
+int AddLineStyle(const ImU32* keys, int count) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(count > 1, "The line style size must be greater than 1!");
+    int period = 0;
+    for (int i = 0; i < count; ++i){
+        period += keys[i];
+    }
+    // Get font atlas and add a custom rectangle to it
+    ImFontAtlas *atlas = ImGui::GetIO().Fonts;
+    ImFontAtlasRectId rectID = atlas->AddCustomRect(510, 1);
+    int keyIdx = 0;
+    ImU32 k = 0;
+    ImU32 color = ~0;
+    if (rectID != -1)
+    {
+        // Build the atlas and get the pixel data
+        unsigned char* pixels;
+        int width, height;
+        atlas->GetTexDataAsRGBA32(&pixels, &width, &height);
+        // Retrieve the rectangle location and fill it with data
+        ImFontAtlasRect rect;
+        if (atlas->GetCustomRect(rectID, &rect))
+        {
+            for (int i = 0; i < rect.h; i++)
+            {
+                // Calculate the pointer to the start of the row in the atlas
+                ImU32* row = (ImU32*)pixels + (rect.y + i) * width + rect.x;
+                for (int j = 0; j < rect.w; j++)
+                {
+                    row[j] = color;
+                    if (++k >= keys[keyIdx]) {
+                        color = ~color;
+                        keyIdx = (keyIdx + 1) % count;
+                        k = 0;
+                    }
+                }
+            }
+            ImPlotLineStyleData data(rectID, period, 510);
+            gp.LineStyleData.push_back(data);
+            return gp.LineStyleData.Size - 1;
+        }
+        else
+            IM_ASSERT(0 && "Failed to retrieve custom rectangle from font atlas for line style!");
+    }
+    else
+        IM_ASSERT(0 && "Failed to add custom rectangle to font atlas for line style!");
+
+    return -1;
+}
+
+const ImPlotLineStyleData& GetLineStyleData(ImPlotLineStyle style) {
+    ImPlotContext& gp = *GImPlot;
+    IM_ASSERT_USER_ERROR(style >= 0 && style < gp.LineStyleData.Size, "Invalid line style index!");
+    const ImPlotLineStyleData& data = gp.LineStyleData[style];
+    if (!ImGui::GetIO().Fonts->GetCustomRect(data.RectID, &data.Rect))
+        IM_ASSERT(0 && "Failed to retrieve custom rectangle from font atlas for line style!");
+    return data;
+}
     
 //------------------------------------------------------------------------------
 // [Section] Colormaps

--- a/implot.cpp
+++ b/implot.cpp
@@ -4563,19 +4563,34 @@ void LoadDefaultLineStyles() {
     const ImU32 DashDot[] = {10, 6, 2, 6};
     const ImU32 DashDotDot[] = {10, 6, 2, 6, 2, 6};
 
-    AddLineStyle(Dash, sizeof(Dash)/sizeof(ImU32));
-    AddLineStyle(Dot, sizeof(Dot)/sizeof(ImU32));
-    AddLineStyle(DashDot, sizeof(DashDot)/sizeof(ImU32));
-    AddLineStyle(DashDotDot, sizeof(DashDotDot)/sizeof(ImU32));
+    // The default line styles are added at fixed indices
+    // We use the internal add function with the desired index to ensure they are stored in the correct order and that user defined line styles are added after them
+    AddLineStyleInternal(ImPlotLineStyle_Dashed, Dash, sizeof(Dash)/sizeof(ImU32));
+    AddLineStyleInternal(ImPlotLineStyle_Dotted, Dot, sizeof(Dot)/sizeof(ImU32));
+    AddLineStyleInternal(ImPlotLineStyle_DashDot, DashDot, sizeof(DashDot)/sizeof(ImU32));
+    AddLineStyleInternal(ImPlotLineStyle_DashDotDot, DashDotDot, sizeof(DashDotDot)/sizeof(ImU32));
 }
 
 int AddLineStyle(const ImU32* keys, int count) {
+    IM_ASSERT_USER_ERROR(count > 1 && count % 2 == 0, "The line style size must be greater than 1 and even!");
+    // User defined line styles are added after the default line styles, so we start with an index of -1 to append to the end of the list
+    return AddLineStyleInternal(-1, keys, count);
+}
+
+int AddLineStyleInternal(const int ID, const ImU32* keys, const int count) {
+    IM_ASSERT(ID < ImPlotLineStyle_COUNT || ID == -1); // ID must be a valid default line style index or -1 for user defined styles
     ImPlotContext& gp = *GImPlot;
-    IM_ASSERT_USER_ERROR(count > 1, "The line style size must be greater than 1!");
     int period = 0;
     for (int i = 0; i < count; ++i){
         period += keys[i];
     }
+    // Reserve space for default line styles if they haven't been added yet
+    if (gp.LineStyleData.Size < ImPlotLineStyle_COUNT) {
+        gp.LineStyleData.resize(ImPlotLineStyle_COUNT);
+        for (int i = 0; i < ImPlotLineStyle_COUNT; ++i) gp.LineStyleData[i].RectID = -1;
+    }
+    if (ID >= 0 && gp.LineStyleData[ID].RectID != -1)
+        return ID; // If the ID is already used
     // Get font atlas and add a custom rectangle to it
     ImFontAtlas *atlas = ImGui::GetIO().Fonts;
     ImFontAtlasRectId rectID = atlas->AddCustomRect(510, 1);
@@ -4606,8 +4621,11 @@ int AddLineStyle(const ImU32* keys, int count) {
                     }
                 }
             }
-            ImPlotLineStyleData data(rectID, period, 510);
-            gp.LineStyleData.push_back(data);
+            // Add the line style data to the context
+            if (ID < 0)
+                gp.LineStyleData.push_back(ImPlotLineStyleData(rectID, period, 510));
+            else
+                gp.LineStyleData[ID] = ImPlotLineStyleData(rectID, period, 510);
             return gp.LineStyleData.Size - 1;
         }
         else
@@ -4615,7 +4633,6 @@ int AddLineStyle(const ImU32* keys, int count) {
     }
     else
         IM_ASSERT(0 && "Failed to add custom rectangle to font atlas for line style!");
-
     return -1;
 }
 

--- a/implot.h
+++ b/implot.h
@@ -115,6 +115,7 @@ typedef int ImPlotCond;               // -> enum ImPlotCond_
 typedef int ImPlotCol;                // -> enum ImPlotCol_
 typedef int ImPlotStyleVar;           // -> enum ImPlotStyleVar_
 typedef int ImPlotScale;              // -> enum ImPlotScale_
+typedef int ImPlotLineStyle;          // -> enum ImPlotLineStyle_
 typedef int ImPlotMarker;             // -> enum ImPlotMarker_
 typedef int ImPlotColormap;           // -> enum ImPlotColormap_
 typedef int ImPlotLocation;           // -> enum ImPlotLocation_
@@ -139,6 +140,7 @@ enum ImAxis_ {
 enum ImPlotProp_ {
     ImPlotProp_LineColor,       // line color (applies to lines, bar edges); IMPLOT_AUTO_COL will use next Colormap color or current item color
     ImPlotProp_LineWeight,      // line weight in pixels (applies to lines, bar edges, marker edges)
+    ImPlotProp_LineStyle,       // line style (applies to lines)
     ImPlotProp_FillColor,       // fill color (applies to shaded regions, bar faces); IMPLOT_AUTO_COL will use next Colormap color or current item color
     ImPlotProp_FillAlpha,       // alpha multiplier (applies to FillColor and MarkerFillColor)
     ImPlotProp_Marker,          // marker type; specify ImPlotMarker_Auto to use the next unused marker
@@ -429,6 +431,16 @@ enum ImPlotScale_ {
     ImPlotScale_SymLog,     // symmetric log scale
 };
 
+// Line style specifications.
+enum ImPlotLineStyle_ {
+    ImPlotLineStyle_Solid = -1,// default
+    ImPlotLineStyle_Dashed,    // 6px on, 6px off
+    ImPlotLineStyle_Dotted,    // 2px on, 6px off
+    ImPlotLineStyle_DashDot,   // 6px on, 2px off, 2px on, 2px off
+    ImPlotLineStyle_DashDotDot,// 6px on, 2px off, 2px on, 2px off, 2px on, 2px off
+    ImPlotLineStyle_COUNT
+};
+
 // Marker specifications.
 enum ImPlotMarker_ {
     ImPlotMarker_None = -2, // no marker
@@ -510,6 +522,7 @@ enum ImPlotBin_ {
 struct ImPlotSpec {
     ImVec4          LineColor       = IMPLOT_AUTO_COL;       // line color (applies to lines, bar edges); IMPLOT_AUTO_COL will use next Colormap color or current item color
     float           LineWeight      = 1.0f;                  // line weight in pixels (applies to lines, bar edges, marker edges)
+    ImPlotLineStyle LineStyle       = ImPlotLineStyle_Solid; // line style (applies to lines)
     ImVec4          FillColor       = IMPLOT_AUTO_COL;       // fill color (applies to shaded regions, bar faces); IMPLOT_AUTO_COL will use next Colormap color or current item color
     float           FillAlpha       = 1.0f;                  // alpha multiplier (applies to FillColor and MarkerFillColor)
     ImPlotMarker    Marker          = ImPlotMarker_None;     // marker type; specify ImPlotMarker_Auto to use the next unused marker
@@ -544,6 +557,7 @@ struct ImPlotSpec {
         switch (prop) {
         case ImPlotProp_LineColor       : LineColor       = ImGui::ColorConvertU32ToFloat4((ImU32)v); return;
         case ImPlotProp_LineWeight      : LineWeight      = (float)v;                                 return;
+        case ImPlotProp_LineStyle       : LineStyle       = (ImPlotLineStyle)v;                       return;
         case ImPlotProp_FillColor       : FillColor       = ImGui::ColorConvertU32ToFloat4((ImU32)v); return;
         case ImPlotProp_FillAlpha       : FillAlpha       = (float)v;                                 return;
         case ImPlotProp_Marker          : Marker          = (ImPlotMarker)v;                          return;
@@ -1215,6 +1229,11 @@ IMPLOT_API const char* GetMarkerName(ImPlotMarker idx);
 
 // Returns the next marker and advances the marker for the current plot. You need to call this between Begin/EndPlot!
 IMPLOT_API ImPlotMarker NextMarker();
+
+// Executes post-setup initialization
+IMPLOT_API void LoadDefaultLineStyles();
+
+IMPLOT_API int AddLineStyle(const ImU32* keys, int count);
 
 //-----------------------------------------------------------------------------
 // [SECTION] Colormaps

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1065,18 +1065,35 @@ void Demo_RealtimePlots() {
 
 void Demo_LineStyles() {
     IMGUI_DEMO_MARKER("Plots/Line Styles");
-    // ImPlot::LoadDefaultLineStyles() must be called before using line styles!
-    // It should be called once during font loading.
     static ImPlotSpec spec;
+    static bool is_init = false;
+    static ImPlotLineStyle custom_style[2];
+    // Custom line styles are defined by an array of on/off lengths in pixels.
+    // The first element is the length of the dash, the second is the length of the gap, and so on.
+    static ImU32 styleA[] = {15, 6, 15, 6, 2, 6}; // dash, dash, dot
+    static ImU32 styleB[] = {20, 6, 10, 6}; // long dash, short dash
+
+    // ImPlot::LoadDefaultLineStyles() must be called before using line styles!
+    // It should be called once after context creation and backend initialization
+    // Called here for demo purposes, but you should call it in your initialization code.
+    if (!is_init) {
+        // Register custom line style before loading defaults
+        custom_style[0] = ImPlot::AddLineStyle(styleA, sizeof(styleA)/sizeof(ImU32));
+        // Load default line styles
+        ImPlot::LoadDefaultLineStyles();
+        // Register custom line style after loading defaults (order doesn't matter)
+        custom_style[1] = ImPlot::AddLineStyle(styleB, sizeof(styleB)/sizeof(ImU32));
+        is_init = true;
+    }
     ImGui::DragFloat("Line Weight", &spec.LineWeight,0.05f,0.5f,32.0f,"%.2f px");
 
     if (ImPlot::BeginPlot("##LineStyles", ImVec2(-1,0), ImPlotFlags_CanvasOnly)) {
 
         ImPlot::SetupAxes(nullptr, nullptr, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations);
-        ImPlot::SetupAxesLimits(0, 5, 0, 7);
+        ImPlot::SetupAxesLimits(0, 5, 0, 9);
 
         ImS8 xs[2] = {1,4};
-        ImS8 ys[2] = {5,6};
+        ImS8 ys[2] = {7,8};
 
         // Line Styles
         for (int m = 0; m < ImPlotLineStyle_COUNT; ++m) {
@@ -1086,7 +1103,14 @@ void Demo_LineStyles() {
             ImGui::PopID();
             ys[0]--; ys[1]--;
         }
-
+        // Custom Line Styles
+        for (int m = 0; m < 2; ++m) {
+            ImGui::PushID(m);
+            spec.LineStyle = custom_style[m];
+            ImPlot::PlotLine("##Custom", xs, ys, 2, spec);
+            ImGui::PopID();
+            ys[0]--; ys[1]--;
+        }
         ImPlot::EndPlot();
     }
 }

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1063,6 +1063,36 @@ void Demo_RealtimePlots() {
 
 //-----------------------------------------------------------------------------
 
+void Demo_LineStyles() {
+    IMGUI_DEMO_MARKER("Plots/Line Styles");
+    // ImPlot::LoadDefaultLineStyles() must be called before using line styles!
+    // It should be called once during font loading.
+    static ImPlotSpec spec;
+    ImGui::DragFloat("Line Weight", &spec.LineWeight,0.05f,0.5f,32.0f,"%.2f px");
+
+    if (ImPlot::BeginPlot("##LineStyles", ImVec2(-1,0), ImPlotFlags_CanvasOnly)) {
+
+        ImPlot::SetupAxes(nullptr, nullptr, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations);
+        ImPlot::SetupAxesLimits(0, 5, 0, 7);
+
+        ImS8 xs[2] = {1,4};
+        ImS8 ys[2] = {5,6};
+
+        // Line Styles
+        for (int m = 0; m < ImPlotLineStyle_COUNT; ++m) {
+            ImGui::PushID(m);
+            spec.LineStyle = (ImPlotLineStyle)m;
+            ImPlot::PlotLine("##Style", xs, ys, 2, spec);
+            ImGui::PopID();
+            ys[0]--; ys[1]--;
+        }
+
+        ImPlot::EndPlot();
+    }
+}
+
+//-----------------------------------------------------------------------------
+
 void Demo_MarkersAndText() {
     IMGUI_DEMO_MARKER("Plots/Markers and Text");
     static ImPlotSpec spec(ImPlotProp_Marker, ImPlotMarker_Auto);
@@ -2499,6 +2529,7 @@ void ShowDemoWindow(bool* p_open) {
             DemoHeader("Histogram 2D", Demo_Histogram2D);
             DemoHeader("Digital Plots", Demo_DigitalPlots);
             DemoHeader("Images", Demo_Images);
+            DemoHeader("Line Styles", Demo_LineStyles);
             DemoHeader("Markers and Text", Demo_MarkersAndText);
             DemoHeader("NaN Values", Demo_NaNValues);
             ImGui::EndTabItem();

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -123,6 +123,8 @@ template <typename T>
 static inline T ImRemap01(T x, T x0, T x1) { return (x - x0) / (x1 - x0); }
 // Returns always positive modulo (assumes r != 0)
 static inline int ImPosMod(int l, int r) { return (l % r + r) % r; }
+// Returns the modulo of x by y (assumes y != 0)
+static inline double ImMod(double x, double y) { return fmod(x, y); }
 // Returns true if val is NAN
 static inline bool ImNan(double val) { return isnan(val); }
 // Returns true if val is NAN or INFINITY
@@ -284,6 +286,17 @@ typedef void (*ImPlotLocator)(ImPlotTicker& ticker, const ImPlotRange& range, fl
 //-----------------------------------------------------------------------------
 // [SECTION] Structs
 //-----------------------------------------------------------------------------
+
+struct ImPlotLineStyleData {
+    ImPlotLineStyleData(ImFontAtlasRectId rect_id, float period, float max_length) :
+        RectID(rect_id),
+        Period(period),
+        MaxLength(max_length) {}
+    const ImFontAtlasRectId RectID;   // texture atlas rect ID for line style
+    const float  Period;              // period of line style in pixels
+    const float  MaxLength;           // maximum length of line style in pixels
+    mutable ImFontAtlasRect Rect;     // cached rectangle for line style (filled in on demand)
+};
 
 // Combined date/time format spec
 struct ImPlotDateTimeSpec {
@@ -1243,11 +1256,12 @@ struct ImPlotContext {
     ImPlotTagCollection        Tags;
 
     // Style and Colormaps
-    ImPlotStyle                 Style;
-    ImVector<ImGuiColorMod>     ColorModifiers;
-    ImVector<ImGuiStyleMod>     StyleModifiers;
-    ImPlotColormapData          ColormapData;
-    ImVector<ImPlotColormap>    ColormapModifiers;
+    ImPlotStyle                     Style;
+    ImVector<ImGuiColorMod>         ColorModifiers;
+    ImVector<ImGuiStyleMod>         StyleModifiers;
+    ImPlotColormapData              ColormapData;
+    ImVector<ImPlotColormap>        ColormapModifiers;
+    ImVector<ImPlotLineStyleData>   LineStyleData;
 
     // Time
     tm Tm;
@@ -1507,6 +1521,8 @@ IMPLOT_API ImU32  SampleColormapU32(float t, ImPlotColormap cmap);
 
 // Render a colormap bar
 IMPLOT_API void RenderColorBar(const ImU32* colors, int size, ImDrawList& DrawList, const ImRect& bounds, bool vert, bool reversed, bool continuous);
+
+IMPLOT_API const ImPlotLineStyleData& GetLineStyleData(ImPlotLineStyle style);
 
 //-----------------------------------------------------------------------------
 // [SECTION] Math and Misc Utils

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -288,14 +288,15 @@ typedef void (*ImPlotLocator)(ImPlotTicker& ticker, const ImPlotRange& range, fl
 //-----------------------------------------------------------------------------
 
 struct ImPlotLineStyleData {
+    ImPlotLineStyleData() {}
     ImPlotLineStyleData(ImFontAtlasRectId rect_id, float period, float max_length) :
         RectID(rect_id),
         Period(period),
         MaxLength(max_length) {}
-    const ImFontAtlasRectId RectID;   // texture atlas rect ID for line style
-    const float  Period;              // period of line style in pixels
-    const float  MaxLength;           // maximum length of line style in pixels
-    mutable ImFontAtlasRect Rect;     // cached rectangle for line style (filled in on demand)
+    ImFontAtlasRectId RectID;  // texture atlas rect ID for line style
+    float  Period;                  // period of line style in pixels
+    float  MaxLength;               // maximum length of line style in pixels
+    mutable ImFontAtlasRect Rect;   // cached rectangle for line style (filled in on demand)
 };
 
 // Combined date/time format spec
@@ -1522,6 +1523,10 @@ IMPLOT_API ImU32  SampleColormapU32(float t, ImPlotColormap cmap);
 // Render a colormap bar
 IMPLOT_API void RenderColorBar(const ImU32* colors, int size, ImDrawList& DrawList, const ImRect& bounds, bool vert, bool reversed, bool continuous);
 
+// Adds a line style with the given ID to ImPlot context. Set ID to -1 to add a line style with an automatically generated ID.
+IMPLOT_API int AddLineStyleInternal(const int ID, const ImU32* keys, const int count);
+
+// Returns line style data for a given line style. Do not store the returned value between frames as it may be invalidated if texture atlas is rebuilt.
 IMPLOT_API const ImPlotLineStyleData& GetLineStyleData(ImPlotLineStyle style);
 
 //-----------------------------------------------------------------------------

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -204,6 +204,40 @@ IMPLOT_INLINE void PrimLine(ImDrawList& draw_list, const ImVec2& P1, const ImVec
     draw_list._VtxCurrentIdx += 4;
 }
 
+IMPLOT_INLINE void PrimLineUV(ImDrawList& draw_list, const ImVec2& P1, const ImVec2& P2, float half_weight, ImU32 col, const ImVec2& uv_a, const ImVec2 uv_c) {
+    float dx = P2.x - P1.x;
+    float dy = P2.y - P1.y;
+    ImVec2 uv_b(uv_c.x, uv_a.y), uv_d(uv_a.x, uv_c.y);
+    IMPLOT_NORMALIZE2F_OVER_ZERO(dx, dy);
+    dx *= half_weight;
+    dy *= half_weight;
+    draw_list._VtxWritePtr[0].pos.x = P1.x + dy;
+    draw_list._VtxWritePtr[0].pos.y = P1.y - dx;
+    draw_list._VtxWritePtr[0].uv    = uv_a;
+    draw_list._VtxWritePtr[0].col   = col;
+    draw_list._VtxWritePtr[1].pos.x = P2.x + dy;
+    draw_list._VtxWritePtr[1].pos.y = P2.y - dx;
+    draw_list._VtxWritePtr[1].uv    = uv_b;
+    draw_list._VtxWritePtr[1].col   = col;
+    draw_list._VtxWritePtr[2].pos.x = P2.x - dy;
+    draw_list._VtxWritePtr[2].pos.y = P2.y + dx;
+    draw_list._VtxWritePtr[2].uv    = uv_c;
+    draw_list._VtxWritePtr[2].col   = col;
+    draw_list._VtxWritePtr[3].pos.x = P1.x - dy;
+    draw_list._VtxWritePtr[3].pos.y = P1.y + dx;
+    draw_list._VtxWritePtr[3].uv    = uv_d;
+    draw_list._VtxWritePtr[3].col   = col;
+    draw_list._VtxWritePtr += 4;
+    draw_list._IdxWritePtr[0] = (ImDrawIdx)(draw_list._VtxCurrentIdx);
+    draw_list._IdxWritePtr[1] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 1);
+    draw_list._IdxWritePtr[2] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 2);
+    draw_list._IdxWritePtr[3] = (ImDrawIdx)(draw_list._VtxCurrentIdx);
+    draw_list._IdxWritePtr[4] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 2);
+    draw_list._IdxWritePtr[5] = (ImDrawIdx)(draw_list._VtxCurrentIdx + 3);
+    draw_list._IdxWritePtr += 6;
+    draw_list._VtxCurrentIdx += 4;
+}
+
 IMPLOT_INLINE void PrimRectFill(ImDrawList& draw_list, const ImVec2& Pmin, const ImVec2& Pmax, ImU32 col, const ImVec2& uv) {
     draw_list._VtxWritePtr[0].pos   = Pmin;
     draw_list._VtxWritePtr[0].uv    = uv;
@@ -944,6 +978,55 @@ struct RendererLineStrip : RendererBase {
     const _Getter& Getter;
     const ImU32 Col;
     mutable float HalfWeight;
+    mutable ImVec2 P1;
+    mutable ImVec2 UV0;
+    mutable ImVec2 UV1;
+};
+
+template <class _Getter>
+struct RendererLineStripUV : RendererBase {
+    RendererLineStripUV(const _Getter& getter, ImU32 col, ImPlotLineStyleData style_data, float weight) :
+        RendererBase(getter.Count - 1, 6, 4),
+        Getter(getter),
+        Col(col),
+        StyleData(style_data),
+        HalfWeight(ImMax(1.0f,weight)*0.5f),
+        cumLen(0.f)
+    {
+        P1 = this->Transformer(Getter[0]);
+    }
+    void Init(ImDrawList& draw_list) const {
+        GetLineRenderProps(draw_list, HalfWeight, UV0, UV1);
+    }
+    IMPLOT_INLINE bool Render(ImDrawList& draw_list, const ImRect& cull_rect, int prim) const {
+        ImVec2 P2 = this->Transformer(Getter[prim + 1]);
+        float segLen;
+        if (!(ImNan(P1.x) || ImNan(P1.y) || ImNan(P2.x) || ImNan(P2.y)))
+            segLen = ImSqrt(ImLengthSqr(P2 - P1));
+        else
+            segLen = 0.f;
+        
+        if (!cull_rect.Overlaps(ImRect(ImMin(P1, P2), ImMax(P1, P2)))) {
+            cumLen = ImMod(cumLen + segLen, StyleData.Period);
+            P1 = P2;
+            return false;
+        }
+        UV0.x = ImRemap(cumLen, 0.f, StyleData.MaxLength, StyleData.Rect.uv0.x, StyleData.Rect.uv1.x);
+        UV1.x = ImRemap(cumLen + segLen, 0.f, StyleData.MaxLength, StyleData.Rect.uv0.x, StyleData.Rect.uv1.x);
+        UV0.y = StyleData.Rect.uv0.y;
+        UV1.y = StyleData.Rect.uv1.y;
+
+        PrimLineUV(draw_list,P1,P2,HalfWeight,Col,UV0,UV1);
+
+        cumLen = ImMod(cumLen + segLen, StyleData.Period);
+        P1 = P2;
+        return true;
+    }
+    const _Getter& Getter;
+    const ImU32 Col;
+    const ImPlotLineStyleData StyleData;
+    mutable float HalfWeight;
+    mutable float cumLen;
     mutable ImVec2 P1;
     mutable ImVec2 UV0;
     mutable ImVec2 UV1;
@@ -1796,14 +1879,22 @@ void PlotLineEx(const char* label_id, const _Getter& getter, const ImPlotSpec& s
                 else if (ImHasFlag(spec.Flags, ImPlotLineFlags_Loop)) {
                     if (ImHasFlag(spec.Flags, ImPlotLineFlags_SkipNaN))
                         RenderPrimitives1<RendererLineStripSkip>(GetterLoop<_Getter>(getter),col_line,s.Spec.LineWeight);
-                    else
-                        RenderPrimitives1<RendererLineStrip>(GetterLoop<_Getter>(getter),col_line,s.Spec.LineWeight);
+                    else {
+                        if (s.Spec.LineStyle == ImPlotLineStyle_Solid)
+                            RenderPrimitives1<RendererLineStrip>(GetterLoop<_Getter>(getter),col_line,s.Spec.LineWeight);
+                        else
+                            RenderPrimitives1<RendererLineStripUV>(GetterLoop<_Getter>(getter),col_line,GetLineStyleData(s.Spec.LineStyle), s.Spec.LineWeight);
+                    }
                 }
                 else {
                     if (ImHasFlag(spec.Flags, ImPlotLineFlags_SkipNaN))
                         RenderPrimitives1<RendererLineStripSkip>(getter,col_line,s.Spec.LineWeight);
-                    else
-                        RenderPrimitives1<RendererLineStrip>(getter,col_line,s.Spec.LineWeight);
+                    else {
+                        if (s.Spec.LineStyle == ImPlotLineStyle_Solid)
+                            RenderPrimitives1<RendererLineStrip>(getter,col_line,s.Spec.LineWeight);
+                        else
+                            RenderPrimitives1<RendererLineStripUV>(getter,col_line,GetLineStyleData(s.Spec.LineStyle),s.Spec.LineWeight);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #185 

<img width="543" height="304" alt="imagen" src="https://github.com/user-attachments/assets/e4097df5-f08e-4a1e-91b9-46ac46e28a2f" />

## Background
First of all, thanks for this incredible library!

I've recently been using ImPlot for a personal project and wanted to display lines with different patterns only to discover it hasn't been implemented yet! Then I came across [this issue](#185) and the discussion about possible implementations.
From what I understand there is only one viable solution with the current ImGui API that does not require a dedicated render backend: Using textured lines created with the AddCustomRect() API.

This PR implements this idea in what I hope is simple and user friendly.
It is NOT a complete implementation as it currently only supports line strips, lacks AA and does not render properly for large gaps between data points.
I'd like to get the community feedback before going any further and attempt to implement this missing features.

## Summary
Added support for line patterns (dashed, dotted, etc.)

## Implementation
**ImPlotSpec:** Added LineStyle property
**ImPlotLineStyle:** New typedef for line style IDs
**ImPlotLineStyle_:** New enum for default line styles defined by ImPlot
**PrimLineUV:** New function to add a textured line primitive to draw_list
**RendererLineStripUV:** New renderer supporting textured lines
**ImPlotLineStyleData:** New struct to hold ImFontAtlasRectId, pattern period, max rectangle size and ImFontAtlasRect data
**LineStyleData vector:** New ImVector in ImPlot context to hold loaded line style data
**LoadDefaultLineStyles:** Function to load default line styles defined by ImPlot
**AddLineStyle:** User function to add custom line styles using a sequence of on/off pixel widths
**AddLineStyleInternal:** Internal function used to generate the default line styles
**GetLineStyleData:** Internal helper function to gather ImFontAtlasRect data before rendering
**Demo_LineStyles:** New demo tab showcasing plot line styles, how to load default styles and how to add custom ones.

## Demo
A line styles tab has been added to `implot_demo.cpp` showcasing
- Loading Default (ImPlot defined) line styles
- Adding custom defined line styles
- How to use ImPlotSpec to set a default line style
- How to use ImPlotSpec to set a custom line style

## Technical details
First of all the texture data for the line patterns is generated in the `AddLineStyleInternal()` function which is called either from `AddLineStyle()` or `LoadDefaultLineStyles()`

`AddLineStyleInternal()` calls `AddCustomRect()` to reserve a rectangle in the FontAtlas with a fixed size (for now) of 511x1 pixels.
The default atlas width is usually 512 pixels and a rectangle of 511 pixels is the maximum we can get without forcing the creation of a 1024 wide texture.
The rectangle height only needs one pixel regardless of the actual plot line width:
- For 1 pixel wide lines we can use two triangles per line and UV coordinates around the atlas rectangle to get AA.
- For thick lines we can draw a core+fringe to get AA. We need more geometry but avoid generating one rectangle for every line pattern and every line width.
- If no AA is needed, we can still use a 1 pixel wide texture and set the UV coordinates to the center of the line

With the rectangle reserved, we fill the pixel data according to the on/off sequence passed into `AddLineStyleInternal()`. A sequence might look like this ´{6, 6, 2, 6}´ for 6 pixels on, 6 pixels off, 2 pixels on, 6 pixels off. The pattern is repeated until the whole texture is filled.

Then, the rectangle ID and pattern period (in pixels) are stored as a `ImPlotLineStyleData` object in the ImPlot context
At this point the line pattern is ready to be used.

When the user draws a plot line with LineStyle other than solid line, the rectangle UV coordinates are retrieved using `GetLineStyleData()` and passed to the renderer.

Finally, the renderer maps the uv coordinates according to the cumulate pixel length of the line and fills the draw_list.
The problem with this approach appears when a single line segment is longer than the atlas rectangle length:
- If there are other rectangles next to the line pattern in the font atlas, they will be drawn into the plot line
- If the uv coordinates reach the end of the texture, they will be clamped and show whatever color the last pixel has.

My proposal is to split long lines and generate subsegments. That would require to call `PrimReserve()` within the renderer, which isn't very elegant. If we had the ability to load a custom texture to the GPU and set the UV wrap mode to repeating (or equivalent for renderers other than OpenGL) this problem could be avoided. However with the current API  I see no alternative other than more geometry.

Sorry if the text above was too long and thank you for taking the time to read it!
Let me know your thoughts about this implementation and where I can improve/add functionality.