### PR TITLE
Fix: Apply ImGui style alpha to ImPlot colors

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -667,7 +667,7 @@ bool ShowLegendEntries(ImPlotItemGroup& items, const ImRect& legend_bb, bool hov
         label_bb.Min = top_left;
         label_bb.Max = top_left + ImVec2(label_width + icon_size, icon_size);
         ImU32 col_txt_hl;
-        ImU32 col_item = ImAlphaU32(item->Color,1);
+        ImU32 col_item = ImAlphaU32(item->Color, ImGui::GetStyle().Alpha);
 
         ImRect button_bb(icon_bb.Min, label_bb.Max);
 

--- a/implot_internal.h
+++ b/implot_internal.h
@@ -212,9 +212,10 @@ static inline ImU32 ImLerpU32(const ImU32* colors, int size, float t) {
     return ImMixU32(colors[i1], colors[i2], (ImU32)(tr*256));
 }
 
-// Set alpha channel of 32-bit color from float in range [0.0 1.0]
-static inline ImU32 ImAlphaU32(ImU32 col, float alpha) {
-    return col & ~((ImU32)((1.0f-alpha)*255)<<IM_COL32_A_SHIFT);
+// Multiply alpha channel of 32-bit color by float
+static inline ImU32 ImAlphaU32(ImU32 col, float alpha_mul) {
+    ImU32 alpha = (ImU32)ImClamp((int)((col >> IM_COL32_A_SHIFT) * alpha_mul), 0, 255);
+    return (col & ~IM_COL32_A_MASK) | (alpha << IM_COL32_A_SHIFT);
 }
 
 // Returns true of two ranges overlap
@@ -1468,7 +1469,12 @@ static inline bool IsColorAuto(ImPlotCol idx) { return IsColorAuto(GImPlot->Styl
 IMPLOT_API ImVec4 GetAutoColor(ImPlotCol idx);
 
 // Returns the style color whether it is automatic or custom set
-static inline ImVec4 GetStyleColorVec4(ImPlotCol idx) { return IsColorAuto(idx) ? GetAutoColor(idx) : GImPlot->Style.Colors[idx]; }
+static inline ImVec4 GetStyleColorVec4(ImPlotCol idx, float alpha_mul = 1.0f) {
+    ImVec4 color = IsColorAuto(idx) ? GetAutoColor(idx) : GImPlot->Style.Colors[idx];
+    color.w *= ImGui::GetStyle().Alpha * alpha_mul;
+    return color;
+}
+
 static inline ImU32  GetStyleColorU32(ImPlotCol idx)  { return ImGui::ColorConvertFloat4ToU32(GetStyleColorVec4(idx)); }
 
 // Draws vertical text. The position is the bottom left of the text rect.


### PR DESCRIPTION
Respect current `GImGui->Style.Alpha` value when getting colors, the same way ImGui does in `ImGui::GetColorU32` (https://github.com/ocornut/imgui/blob/4b80d409e721b096b2b26e5edbf575178bdb48f0/imgui.cpp#L3545).

Rewrite ImAlphaU32 to multiply alphas and fix setting the alpha component in the output color.