### PR TITLE
Feat: Ignore `deprecated-enum-enum-conversion` warnings in GCC

### DIFF
--- a/implot.cpp
+++ b/implot.cpp
@@ -219,6 +219,7 @@ You can read releases logs https://github.com/epezent/implot/releases for more d
 #pragma clang diagnostic ignored "-Wenum-enum-conversion" // warning: bitwise operation between different enumeration types ('XXXFlags_' and 'XXXFlagsPrivate_') is deprecated
 #elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"    // warning: format not a string literal, format string not checked
+#pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion" // warning: bitwise operation between different enumeration types ('XXXFlags_' and 'XXXFlagsPrivate_') is deprecated
 #endif
 
 // Global plot context


### PR DESCRIPTION
The fix to issue #688 was to ignore  `deprecated-enum-enum-conversion` warnings (see PR #689).

However, that pull request only implemented the fix for clang. This PR also implements this in GCC.