### PR TITLE
Ensure consistent imgui enum types when OR-ing

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -1874,13 +1874,13 @@ bool UpdateInput(ImPlotPlot& plot) {
 
     // BUTTON STATE -----------------------------------------------------------
 
-    const ImGuiButtonFlags plot_button_flags = ImGuiButtonFlags_AllowOverlap
+    const ImGuiButtonFlags plot_button_flags = static_cast<ImGuiButtonFlags>(ImGuiButtonFlags_AllowOverlap)
                                              | ImGuiButtonFlags_PressedOnClick
                                              | ImGuiButtonFlags_PressedOnDoubleClick
                                              | ImGuiButtonFlags_MouseButtonLeft
                                              | ImGuiButtonFlags_MouseButtonRight
                                              | ImGuiButtonFlags_MouseButtonMiddle;
-    const ImGuiButtonFlags axis_button_flags = ImGuiButtonFlags_FlattenChildren
+    const ImGuiButtonFlags axis_button_flags = static_cast<ImGuiButtonFlags>(ImGuiButtonFlags_FlattenChildren)
                                              | plot_button_flags;
 
     const bool plot_clicked = ImGui::ButtonBehavior(plot.PlotRect,plot.ID,&plot.Hovered,&plot.Held,plot_button_flags);
@@ -3107,7 +3107,7 @@ void EndPlot() {
                                                         legend_out ? plot.FrameRect : plot.PlotRect,
                                                         legend_out ? gp.Style.PlotPadding : gp.Style.LegendPadding
                                                         );
-        const ImGuiButtonFlags legend_button_flags = ImGuiButtonFlags_AllowOverlap
+        const ImGuiButtonFlags legend_button_flags = static_cast<ImGuiButtonFlags>(ImGuiButtonFlags_AllowOverlap)
                                                     | ImGuiButtonFlags_PressedOnClick
                                                     | ImGuiButtonFlags_PressedOnDoubleClick
                                                     | ImGuiButtonFlags_MouseButtonLeft
@@ -3513,7 +3513,7 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
             ImGui::KeepAliveID(sep_id);
             const ImRect sep_bb = ImRect(subplot.GridRect.Min.x, ypos-SUBPLOT_SPLITTER_HALF_THICKNESS, subplot.GridRect.Max.x, ypos+SUBPLOT_SPLITTER_HALF_THICKNESS);
             bool sep_hov = false, sep_hld = false;
-            const bool sep_clk = ImGui::ButtonBehavior(sep_bb, sep_id, &sep_hov, &sep_hld, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
+            const bool sep_clk = ImGui::ButtonBehavior(sep_bb, sep_id, &sep_hov, &sep_hld, static_cast<ImGuiButtonFlags>(ImGuiButtonFlags_FlattenChildren) | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
             if ((sep_hov && G.HoveredIdTimer > SUBPLOT_SPLITTER_FEEDBACK_TIMER) || sep_hld) {
                 if (sep_clk && ImGui::IsMouseDoubleClicked(0)) {
                     float p = (subplot.RowRatios[r] + subplot.RowRatios[r+1])/2;
@@ -3543,7 +3543,7 @@ bool BeginSubplots(const char* title, int rows, int cols, const ImVec2& size, Im
             ImGui::KeepAliveID(sep_id);
             const ImRect sep_bb = ImRect(xpos-SUBPLOT_SPLITTER_HALF_THICKNESS, subplot.GridRect.Min.y, xpos+SUBPLOT_SPLITTER_HALF_THICKNESS, subplot.GridRect.Max.y);
             bool sep_hov = false, sep_hld = false;
-            const bool sep_clk = ImGui::ButtonBehavior(sep_bb, sep_id, &sep_hov, &sep_hld, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
+            const bool sep_clk = ImGui::ButtonBehavior(sep_bb, sep_id, &sep_hov, &sep_hld, static_cast<ImGuiButtonFlags>(ImGuiButtonFlags_FlattenChildren) | ImGuiButtonFlags_PressedOnClick | ImGuiButtonFlags_PressedOnDoubleClick);
             if ((sep_hov && G.HoveredIdTimer > SUBPLOT_SPLITTER_FEEDBACK_TIMER) || sep_hld) {
                 if (sep_clk && ImGui::IsMouseDoubleClicked(0)) {
                     float p = (subplot.ColRatios[c] + subplot.ColRatios[c+1])/2;
@@ -3630,7 +3630,7 @@ void EndSubplots() {
         legend.Rect = ImRect(legend_pos, legend_pos + legend_size);
         legend.RectClamped = legend.Rect;
         const bool legend_scrollable = ClampLegendRect(legend.RectClamped,subplot.FrameRect, gp.Style.PlotPadding);
-        const ImGuiButtonFlags legend_button_flags = ImGuiButtonFlags_AllowOverlap
+        const ImGuiButtonFlags legend_button_flags = static_cast<ImGuiButtonFlags>(ImGuiButtonFlags_AllowOverlap)
                                                     | ImGuiButtonFlags_PressedOnClick
                                                     | ImGuiButtonFlags_PressedOnDoubleClick
                                                     | ImGuiButtonFlags_MouseButtonLeft

--- a/implot.h
+++ b/implot.h
@@ -496,7 +496,7 @@ enum ImPlotBin_ {
 //    spec.LineColor = ImVec4(1,0,0,1);
 //    spec.LineWeight = 2.0f;
 //    spec.Marker = ImPlotMarker_Circle;
-//    spec.Flags = ImPlotItemFlags_NoLegend | ImPlotLineFlags_Segments;
+//    spec.Flags = static_cast<ImPlotItemFlags>(ImPlotItemFlags_NoLegend) | ImPlotLineFlags_Segments;
 //    ImPlot::PlotLine("MyLine", xs, ys, 100, spec);
 //
 // 2. Inline using (ImPlotProp,value) pairs (order does NOT matter):
@@ -505,7 +505,7 @@ enum ImPlotBin_ {
 //      ImPlotProp_LineColor, ImVec4(1,0,0,1),
 //      ImPlotProp_LineWeight, 2.0f,
 //      ImPlotProp_Marker, ImPlotMarker_Circle,
-//      ImPlotProp_Flags, ImPlotItemFlags_NoLegend | ImPlotLineFlags_Segments
+//      ImPlotProp_Flags, static_cast<ImPlotItemFlags>(ImPlotItemFlags_NoLegend) | ImPlotLineFlags_Segments
 //    });
 struct ImPlotSpec {
     ImVec4          LineColor       = IMPLOT_AUTO_COL;       // line color (applies to lines, bar edges); IMPLOT_AUTO_COL will use next Colormap color or current item color

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -2103,7 +2103,7 @@ void Demo_ItemStylingAndSpec() {
         spec.Marker = ImPlotMarker_Square;
         spec.MarkerSize = 6;
         spec.Stride = sizeof(ImVec2);
-        spec.Flags = ImPlotItemFlags_NoLegend | ImPlotLineFlags_Shaded;
+        spec.Flags = static_cast<ImPlotItemFlags>(ImPlotItemFlags_NoLegend) | ImPlotLineFlags_Shaded;
         ImPlot::PlotLine("Line 1", &data1[0].x, &data1[0].y, 20, spec);
 
         // 2. Inline using ImPlotProp,value pairs (order does NOT matter):
@@ -2115,7 +2115,7 @@ void Demo_ItemStylingAndSpec() {
             ImPlotProp_Marker, ImPlotMarker_Diamond,
             ImPlotProp_Size, 6,
             ImPlotProp_Stride, sizeof(ImVec2),
-            ImPlotProp_Flags, ImPlotItemFlags_NoLegend | ImPlotLineFlags_Shaded
+            ImPlotProp_Flags, static_cast<ImPlotItemFlags>(ImPlotItemFlags_NoLegend) | ImPlotLineFlags_Shaded
         });
 
         ImPlot::EndPlot();


### PR DESCRIPTION
This fixes https://github.com/epezent/implot/issues/688 and similar issues.

This was a latent bug going back to 2021, now breaks with modern Clang diagnostics and most recent Imgui master.

ImPlot is building plot_button_flags by OR-ing values from two different Dear ImGui enum families:

- public `ImGuiButtonFlags_` in include/imgui/imgui.h:1865: AllowOverlap, MouseButtonLeft/Right/Middle
- internal `ImGuiButtonFlagsPrivate_` in include/imgui/imgui_internal.h:1031: PressedOnClick, PressedOnDoubleClick, FlattenChildren

`ButtonBehavior()` still takes `ImGuiButtonFlags`, but the bitwise expression itself mixes distinct enum types, so Clang emits `-Wenum-enum-conversion`, and as warnings are treated as errors, the build fails.

This PR casts enums to a consistent type when OR-ing them together.