### PR TITLE
Fixes for ImDrawList::AddRect() signature change in 19276.

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -3171,8 +3171,13 @@ void EndPlot() {
     }
 
     // render border
+#if IMGUI_VERSION_NUM < 19276
     if (render_border)
-        DrawList.AddRect(plot.PlotRect.Min, plot.PlotRect.Max, GetStyleColorU32(ImPlotCol_PlotBorder), 0, ImDrawFlags_RoundCornersAll, gp.Style.PlotBorderSize);
+        DrawList.AddRect(plot.PlotRect.Min, plot.PlotRect.Max, GetStyleColorU32(ImPlotCol_PlotBorder), 0, ImDrawFlags_None, gp.Style.PlotBorderSize);
+#else
+    if (render_border)
+        DrawList.AddRect(plot.PlotRect.Min, plot.PlotRect.Max, GetStyleColorU32(ImPlotCol_PlotBorder), 0, gp.Style.PlotBorderSize, ImDrawFlags_None);
+#endif
 
     // render tags
     for (int i = 0; i < gp.Tags.Size; ++i) {

--- a/implot_items.cpp
+++ b/implot_items.cpp
@@ -2145,7 +2145,11 @@ void PlotPolygonEx(const char* label_id, const Getter& getter, const ImPlotSpec&
         }
         if (s.RenderLine && getter.Count >= 2) {
             const ImU32 col_line = ImGui::GetColorU32(s.Spec.LineColor);
+#if IMGUI_VERSION_NUM < 19276
             draw_list.AddPolyline(points, getter.Count, col_line, ImDrawFlags_Closed, s.Spec.LineWeight);
+#else
+            draw_list.AddPolyline(points, getter.Count, col_line, s.Spec.LineWeight, ImDrawFlags_Closed);
+#endif
         }
         IM_FREE(points);
 


### PR DESCRIPTION
Fix for breaking change https://github.com/ocornut/imgui/commit/6df50a0667a35a853da38cf4a4cbcf632325fec9#diff-cbc47f9fc55eb2c19b4be92d1c1e137bb8b72d072588ab3cb4bcba88576d14cb

ImPlot3D would need a similar fix is using the last two parameters of `ImDrawList::AddRect()`.
