### PR TITLE
Feat: Add Vertical and Horizontal markers

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -307,6 +307,8 @@ const char* GetMarkerName(ImPlotMarker marker) {
         case ImPlotMarker_Cross:    return "Cross";
         case ImPlotMarker_Plus:     return "Plus";
         case ImPlotMarker_Asterisk: return "Asterisk";
+        case ImPlotMarker_Vertical: return "Vertical";
+        case ImPlotMarker_Horizontal: return "Horizontal";
         default:                    return "";
     }
 }

--- a/implot.h
+++ b/implot.h
@@ -448,6 +448,8 @@ enum ImPlotMarker_ {
     ImPlotMarker_Cross,     // a cross marker (not fill-able)
     ImPlotMarker_Plus,      // a plus marker (not fill-able)
     ImPlotMarker_Asterisk,  // a asterisk marker (not fill-able)
+    ImPlotMarker_Vertical,   // a vertical line marker (not fill-able)
+    ImPlotMarker_Horizontal, // a horizontal line marker (not fill-able)
     ImPlotMarker_COUNT
 };
 

--- a/implot_demo.cpp
+++ b/implot_demo.cpp
@@ -1078,7 +1078,7 @@ void Demo_MarkersAndText() {
     if (ImPlot::BeginPlot("##MarkerStyles", ImVec2(-1,0), ImPlotFlags_CanvasOnly)) {
 
         ImPlot::SetupAxes(nullptr, nullptr, ImPlotAxisFlags_NoDecorations, ImPlotAxisFlags_NoDecorations);
-        ImPlot::SetupAxesLimits(0, 10, 0, 12);
+        ImPlot::SetupAxesLimits(0, 10, -2, 12);
 
         ImS8 xs[2] = {1,4};
         ImS8 ys[2] = {10,11};
@@ -1101,11 +1101,11 @@ void Demo_MarkersAndText() {
             ys[0]--; ys[1]--;
         }
 
-        ImPlot::PlotText("Filled Markers", 2.5f, 6.0f);
-        ImPlot::PlotText("Open Markers",   7.5f, 6.0f);
+        ImPlot::PlotText("Filled Markers", 2.5f, 5.0f);
+        ImPlot::PlotText("Open Markers",   7.5f, 5.0f);
 
         ImPlot::PushStyleColor(ImPlotCol_InlayText, ImVec4(1,0,1,1));
-        ImPlot::PlotText("Vertical Text", 5.0f, 6.0f, ImVec2(0,0), {ImPlotProp_Flags, ImPlotTextFlags_Vertical});
+        ImPlot::PlotText("Vertical Text", 5.0f, 5.0f, ImVec2(0,0), {ImPlotProp_Flags, ImPlotTextFlags_Vertical});
         ImPlot::PopStyleColor();
 
         ImPlot::EndPlot();

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -1821,6 +1821,8 @@ constexpr ImVec2 MARKER_LINE_RIGHT[6]    = {ImVec2(1,0),  ImVec2(-0.5, SQRT_3_2)
 constexpr ImVec2 MARKER_LINE_ASTERISK[6] = {ImVec2(-SQRT_3_2, -0.5f), ImVec2(SQRT_3_2, 0.5f),  ImVec2(-SQRT_3_2, 0.5f), ImVec2(SQRT_3_2, -0.5f), ImVec2(0, -1), ImVec2(0, 1)};
 constexpr ImVec2 MARKER_LINE_PLUS[4]     = {ImVec2(-1, 0), ImVec2(1, 0), ImVec2(0, -1), ImVec2(0, 1)};
 constexpr ImVec2 MARKER_LINE_CROSS[4]    = {ImVec2(-SQRT_1_2,-SQRT_1_2),ImVec2(SQRT_1_2,SQRT_1_2),ImVec2(SQRT_1_2,-SQRT_1_2),ImVec2(-SQRT_1_2,SQRT_1_2)};
+constexpr ImVec2 MARKER_LINE_VERTICAL[2] = {ImVec2(0, -1), ImVec2(0, 1)};
+constexpr ImVec2 MARKER_LINE_HORIZONTAL[2] = {ImVec2(-1, 0), ImVec2(1, 0)};
 
 template <typename _Getter, typename _GetterFillColor, typename _GetterLineColor, typename _GetterSize>
 void RenderMarkers(const _Getter& getter, ImPlotMarker marker, bool rend_fill, const _GetterFillColor& col_fill_getter, bool rend_line, const _GetterLineColor& col_line_getter, const _GetterSize& size_getter, float weight) {
@@ -1847,6 +1849,8 @@ void RenderMarkers(const _Getter& getter, ImPlotMarker marker, bool rend_fill, c
             case ImPlotMarker_Asterisk  : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_ASTERISK,6,weight); break;
             case ImPlotMarker_Plus      : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_PLUS,    4,weight); break;
             case ImPlotMarker_Cross     : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_CROSS,   4,weight); break;
+            case ImPlotMarker_Vertical  : RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_VERTICAL,2,weight); break;
+            case ImPlotMarker_Horizontal: RenderPrimitives3<RendererMarkersLine>(getter,col_line_getter,size_getter,MARKER_LINE_HORIZONTAL,2,weight); break;
         }
     }
 }


### PR DESCRIPTION
This PR adds two new markers to the ImPlot library that are commonly used in other plotting libraries (see here: https://matplotlib.org/stable/gallery/lines_bars_and_markers/marker_reference.html)

These are useful for plots that try to cram a lot of events in a small space (for instance, raster plots: 
<img width="560" height="420" alt="image" src="https://github.com/user-attachments/assets/42c960ad-ccbb-4c51-80c6-858f177c202b" />)

It should be noted that while this appearance could already be achieved using simple lines, this makes the API easier to use and compatible with the scatter plots.

<img width="295" height="166" alt="{46ADBC27-FD53-477B-8E5D-BDB23B68A3AA}" src="https://github.com/user-attachments/assets/19884654-2aef-426a-b570-45f322172798" />
